### PR TITLE
メソッド名・変数名のスペルの修正

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ BCDiceの問題を発見したり、機能の要望がある時に起こすア�
 3. Discordの [BCDice Offcial Chat][invite discord] にある各種チャンネルへ投稿する
 4. Twitterで [@ysakasin](https://twitter.com/ysakasin) にメンションを送る
 
-## LISENCE
+## LICENSE
 
 [BSD 3-Clause License](LICENSE)
 

--- a/src/bcdice.rb
+++ b/src/bcdice.rb
@@ -35,8 +35,8 @@ def mainBcDiceCli(args)
   print message
   print "\n"
   
-  bcdiceMarker = BCDiceMaker.new
-  bcdice = bcdiceMarker.newBcDice()
+  bcdiceMaker = BCDiceMaker.new
+  bcdice = bcdiceMaker.newBcDice()
   bcdice.setIrcClient( Cli.new )
   bcdice.setGameByTitle( gameType )
   

--- a/src/diceBot/BarnaKronika.rb
+++ b/src/diceBot/BarnaKronika.rb
@@ -131,8 +131,8 @@ INFO_MESSAGE_TEXT
       if( isCriticalCall(i, criticalCallDice) )
         debug("isCriticalCall")
         at_str += getAttackStringWhenCriticalCall(i, diceCount)
-      elsif( isNomalAtack(criticalCallDice, diceCount) )
-        debug("isNomalAtack")
+      elsif( isNomalAttack(criticalCallDice, diceCount) )
+        debug("isNomalAttack")
         at_str += getAttackStringWhenNomal(i, diceCount)
       end
 
@@ -166,28 +166,28 @@ INFO_MESSAGE_TEXT
     return (criticalCallDice == (index + 1))
   end
 
-  def isNomalAtack(criticalCallDice, diceCount)
+  def isNomalAttack(criticalCallDice, diceCount)
     return false unless( @isBattleMode )
     return false if(criticalCallDice != 0)
     return (diceCount > 1)
   end
 
   def getAttackStringWhenCriticalCall(index, diceCount)
-    hitLocation = getAtackHitLocation(index + 1)
-    atackValue = (diceCount * 2)
-    result = hitLocation + ":攻撃値#{atackValue},"
+    hitLocation = getAttackHitLocation(index + 1)
+    attackValue = (diceCount * 2)
+    result = hitLocation + ":攻撃値#{attackValue},"
     return result
   end
 
   def getAttackStringWhenNomal(index, diceCount)
-    hitLocation = getAtackHitLocation(index + 1)
-    atackValue = diceCount
-    result = hitLocation + ":攻撃値#{atackValue},"
+    hitLocation = getAttackHitLocation(index + 1)
+    attackValue = diceCount
+    result = hitLocation + ":攻撃値#{attackValue},"
     return result
   end
 
   # 命中部位表
-  def getAtackHitLocation(num)
+  def getAttackHitLocation(num)
     table = [
              [1, '頭部' ],
              [2, '右腕' ],

--- a/src/diceBot/DiceBot.rb
+++ b/src/diceBot/DiceBot.rb
@@ -95,7 +95,7 @@ class DiceBot
     {
       'name' => gameName,
       'gameType' => gameType,
-      'prefixs' => self.class.prefixes,
+      'prefixes' => self.class.prefixes,
       'info' => getHelpMessage,
     }
   end

--- a/src/diceBot/DiceBot.rb
+++ b/src/diceBot/DiceBot.rb
@@ -226,7 +226,7 @@ class DiceBot
   end
   
   def removeDiceCommandMessage(command)
-    # "2d6 Atack" のAtackのようなメッセージ部分をここで除去
+    # "2d6 Attack" のAttackのようなメッセージ部分をここで除去
     command.sub(/[\s　].+/, '')
   end
   

--- a/src/diceBot/ShinkuuGakuen.rb
+++ b/src/diceBot/ShinkuuGakuen.rb
@@ -37,8 +37,8 @@ MESSAGETEXT
   end
 
   def rollDiceCommand(command)
-    prefixsRegText = prefixs.collect{|i| i.sub(/\.\*/, '')}.join('|')
-    unless ( /(^|\s)(S)?(#{prefixsRegText})([\d\+\-]*)(>=(\d+))?/i === command )
+    prefixesRegText = prefixes.collect{|i| i.sub(/\.\*/, '')}.join('|')
+    unless ( /(^|\s)(S)?(#{prefixesRegText})([\d\+\-]*)(>=(\d+))?/i === command )
       debug("NOT match")
       return nil
     end

--- a/src/diceBot/ShinkuuGakuen.rb
+++ b/src/diceBot/ShinkuuGakuen.rb
@@ -45,34 +45,34 @@ MESSAGETEXT
 
     debug("matched.")
 
-    waponCommand = $3
+    weaponCommand = $3
     base = $4.to_i
     diff = $6
 
-    waponInfo = getWaponTable(waponCommand)
-    output_msg = rollJudge(base, diff, waponInfo)
+    weaponInfo = getWeaponTable(weaponCommand)
+    output_msg = rollJudge(base, diff, weaponInfo)
 
     return output_msg
   end
 
-  def rollJudge(base, diff, waponInfo)
+  def rollJudge(base, diff, weaponInfo)
     debug("rollJudge base", base)
     debug("rollJudge diff", diff)
 
-    waponName = waponInfo[:name]
-    waponTable = waponInfo[:table]
+    weaponName = weaponInfo[:name]
+    weaponTable = weaponInfo[:table]
 
     diceList = getJudgeDiceList
     total = diceList.inject(){|value, i| value += i}
     allTotal = total + base
 
     diffText = if diff.nil? then "" else ">=#{diff}" end
-    result = "(#{waponName}：#{base}#{diffText}) ＞ 1D100+#{base} ＞ #{total}"
+    result = "(#{weaponName}：#{base}#{diffText}) ＞ 1D100+#{base} ＞ #{total}"
     result += "[#{diceList.join(',')}]" if( diceList.length >= 2 )
     result += "+#{base}"
     result += " ＞ #{allTotal}"
-    result += getSuccessText(allTotal, diff, diceList, waponTable)
-    result += getWaponSkillText(waponTable, diceList.max)
+    result += getSuccessText(allTotal, diff, diceList, weaponTable)
+    result += getWeaponSkillText(weaponTable, diceList.max)
 
     debug("check_1D100 result", result)
 
@@ -94,7 +94,7 @@ MESSAGETEXT
     return diceList
   end
 
-  def getSuccessText(allTotal, diff, diceList, isWapon)
+  def getSuccessText(allTotal, diff, diceList, isWeapon)
     first = diceList.first
     return '' if( first.nil? )
 
@@ -105,7 +105,7 @@ MESSAGETEXT
     end
 
     result = ''
-    skillText = getSkillText(first, diff, isWapon)
+    skillText = getSkillText(first, diff, isWeapon)
     result += skillText
 
     unless( diff.nil? )
@@ -118,9 +118,9 @@ MESSAGETEXT
     return result
   end
 
-  def getSkillText(first, diff, isWapon)
+  def getSkillText(first, diff, isWeapon)
     result = ''
-    return result if( isWapon )
+    return result if( isWeapon )
 
     result = ' ＞ '
     return result unless( first == 10 )
@@ -134,58 +134,58 @@ MESSAGETEXT
     return result\
   end
 
-  def getWaponTable(waponCommand)
-    debug('getWaponTable waponCommand', waponCommand)
+  def getWeaponTable(weaponCommand)
+    debug('getWeaponTable weaponCommand', weaponCommand)
 
-    case waponCommand.upcase
+    case weaponCommand.upcase
     when 'SW'
-      return getWaponTableSword
+      return getWeaponTableSword
     when 'CSW'
-      return getWaponTableSwordCounter
+      return getWeaponTableSwordCounter
     when 'LS'
-      return getWaponTableLongSword
+      return getWeaponTableLongSword
     when 'CLS'
-      return getWaponTableLongSwordCounter
+      return getWeaponTableLongSwordCounter
     when 'SS'
-      return getWaponTableShortSword
+      return getWeaponTableShortSword
     when 'CSS'
-      return getWaponTableShortSwordCounter
+      return getWeaponTableShortSwordCounter
     when 'SP'
-      return getWaponTableSpear
+      return getWeaponTableSpear
     when 'CSP'
-      return getWaponTableSpearCounter
+      return getWeaponTableSpearCounter
     when 'AX'
-      return getWaponTableAx
+      return getWeaponTableAx
     when 'CAX'
-      return getWaponTableAxCounter
+      return getWeaponTableAxCounter
     when 'CL'
-      return getWaponTableClub
+      return getWeaponTableClub
     when 'CCL'
-      return getWaponTableClubCounter
+      return getWeaponTableClubCounter
     when 'BW'
-      return getWaponTableBow
+      return getWeaponTableBow
     when 'MA'
-      return getWaponTableMartialArt
+      return getWeaponTableMartialArt
     when 'CMA'
-      return getWaponTableMartialArtCounter
+      return getWeaponTableMartialArtCounter
     when 'BX'
-      return getWaponTableBoxing
+      return getWeaponTableBoxing
     when 'CBX'
-      return getWaponTableBoxingCounter
+      return getWeaponTableBoxingCounter
     when 'PR'
-      return getWaponTableProWrestling
+      return getWeaponTableProWrestling
     when 'CPR'
-      return getWaponTableProWrestlingCounter
+      return getWeaponTableProWrestlingCounter
     when 'ST'
-      return getWaponTableStand
+      return getWeaponTableStand
     when 'CST'
-      return getWaponTableStandCounter
+      return getWeaponTableStandCounter
     end
 
     return {:name => '判定', :table => nil}
   end
 
-  def getWaponTableSword
+  def getWeaponTableSword
     {:name => '剣',
       :table =>
       [[11, '失礼剣', '成功度＋５'],
@@ -201,7 +201,7 @@ MESSAGETEXT
       ]}
   end
 
-  def getWaponTableSwordCounter
+  def getWeaponTableSwordCounter
     {:name => '剣カウンター',
       :table =>
       [[33, 'パリィ', '攻撃の無効化'],
@@ -215,7 +215,7 @@ MESSAGETEXT
       ]}
   end
 
-  def getWaponTableLongSword
+  def getWeaponTableLongSword
     {:name => '大剣',
       :table =>
       [[11, 'スマッシュ', '敵防御半分'],
@@ -231,7 +231,7 @@ MESSAGETEXT
       ]}
   end
 
-  def getWaponTableLongSwordCounter
+  def getWeaponTableLongSwordCounter
     {:name => '大剣カウンター',
       :table =>
       [[22, '無形の位', '攻撃の無効化'],
@@ -246,7 +246,7 @@ MESSAGETEXT
       ]}
   end
 
-  def getWaponTableShortSword
+  def getWeaponTableShortSword
     {:name => '小剣',
       :table =>
       [[11, '乱れ突き', '２連続攻撃'],
@@ -262,7 +262,7 @@ MESSAGETEXT
       ]}
   end
 
-  def getWaponTableShortSwordCounter
+  def getWeaponTableShortSwordCounter
     {:name => '小剣カウンター',
       :table =>
       [[11, 'リポスト', 'カウンター'],
@@ -278,7 +278,7 @@ MESSAGETEXT
       ]}
   end
 
-  def getWaponTableSpear
+  def getWeaponTableSpear
     {:name => '槍',
       :table =>
       [[11, 'チャージ', 'ダメージ１．５倍、盾受けー３０'],
@@ -294,7 +294,7 @@ MESSAGETEXT
       ]}
   end
 
-  def getWaponTableSpearCounter
+  def getWeaponTableSpearCounter
     {:name => '槍カウンター',
       :table =>
       [[55, '風車', 'カウンター、ダメージ２倍'],
@@ -306,7 +306,7 @@ MESSAGETEXT
       ]}
   end
 
-  def getWaponTableAx
+  def getWeaponTableAx
     {:name => '斧',
       :table =>
       [[11, '一人時間差', '防御行動ー１００'],
@@ -322,7 +322,7 @@ MESSAGETEXT
       ]}
   end
 
-  def getWaponTableAxCounter
+  def getWeaponTableAxCounter
     {:name => '斧カウンター',
       :table =>
       [[44, '真っ向唐竹割り', 'クロスカウンター、Ｂ・Ｄ'],
@@ -335,7 +335,7 @@ MESSAGETEXT
       ]}
   end
 
-  def getWaponTableClub
+  def getWeaponTableClub
     {:name =>'棍棒',
       :table =>
       [[11, 'ハードヒット', '防御力無視'],
@@ -351,7 +351,7 @@ MESSAGETEXT
       ]}
   end
 
-  def getWaponTableClubCounter
+  def getWeaponTableClubCounter
     {:name =>'棍棒カウンター',
       :table =>
       [[11, 'ブロッキング', '攻撃の無効化'],
@@ -367,7 +367,7 @@ MESSAGETEXT
       ]}
   end
 
-  def getWaponTableBow
+  def getWeaponTableBow
     {:name => '弓',
       :table =>
       [[11, '影縫い', '麻痺効果「注意力」０'],
@@ -383,7 +383,7 @@ MESSAGETEXT
       ]}
   end
 
-  def getWaponTableMartialArt
+  def getWeaponTableMartialArt
     {:name => '体術',
       :table =>
       [[11, '集気法', '通常ダメージ分自分のＨＰ回復'],
@@ -399,7 +399,7 @@ MESSAGETEXT
       ]}
   end
 
-  def getWaponTableMartialArtCounter
+  def getWeaponTableMartialArtCounter
     {:name => '体術カウンター',
       :table =>
       [[11, 'スウェイバック', '攻撃の無効化'],
@@ -420,16 +420,16 @@ MESSAGETEXT
     dice = value * 10 + value
     dice = 100 if( value == 110 )
 
-    tableInfo = getWaponTableMartialArt
-    waponTable = tableInfo[:table]
+    tableInfo = getWeaponTableMartialArt
+    weaponTable = tableInfo[:table]
 
     result = " ＞ (#{value})"
-    result += getWaponSkillText(waponTable, dice)
+    result += getWeaponSkillText(weaponTable, dice)
 
     return result
   end
 
-  def getWaponTableBoxing
+  def getWeaponTableBoxing
     {:name => 'ボクシング',
       :table =>
       [[11, 'ワン・ツー', '２連続攻撃・２攻撃目盾受け、回避不可'],
@@ -445,7 +445,7 @@ MESSAGETEXT
       ]}
   end
 
-  def getWaponTableBoxingCounter
+  def getWeaponTableBoxingCounter
     {:name => 'ボクシングカウンター',
       :table =>
       [[11, 'ダッキングブロー', 'カウンター'],
@@ -461,7 +461,7 @@ MESSAGETEXT
       ]}
   end
 
-  def getWaponTableProWrestling
+  def getWeaponTableProWrestling
     {:name => 'プロレス',
       :table =>
       [[11, 'ボディスラム', '盾受け不可'],
@@ -477,7 +477,7 @@ MESSAGETEXT
       ]}
   end
 
-  def getWaponTableProWrestlingCounter
+  def getWeaponTableProWrestlingCounter
     {:name => 'プロレスカウンター',
       :table =>
       [[22, 'パワースラム', 'カウンター'],
@@ -490,7 +490,7 @@ MESSAGETEXT
       ]}
   end
 
-  def getWaponTableStand
+  def getWeaponTableStand
     {:name => '幽波紋',
       :table =>
       [[11, 'SILER CHARIOT', '攻撃量５倍、刺しタイプ攻撃'],
@@ -506,7 +506,7 @@ MESSAGETEXT
       ]}
   end
 
-  def getWaponTableStandCounter
+  def getWeaponTableStandCounter
     {:name => '幽波紋カウンター',
       :table =>
       [[11, 'ANUBIS', '技のみカウンター、ダメージ（カウンターした回数の２乗）倍、斬りタイプ攻撃'],
@@ -522,15 +522,15 @@ MESSAGETEXT
       ]}
   end
 
-  def getWaponSkillText(waponTable, dice)
-    debug('getWaponSkillText', dice)
+  def getWeaponSkillText(weaponTable, dice)
+    debug('getWeaponSkillText', dice)
 
-    return '' if( waponTable.nil? )
+    return '' if( weaponTable.nil? )
 
     preName = ''
     preEffect = ''
 
-    waponTable.each do |index, name, effect|
+    weaponTable.each do |index, name, effect|
       name ||= preName
       preName = name
 

--- a/src/diceBot/Warhammer.rb
+++ b/src/diceBot/Warhammer.rb
@@ -38,8 +38,8 @@ INFO_MESSAGE_TEXT
     case command.upcase
 
     when /^(WH\d+(@[\dWH]*)?)/i
-      atackCommand = $1
-      output_msg = getAtackResult(atackCommand)
+      attackCommand = $1
+      output_msg = getAttackResult(attackCommand)
 
     when /^(WH[HABTLW]\d+)/i
       criticalCommand = $1
@@ -301,8 +301,8 @@ INFO_MESSAGE_TEXT
     return output
   end
 
-  def getAtackResult(string)
-    debug("getAtackResult begin string", string)
+  def getAttackResult(string)
+    debug("getAttackResult begin string", string)
 
     pos_type = ""
 

--- a/src/diceBot/_InsaneScp.rb
+++ b/src/diceBot/_InsaneScp.rb
@@ -16,7 +16,7 @@ class Insane < DiceBot
     "Insane"
   end
   
-  def prefixs
+  def prefixes
      ['ST', 'HJST', 'MTST', 'DVST', 'DT', 'BT', 'PT', 'FT', 'JT', 'BET', 'RTT', 'TVT', 'TET', 'TPT', 'TST', 'TKT', 'TMT',
       'CHT', 'VHT', 'IHT', 'RHT', 'MHT', 'LHT', 'ECT','EMT','EAT','OPT','OHT','OWT','CNT1','CNT2','CNT3','RET', 'IRN']
   end


### PR DESCRIPTION
メソッド名・変数名に存在する、以下のスペルミスを修正しました。

* prefixs -> prefixes
* marker -> maker
* wapon -> weapon
* lisence -> license
* atack -> attack

API が変わりかねないため、気付いた中でも以下のスペルミスは修正していません(他にもあるかもしれません)。

* recive, recieve -> receive
  - recieveMessage など
  - $isRollVoidDiceAtAnyRecive
* uppler -> upper
  - upplerRollThreshold など

`ruby src/test.rb` コマンドは全てパスしています。
以上、ご確認頂きますよう、よろしくお願い致します。