### PR TITLE
デバッグ出力の文字化けを修正

### DIFF
--- a/src/bcdiceCore.rb
+++ b/src/bcdiceCore.rb
@@ -39,6 +39,10 @@ def encode(code, str)
   return Kconv.kconv(str, code)
 end
 
+# WindowsでかつRuby 1.9未満の環境であるかどうかを示す
+# 端末にShift_JISで出力する必要性の判定に用いる
+$RUBY18_WIN = RUBY_VERSION < '1.9' &&
+  /mswin(?!ce)|mingw|cygwin|bccwin/i === RUBY_PLATFORM
 
 $secretRollMembersHolder = {}
 $secretDiceResultHolder = {}

--- a/src/bcdiceGui.rb
+++ b/src/bcdiceGui.rb
@@ -29,11 +29,20 @@ end
 
 $debugText = nil
 
+# デバッグ文字列出力（末尾改行なし）
 def debugPrint(text)
-  return if( $debugText.nil? ) 
-  $debugText.append_text(text)
+  if $debugText
+    $debugText.append_text($RUBY18_WIN ? text.tosjis : text)
+  end
 end
 
+# デバッグ文字列出力（末尾改行あり）
+def debugPuts(text)
+  if $debugText
+    line = "#{text}\n"
+    $debugText.append_text($RUBY18_WIN ? text.tosjis : text)
+  end
+end
 
 class BCDiceDialog < Wx::Dialog
   

--- a/src/log.rb
+++ b/src/log.rb
@@ -2,43 +2,32 @@
 
 $isDebug = false
 
-def debug(obj1, *obj2)
-  return unless( $isDebug )
-  
-  unless( obj1.is_a?(String) )
-    obj1 = obj1.inspect
-  end
-
-  if( obj2.empty? )
-    debugPrint("#{obj1}\n".tosjis)
-    return
-  end
-  
-  obj2 = getTextFromLogTarget(obj2)
-  
-  debugPrint("#{obj1} : #{obj2}\n".tosjis)
-end
-
+# デバッグ文字列出力（末尾改行なし）
 def debugPrint(text)
-  print(text)
+  print($RUBY18_WIN ? text.tosjis : text)
 end
 
-def getTextFromLogTarget(target)
-  return target.inspect if( target.nil? )
-  
-  list = target.collect do |i|
-    if( i.is_a?(String) )
-      '"' + i + '"'
-      #print(i + "\n")
-    else
-      i.inspect
+# デバッグ文字列出力（末尾改行あり）
+def debugPuts(text)
+  line = "#{text}\n"
+  puts($RUBY18_WIN ? line.tosjis : line)
+end
+
+# デバッグ出力を行う
+# @param [Object] target 対象項目
+# @param [Object] values 値
+def debug(target, *values)
+  return unless $isDebug
+
+  targetStr = target.kind_of?(String) ? target : target.inspect
+
+  if values.empty?
+    debugPuts(targetStr)
+  else
+    valueStrs = values.map do |value|
+      value.kind_of?(String) ? %Q("#{value}") : value.inspect
     end
+
+    debugPuts("#{targetStr}: #{valueStrs.join(', ')}")
   end
-  
-  return list.join(", ")
 end
-
-
-
-
-

--- a/src/test/DiceBotTest.rb
+++ b/src/test/DiceBotTest.rb
@@ -44,12 +44,10 @@ class DiceBotTest
     if @errorLog.empty?
       puts('OK.')
     else
-      if /mswin(?!ce)|mingw|cygwin|bccwin/ === RUBY_PLATFORM.downcase
-        @errorLog.map!(&:tosjis)
-      end
+      errorLog = $RUBY18_WIN ? @errorLog.map(&:tosjis) : @errorLog
 
       puts('[Failures]')
-      puts(@errorLog.join("\n===========================\n"))
+      puts(errorLog.join("\n===========================\n"))
     end
 
     true


### PR DESCRIPTION
文字コードをShift_JISに固定していたため、デバッグ出力がそれ以外の文字コードの端末で文字化けするのを修正しました。変更後はデバッグ出力時に以下のように動作します。
- Ruby 1.8（Windows）：従来と同じ処理を行う。
- Ruby 1.8（Windows以外）：文字コードを変換せず出力する。
- Ruby 1.9以降：`Encoding.default_external` に依存するRubyの自動エンコード機構を利用する。文字コードを明示的に変換しない
