### PR TITLE
不要なスペースを削除する

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -3,6 +3,7 @@ root = true
 [*]
 end_of_line = lf
 insert_final_newline = true
+trim_trailing_whitespace = true
 charset = utf-8
 
 [*.rb]

--- a/.editorconfig
+++ b/.editorconfig
@@ -3,12 +3,12 @@ root = true
 [*]
 end_of_line = lf
 insert_final_newline = true
-trim_trailing_whitespace = true
 charset = utf-8
 
 [*.rb]
 indent_style = space
 indent_size = 2
+trim_trailing_whitespace = true
 
 [*.yml]
 indent_style = space

--- a/src/.rubocop_todo.yml
+++ b/src/.rubocop_todo.yml
@@ -427,12 +427,6 @@ Layout/SpaceInsideStringInterpolation:
 Layout/Tab:
   Enabled: false
 
-# Offense count: 2764
-# Cop supports --auto-correct.
-# Configuration parameters: AllowInHeredoc.
-Layout/TrailingWhitespace:
-  Enabled: false
-
 # Offense count: 1
 # Configuration parameters: AllowSafeAssignment.
 Lint/AssignmentInCondition:

--- a/src/ArgsAnalizer.rb
+++ b/src/ArgsAnalizer.rb
@@ -2,55 +2,55 @@
 # -*- coding: utf-8 -*-
 
 class ArgsAnalizer
-  
+
   def initialize(args)
     @args = args
     @isStartIrc = true
   end
-  
+
   attr :isStartIrc
-  
+
   def analize
     isAnalized = false
-    
+
     @args.each do |arg|
       result = analizeArg(arg)
       checkArg(arg)
-      
+
       if( result )
         isAnalized = true
       end
     end
-    
+
     return isAnalized
   end
 
-  
+
   def checkArg(arg)
     if( isCreateExeMode(arg) )
       @isStartIrc = false
     end
   end
-  
-  
+
+
   def isCreateExeMode(arg)
     if( arg == "createExe" )
       if( File.exist?("__createExe__.txt") )
         return true
       end
     end
-    
+
     return false
   end
-  
 
-  
+
+
   def analizeArg(arg)
     return false unless( /^-([scngmeir])(.+)$/i =~ arg )
-    
+
     command = $1.downcase
     @param = $2
-    
+
     case command
     when "s"
       setServer
@@ -69,36 +69,36 @@ class ArgsAnalizer
     else
       return false
     end
-    
+
     return true
   end
-  
-  
+
+
   def setServer
     # サーバ設定(Server:Port)
     data = @param.split(/:/)
     $server = data[0];
     $port = data[1] if( data[1] );
   end
-  
+
   def setChannel
     $defaultLoginChannelsText = decode($ircCode, @param)
   end
-  
+
   def setNick
     $nick = @param;
   end
-  
+
   def setGame
     $defaultGameType = @param
   end
-  
+
   def readExtraCard
     $extraCardFileName = @param
   end
-  
+
   def setIrcServerCharacterCode
     $ircCode = param;
   end
-  
+
 end

--- a/src/CardTrader.rb
+++ b/src/CardTrader.rb
@@ -1,4 +1,4 @@
-#!/perl/bin/ruby -Ku 
+#!/perl/bin/ruby -Ku
 # -*- coding: utf-8 -*-
 
 require 'configBcDice.rb'
@@ -19,17 +19,17 @@ class CardTrader
   # ジョーカーの数
   # @return [Integer]
   attr_reader :numOfJokers
-  
+
   def initialize
     initValues
-    
+
     @card_channels = {};
     @card_spell = [
                    'A','B','C','D','E','F','G','H','I','J','K','L','M','N','P','Q','R','S','T','U','V','W','X','Y','Z',
                    'a','b','c','d','e','f','g','h','i','j','k','m','n','o','p','q','r','s','t','u','v','w','x','y','z',
                   ];  # 64種類の記号
   end
-  
+
   # カードをデフォルトに戻す
   def initValues
     @cardTitles = {}
@@ -105,19 +105,19 @@ class CardTrader
 
     self
   end
-  
+
   def setBcDice(bcDice)
     @bcdice = bcDice
   end
-  
+
   def setNick(nick_e)
     @nick_e = nick_e
   end
-  
+
   def setTnick(t)
     @tnick = t
   end
-  
+
   # カード機能ヘルプ
   def printCardHelp
     send_to_sender = lambda { |message| sendMessageToOnlySender message }
@@ -177,20 +177,20 @@ class CardTrader
 
     sendMessageToOnlySender "  -- END ---"
   end
-  
+
   def setCardMode()
     return unless( /(\d+)/  =~ @tnick )
-    
+
     @card_place = $1.to_i
-    
+
     if( @card_place > 0 )
       sendMessageToChannels("カード置き場ありに変更しました")
     else
       sendMessageToChannels("カード置き場無しに変更しました")
     end
   end
-  
-  
+
+
   def readCardSet()
     begin
       readExtraCard(@tnick);
@@ -199,150 +199,150 @@ class CardTrader
       sendMessageToOnlySender(e.to_s)
     end
   end
-  
-  
+
+
   def sendMessage(to, message)
     @bcdice.sendMessage(to, message)
   end
-  
+
   def sendMessageToOnlySender(message)
     @bcdice.sendMessageToOnlySender(message)
   end
-  
+
   def sendMessageToChannels(message)
     @bcdice.sendMessageToChannels(message)
   end
-  
-  
+
+
   ###########################################################################
   #**                        ゲーム設定関連
   ###########################################################################
-  
+
   # 専用カードセットのロード
   def readExtraCard(cardFileName)
     return if(cardFileName.nil?)
     return if(cardFileName.empty?)
-    
+
     debug("Loading Cardset『#{cardFileName}』...\n");
-    
+
     @card_val = [];
-    
+
     begin
       lines = File.readlines(cardFileName)
-      
+
       lines.each do |line|
         next unless(/^(\d+)->(.+)$/ =~ line)  # 番号->タイトル
-        
+
         cardNumber = $1.to_i;
         cardTitle = $2;
         @card_val.push(cardNumber);
         @cardTitles[cardNumber] = cardTitle;
       end
-      
+
       @cardRegExp = '[\d]+';    #カード指定文字列の正規表現
       @cardRest = @card_val.clone
       @deal_cards = {'card_played' => []};
-      
+
       debug("Load Finished...\n");
     rescue => e
       raise ("カードデータを開けません :『#{cardFileName}』" + e.to_s)
     end
   end
-  
-  
+
+
   def executeCard(arg, channel)
     @channel = channel
-    
+
     debug('executeCard arg', arg)
     return unless( /(c-)/ =~ arg )
-    
+
     card_ok = 0
     count = 0
-    
+
     case arg
     when /(c-shuffle|c-sh)($|\s)/
       output_msg = shuffleCards
       sendMessage(@channel, output_msg);
-      
+
     when /c-draw(\[[\d]+\])?($|\s)/
       drawCardByCommandText(arg)
-      
+
     when /(c-odraw|c-opend)(\[[\d]+\])?($|\s)/
       value = $2
       drawCardOpen(value)
-      
+
     when /c-hand($|\s)/
       sendMessageToOnlySender(getHandAndPlaceCardInfoText(arg, @nick_e));
-      
+
     when /c-vhand\s*(#{$ircNickRegExp})($|\s)/
       name = $1
       debug("c-vhand name", name)
       messageText = ("#{name} の手札は" + getHandAndPlaceCardInfoText("c-hand", name) + "です")
       sendMessageToOnlySender(messageText);
-      
+
     when /c-play(\d*)\[#{@cardRegExp}(,#{@cardRegExp})*\]($|\s)/
         playCardByCommandText(arg)
-      
+
     when /(c-rshuffle|c-rsh)($|\s)/
       output_msg = returnCards
       sendMessage(@channel, output_msg);
-      
+
     when /c-clean($|\s)/
       output_msg = clearAllPlaceAllPlayerCards
       sendMessage(@channel, output_msg);
-      
+
     when /c-review($|\s)/
       output_msg = reviewCards
       sendMessageToOnlySender(output_msg);
-      
+
     when /c-check($|\s)/
       out_msg, place_msg = getAllCardLocation
       sendMessage(@channel, out_msg);
       sendMessage(@channel, place_msg);
-      
+
     when /c-pass(\d)*(\[#{@cardRegExp}(,#{@cardRegExp})*\])?\s*(#{$ircNickRegExp})($|\s)/
       sendTo = $4
       transferCardsByCommandText(arg, sendTo)
-      
+
     when /c-pick\[#{@cardRegExp}(,#{@cardRegExp})*\]($|\s)/
         pickupCardCommandText(arg)
             # FIXME
     when /c-back(\d)*\[#{@cardRegExp}(,#{@cardRegExp})*\]($|\s)/
         backCardCommandText(arg)
-      
+
     when /c-deal(\[[\d]+\]|\s)\s*(#{$ircNickRegExp})($|\s)/
       count = $1
       targetNick = $2
       dealCard(count, targetNick)
-      
+
     when /c-vdeal(\[[\d]+\]|\s)\s*(#{$ircNickRegExp})($|\s)/
       count = $1
       targetNick = $2
       lookAndDealCard(count, targetNick)
-      
+
     when /c-(dis|discard)(\d)*\[#{@cardRegExp}(,#{@cardRegExp})*\]($|\s)/
       discardCardCommandText(arg)
-      
+
     when /c-place(\d)*(\[#{@cardRegExp}(,#{@cardRegExp})*\])?\s*(#{$ircNickRegExp})($|\s)/
       targetNick = $4
       sendCardToTargetNickPlaceCommandText(arg, targetNick)
-      
+
     when /c-(un)?tap(\d+)\[#{@cardRegExp}(,#{@cardRegExp})*\]($|\s)/
       tapCardCommandText(arg)
-      
+
     when /c-spell(\[(#{$ircNickRegExp}[^\]]+?)\])?($|\s)/
       spellText = $2
       printCardRestorationSpellResult(spellText)
       #c_spell_caller(arg)
-      
+
     when /(c-mil(stone)?(\[[\d]+\])?)($|\s)/
       commandText = $1
       printMilStoneResult(commandText)
     end
   end
-  
+
   ####################            山札関連           ########################
-  
+
   # デッキと手札の初期化
   def shuffleCards
     @cardRest = @card_val.clone
@@ -353,74 +353,74 @@ class CardTrader
 ####################             ドロウ            ########################
   def drawCardByCommandText(arg)
     debug("drawCardByCommandText arg", arg)
-    
+
     cards = drawCard(arg);
     debug("drawCardByCommandText cards", cards)
-    
+
     if(cards.length > 0)
       sendMessageToOnlySender(getCardsTextFromCards(cards));
       sendMessage(@channel, "#{@nick_e}: #{cards.length}枚引きました");
     else
       sendMessage(@channel, "カードが残っていません");
     end
-    
+
     @card_channels[@nick_e] ||= @channel
   end
-  
+
   def drawCardOpen(value)
     cmd = "c-draw";
     cmd += value unless( value.nil? )
-    
+
     cards = drawCard(cmd);
-    
+
     if(cards.length > 0)
       sendMessage(@channel, "#{@nick_e}: " + getCardsTextFromCards(cards) + 'を引きました');
     else
       sendMessage(@channel, "カードが残っていません");
     end
-    
+
     @card_channels[@nick_e] ||= @channel
   end
-  
+
   def drawCard(command, destination = nil)
     destination ||= @nick_e
     destination = destination.upcase
-    
+
     debug("drawCard command, destination", command, destination)
     outputCards = []
-    
+
     debug("@cardRest.length", @cardRest.length)
     if(@cardRest.length <= 0)
       return outputCards
     end
-    
+
     unless(/(c-draw(\[([\d]+)\])?)/ =~ command)
       return outputCards
     end
-    
+
     count = $3
     count ||= 1
     count = count.to_i
     debug("draw count", count)
-    
+
     count.times do |i|
       break if(@cardRest.length <= 0)
-      
+
       card = ejectOneCardRandomFromCards(@cardRest)
       break if( card.nil? )
-      
+
       @deal_cards[ destination ] ||= []
       @deal_cards[ destination ] << card
-      
+
       outputCards << card
     end
-    
+
     return outputCards
   end
-  
+
   def pickupCardCommandText(string)
     debug('pickupCardCommandText string', string)
-    
+
     count, output_msg = pickupCard(string)
     if( count > 0 )
       sendMessage(@channel, "#{@nick_e}: #{count}枚選んで引きました");
@@ -430,38 +430,38 @@ class CardTrader
     end
     sendMessageToOnlySender(getHandAndPlaceCardInfoText("Auto"));
   end
-  
-  
+
+
   def pickupCard(string)
     okCount = 0
     ngCardList = []
-    
+
     if(/(c-pick\[((,)?#{@cardRegExp})+\])/ =~ string)
       cardName = $1
       okCount, ngCardList = pickupCardByCardName(cardName)
     end
-    
+
     ngCardText = ngCardList.join(",")
-    
+
     return okCount, ngCardText;   # 抜き出せた枚数とデッキに無かったカードを返す
   end
-  
+
   def pickupCardByCardName(cardName)
     okCount = 0
     ngCardList = []
-    
+
     if(/\[(#{@cardRegExp}(,#{@cardRegExp})*)\]/ =~ cardName)
       cards = $1.split(/,/)
       okCount, ngCardList = pickupCardByCards(cards)
     end
-    
+
     return okCount, ngCardList
   end
-  
+
   def pickupCardByCards(cards)
     okCount = 0
     ngCardList = []
-    
+
     cards.each do |card|
       string = pickupOneCard(card)
       if(string == $okResult)
@@ -470,20 +470,20 @@ class CardTrader
         ngCardList << string
       end
     end
-    
+
     return okCount, ngCardList
   end
-  
+
   def pickupOneCard(card)
     if(@cardRest.length <= 0)
       return '山札'
     end
-    
+
     targetCard = card.upcase; # デッキから抜き出すカードの指定
     destination = @nick_e.upcase
 
     isDelete = @cardRest.delete_if{|card| card == targetCard}
-    
+
     if( isDelete )
       @deal_cards[destination] ||= []
       @deal_cards[destination] << targetCard
@@ -492,15 +492,15 @@ class CardTrader
       return targetCard;   # 無かったカードを返す
     end
   end
-  
-  
+
+
   def backCardCommandText(command)
     count, output_msg = backCard(command);
-    
+
     if(count > 0)
       sendMessage(@channel, "#{@nick_e}: #{count}枚戻しました");
     end
-    
+
     if(output_msg != "")
       sendMessage(@channel, "[#{getCardsText(output_msg)}]がありません");
     else
@@ -511,24 +511,24 @@ class CardTrader
   def backCard(command)
     okCount = 0;
     ngCards = []
-    
+
     if(/(c-back(\d*)\[((,)?#{@cardRegExp})+\])/ =~ command)
       commandset = $1;
       place = $2.to_i
       okCount, ngCards = backCardByCommandSetAndPlace(commandset, place)
     end
-    
+
     return okCount, ngCards.join(',')
   end
-  
+
   def backCardByCommandSetAndPlace(commandset, place)
     okCount = 0;
     ngCards = []
     destination = @nick_e.upcase
-    
+
     if( /\[(#{@cardRegExp}(,#{@cardRegExp})*)\]/ =~ commandset )
       cards = $1.split(/,/)
-      
+
       cards.each do |card|
         string = backOneCard(card, destination, place);
         if(string == $okResult)
@@ -538,51 +538,51 @@ class CardTrader
         end
       end
     end
-    
+
     return okCount, ngCards;   # 戻せた枚数とNGだったカードを返す
   end
-  
+
   def backOneCard(targetCard, destination, place)
     if(getBurriedCard <= 0)
         return '捨て札';    # 捨て札が無い
     end
-    
-    
+
+
     targetCard = targetCard.upcase
-    
+
     if(@card_place > 0)   # 場があるときのみ処理
       string = transferOneCard(targetCard, "#{place}#{destination}", destination);   # 場から手札への移動
       return $okResult if(string == $okResult);
     end
-    
+
     @deal_cards['card_played'] ||= []
     cards = @deal_cards['card_played']
     isDelete = cards.delete_if{|i| i == targetCard}
-    
+
     if( isDelete )
       @deal_cards[destination] << targetCard
       return $okResult;
     end
-    
+
     return "${targetCard}"; # 戻せるカードが無かったらNGのカードを返す
   end
 
-  
+
   def dealCard(count, targetNick, isLook = false)
     debug("dealCard count, targetNick", count, targetNick)
-    
+
     cards = drawCard("c-draw#{count}", targetNick);
     if(cards.length > 0)
       sendDealResult(targetNick, count, getCardsTextFromCards(cards), isLook)
     else
       sendMessage(@channel, "カードが残っていません");
     end
-    
+
     @card_channels[targetNick] ||= @channel
-    
+
     return count
   end
-  
+
   def sendDealResult(targetNick, count, output_msg, isLook)
     sendMessage(targetNick, output_msg);
     if( isLook )
@@ -595,19 +595,19 @@ class CardTrader
     isLook = true
     dealCard(count, targetNick, isLook)
   end
-  
+
   def discardCardCommandText(commandText)
     count, output_msg, card_ok = discardCards(commandText)
-    
+
     if(count > 0)
       sendMessage(@channel, "#{@nick_e}: #{count}枚捨てました");
-      
+
       unless( @cardTitles.empty? )
         cardText = getCardsText($card_ok)
         sendMessage(@channel, "[#{cardText}]")
       end
     end
-    
+
     if(output_msg != "")
       cardText = getCardsText(output_msg)
       sendMessageToOnlySender("[#{cardText}]がありません");
@@ -615,12 +615,12 @@ class CardTrader
       sendMessageToOnlySender(getHandAndPlaceCardInfoText("Auto"));
     end
   end
-  
-  
+
+
 ####################             プレイ            ########################
   def playCardByCommandText(arg)
     debug('c-play pattern', arg)
-    
+
     count, output_msg, card_ok = playCard(arg);
     if( count > 0 )
       sendMessage(@channel, "#{@nick_e}: #{count}枚出しました");
@@ -632,15 +632,15 @@ class CardTrader
     end
     sendMessageToOnlySender(getHandAndPlaceCardInfoText("Auto", @nick_e));
   end
-  
-  
+
+
   def playCard(cardPlayCommandText)
     debug('playCard cardPlayCommandText', cardPlayCommandText)
-    
+
     okCardCount = 0
     okCardList = []
     ngCardList = []
-    
+
     if(/(c-play(\d*)\[((,)?#{@cardRegExp})+\])/ =~ cardPlayCommandText)
       cardsBlockText = $1
       place = $2.to_i
@@ -649,70 +649,70 @@ class CardTrader
       okCardList, ngCardList = playCardByCardsBlockTextAndPlaceNo(cardsBlockText, place)
       debug("okCardList", okCardList)
       debug("ngCardList", ngCardList)
-      
+
       okCardCount = okCardList.length
       okCardText = okCardList.join(',')
       ngCardText = ngCardList.join(',')
     end
-    
-    
+
+
     # 出せた枚数、NGだったカード、出せたカード
     return okCardCount, ngCardText, okCardText
   end
-  
-  
+
+
   def playCardByCardsBlockTextAndPlaceNo(cardsBlockText, place)
     okCardList = []
     ngCardList = []
-    
+
     if(/\[(#{@cardRegExp}(,#{@cardRegExp})*)\]/ =~ cardsBlockText)
       cardsText = $1
       okCardList, ngCardList = playCardByCardsTextAndPlaceNo(cardsText, place)
     end
-    
+
     return okCardList, ngCardList
   end
-  
+
   def playCardByCardsTextAndPlaceNo(cardsText, place)
     cards = cardsText.split(/,/)
-    
+
     okCardList = []
     ngCardList = []
-    
+
     cards.each do |card|
       okList, ngList = playCardByCardAndPlaceNo(card, place)
-      
+
       okCardList += okList
       ngCardList += ngList
     end
-    
+
     return okCardList, ngCardList
   end
-  
+
   def playCardByCardAndPlaceNo(card, place)
     debug("playCardByCardAndPlaceNo card, place", card, place)
-    
+
     okList = []
     ngList = []
-    
+
     result = playOneCard(card, place)
     debug("playOneCard result", result)
-    
+
     if(result == $okResult)
       okList << card;
     else
       ngList << result
     end
-    
+
     return okList, ngList
   end
-  
+
   def playOneCard(card, place)
     debug("playOneCard card, place", card, place)
-    
+
     destination = @nick_e.upcase
     result = "";
-    
+
     if(place > 0)
       debug("playOneCard place > 0")
       result = transferOneCard(card, destination, "#{place}#{destination}" ); # 場に出す処理
@@ -720,77 +720,77 @@ class CardTrader
       debug("playOneCard place <= 0")
       result = discardOneCard(card, place, destination);    # 場を使わないときは捨て札扱い
     end
-    
+
     if(result == $okResult)
       return result
     else
       return card
     end
   end
-  
+
   def discardCards(command, destination = nil)
     debug("discardCards command, destination", command, destination)
-    
+
     destination = @nick_e if( destination.nil? )
     destination = destination.upcase
-    
+
     okList = []
     ngList = []
-    
+
     if(/(c-(dis|discard)(\d*)\[((,)?#{@cardRegExp})+\])/ =~ command)
       debug("discardCards reg OK")
       commandSet = $1;
       place = $3.to_i
       okList, ngList = discardCardsByCommandSetAndPlaceAndDestination(commandSet, place, destination)
     end
-    
+
     ngText = ngList.join(',')
     okText = okList.join(',')
-    
+
     return okList.length, ngText, okText
   end
-  
+
   def discardCardsByCommandSetAndPlaceAndDestination(commandSet, place, destination)
     okList = []
     ngList = []
-    
+
     if(/\[(#{@cardRegExp}(,#{@cardRegExp})*)\]/ =~ commandSet)
       cards = $1.split(/,/)
       okList, ngList = discardCardsByCardsAndPlace(cards, place, destination)
     end
-    
+
     return okList, ngList
   end
 
   def discardCardsByCardsAndPlace(cards, place, destination)
     okList = []
     ngList = []
-    
+
     cards.each do |card|
       result = discardOneCard(card, place, destination);
-      
+
       if(result == $okResult)
         okList << card
       else
         ngList << result
       end
     end
-    
+
     return okList, ngList
   end
-  
+
 
   def discardOneCard(card, place, destination)
     card = card.upcase
     destination = destination.upcase
     destination = getDestinationWhenPlaceIsNotHand(place, destination)
-    
+
     this_cards = []
     rest_cards = []
-    
+
     temp_cards = getCardsFromDealCards(destination)
-    
-    
+
+
     result = temp_cards.reject! {|i| i == card}
     isTargetCardInHand = ( not result.nil? )
     if( isTargetCardInHand )
@@ -798,9 +798,9 @@ class CardTrader
     else
       rest_cards << card
     end
-    
+
     debug("isTargetCardInHand", isTargetCardInHand)
-    
+
     if( isTargetCardInHand )
       debug("isTargetCardInHand OK, so set card info")
       @deal_cards[destination] ||= []
@@ -808,44 +808,44 @@ class CardTrader
       @deal_cards['card_played'] ||= []
       @deal_cards['card_played'] += this_cards
       debug("@deal_cards", @deal_cards)
-      
+
       return $okResult;
     else
       return card;   # 指定のカードが無いので、無いカードを返す
     end
   end
-  
+
   def getDestinationWhenPlaceIsNotHand(place, destination)
     if(place > 0)
       # 場札から出すときは「出した人」を場札に書き替え
       destination = "#{place}#{destination}"
       return destination
     end
-    
+
     return destination
   end
-  
+
   def getCardsFromDealCards(destination)
     debug('getCardsFromDealCards destination', destination)
     debug('@deal_cards', @deal_cards)
     debug('@deal_cards[destination]', @deal_cards[destination])
-    
+
     if( @deal_cards[destination].nil? )
       debug('getCardsFromDealCards empty')
       return []
     end
-    
+
     cards = @deal_cards[destination]
     debug('getCardsFromDealCards cards', cards)
     return cards
   end
-  
+
 ####################              パス             ########################
-  
+
   def transferCardsByCommandText(commandText, sendTo)
     debug("transferCardsByCommandText commandText, sendTo", commandText, sendTo)
     count, output_msg = transferCards(commandText);
-    
+
     if( count < 0 )
       sendMessage(@channel, "#{@nick_e}: 相手が登録されていません");
     else
@@ -858,66 +858,66 @@ class CardTrader
         sendMessage(sendTo, getHandAndPlaceCardInfoText("Auto", sendTo));
       end
     end
-    
+
     sendMessageToOnlySender(getHandAndPlaceCardInfoText("Auto"));
   end
-  
+
   def transferCards(command)
     debug('transferCards command', command)
-    
+
     okCount = 0;
     ngCardList = []
-    
+
     if(/(c-pass(\d*)(\[(((,)?#{@cardRegExp})*)\])?)\s*(#{$ircNickRegExp})/ =~ command)
       destination = $7.upcase
       commandset = $1;
       place = $2.to_i
       place ||= 0
       okCount, ngCardList = transferCardsByCommand(commandset, place, destination)
-      
+
       debug('transferCardsByCommand resutl okCount, ngCardList', okCount, ngCardList)
     end
-    
+
     ngCardText = ngCardList.join(",")
     return okCount, ngCardText;  # 渡せた枚数とNGなカードを返す
   end
-  
+
   def transferCardsByCommand(commandset, place, destination)
     debug('transferCardsByCommand commandset, place, destination', commandset, place, destination)
-    
+
     nick_e = @nick_e
-    
+
     if(place > 0);
       nick_e = "#{place}#{nick_e}"
     end
-    
+
     okCount = 0
     ngCardList = []
     debug('LINE', __LINE__)
-    
+
     cards = ['']
     if(/\[(#{@cardRegExp}(,#{@cardRegExp})*)\]/ =~ commandset)
-      cards = $1.split(/,/) 
+      cards = $1.split(/,/)
     end
-    
+
     debug('transferCardsByCommand cards', cards)
     okCount, ngCardList = transferCardsByCards(cards, destination, nick_e)
-    
+
     debug('LINE', __LINE__)
-    
+
     return okCount, ngCardList
   end
-  
+
   def transferCardsByCards(cards, destination, nick_e)
     okCount = 0
     ngCardList = []
-    
+
     cards.each do |card|
       debug('transferCardsByCards card', card)
       result = transferOneCard(card, nick_e, destination)
-      
+
       debug('transferOneCard result', result)
-      
+
       case result
       when $ngResult
         return -1, ['渡す相手が登録されていません']
@@ -927,25 +927,25 @@ class CardTrader
         ngCardList << result
       end
     end
-    
+
     return okCount, ngCardList
   end
-  
+
   def transferOneCard(card, from, toSend);
     debug('transferOneCard card, from, toSend', card, from, toSend)
-    
+
     targetCard = card.upcase
     toSend = toSend.upcase
     from = from.upcase
-    
+
     isTargetCardInHand = false;
     restCards = []
     thisCard = "";
-    
+
     @deal_cards[from] ||= []
     cards = @deal_cards[from]
     debug("from, cards, @deal_cards", from, cards, @deal_cards)
-    
+
     if(targetCard == '')
       debug("カード指定がないのでランダムで一枚渡す")
       thisCard = ejectOneCardRandomFromCards(cards)
@@ -956,16 +956,16 @@ class CardTrader
       thisCard, restCards, isTargetCardInHand =
         transferTargetCard(targetCard, cards, toSend, from)
     end
-    
+
     debug("transferOneCard isTargetCardInHand", isTargetCardInHand)
-    
+
     if( not isTargetCardInHand )
       return targetCard;
     end
-    
+
     debug("transferOneCard @deal_cards", @deal_cards)
     debug("transferOneCard toSend", toSend)
-    
+
     if( @deal_cards[toSend] )
       debug("alreadyRegisted")
       # debug('相手は登録済み')
@@ -977,62 +977,62 @@ class CardTrader
       debug('isSuccess', isSuccess)
       return $ngResult unless( isSuccess )
     end
-    
+
     @deal_cards[from] = restCards
     debug("transferOneCard @deal_cards", @deal_cards)
-    
+
     return $okResult;
   end
-  
-  
+
+
   def ejectOneCardRandomFromCards(cards)
     debug('ejectOneCardRandomFromCards cards.length', cards.length)
-    
+
     return nil if( cards.empty? )
-    
+
     cardNumber, dummy = @bcdice.roll(1, cards.length);
     cardNumber -= 1
     debug("cardNumber", cardNumber)
-    
+
     card = cards.delete_at(cardNumber)
     debug("card", card)
-    
+
     return card
   end
-  
+
   def transferTargetCard(targetCard, cards, toSend, from)
     debug('transferTargetCard(targetCard, cards, toSend, from)', targetCard, cards, toSend, from)
-    
+
     thisCard = ""
     restCards = []
     isTargetCardInHand = false
-    
+
     cards.each do |card|
       if((not isTargetCardInHand) and(card == targetCard))
         isTargetCardInHand = true
         thisCard = card
-      else 
+      else
         restCards << card
       end
     end
-    
+
     debug("restCards", restCards)
     return thisCard, restCards, isTargetCardInHand
   end
-  
+
   def transferTargetCardToNewMember(destination, thisCard)
     debug("transferTargetCardToNewMember destination, thisCard", destination, thisCard)
     debug("@card_place", @card_place)
-    
+
     isSuccess = false;
-    
+
     if(@card_place > 0)
-      
+
       if(/^\d+(.+)/ =~ destination)
         #渡すNickが数字で始まっていたら、場に出す処理の最初の一枚目
         placeName = $1
         debug("placeName", placeName)
-        
+
         if( @deal_cards[placeName] )
           #手札は登録されていたら宛先間違いではない
           @deal_cards[destination] ||= []
@@ -1041,11 +1041,11 @@ class CardTrader
         end
       end
     end
-    
+
     return isSuccess
   end
-  
-  
+
+
 
   def sendCardToTargetNickPlaceCommandText(commandText, targetNick)
     debug('sendCardToTargetNickPlaceCommandText commandText, targetNick', commandText, targetNick)
@@ -1057,66 +1057,66 @@ class CardTrader
       sendMessage(@channel, "#{@nick_e}: 相手が登録されていません");
       return;
     end
-    
+
     unless( ngCardList.empty? )
       ngCardText = getCardsTextFromCards(ngCardList)
       sendMessage(@channel, "[#{ngCardText}]がありません");
       return;
     end
-    
+
     if(okCardList.length > 0)
       printRegistCardResult(targetNick, okCards)
     end
-    
+
     sendMessageToOnlySender(getHandAndPlaceCardInfoText("Auto"));
   end
-  
+
   #相手の場にカードを置く
   def getSendCardToTargetNickPlace(commandText, nick_e)
     ngCardList = []
     okCardList = []
-    
+
     debug("commandText", commandText)
     if(/(c-place(\d*)(\[(((,)?#{@cardRegExp})*)\])?)\s*(#{$ircNickRegExp})/ =~ commandText)
       cardset = $1;
       placeNumber = $2.to_i
       destination = $7.upcase
-      
+
       getSendCardToTargetNickPlaceByCardSetAndDestination(cardset, placeNumber, destination)
     end
-    
+
     return okCardList, ngCardList
   end
-  
+
   def getSendCardToTargetNickPlaceByCardSetAndDestination(cardset, placeNumber, destination)
     debug('getSendCardToTargetNickPlaceByCardSetAndDestination cardset, placeNumber, destination', cardset, placeNumber, destination)
-    
+
     debug("今のところ場が１つしかないので相手の場は決めうち")
     toSend = "1#{destination}"
     debug("toSend", toSend)
-    
+
     from = @nick_e
     if( placeNumber > 0 )
       from = "#{placeNumber}#{from}"
     end
     debug("from", from)
-    
+
     if( /\[(#{@cardRegExp}(,#{@cardRegExp})*)\]/ =~ cardset )
       cards = $1.split(/,/)
       okCardList, ngCardList = getSendCardToTargetNickPlaceByCards(cards, from, toSend)
     end
-    
+
     return okCardList, ngCardList
   end
-    
+
   def getSendCardToTargetNickPlaceByCards(cards, destination, toSend)
     debug("getSendCardToTargetNickPlaceByCards cards, destination, toSend", destination, toSend)
     okCardList = []
     ngCardList = []
-    
+
     cards.each do |card|
       result = transferOneCard(card, destination, toSend)
-      
+
       case result
       when $ngResult
         return -1, '渡す相手が登録されていません';
@@ -1126,88 +1126,88 @@ class CardTrader
         ngCardList << result
       end
     end
-    
+
     return okCardList, ngCardList
   end
-  
-  
+
+
   def printRegistCardResult(targetNick, okCards)
     sendMessage(@channel, "#{@nick_e}: #{ okCards.length }枚場に置きました");
-    
+
     unless( @cardTitles.empty? )
       cardText = getCardsTextFromCards(okCards)
       sendMessage(@channel, "[#{cardText}]")
     end
-    
+
     sendMessage(targetNick, getHandAndPlaceCardInfoText("Auto", targetNick));
   end
-  
+
 ####################             タップ            ########################
   def tapCardCommandText(commandText)
     debug("tapCardCommandText commandText", commandText)
-    
+
     okList, ngList, isUntap = tapCard(commandText);
-    
+
     if(okList.length > 0)
       tapTypeName = ( isUntap ? 'アンタップ' : 'タップ');
       sendMessage(@channel, "#{@nick_e}: #{okList.length}枚#{tapTypeName}しました");
       sendMessage(@channel, "[#{getCardsTextFromCards(okList)}]") unless( @cardTitles.empty? )
     end
-    
+
     if(ngList.length > 0)
       sendMessage(@channel, "[#{getCardsTextFromCards(ngList)}]は場にありません");
     end
-    
+
     sendMessageToOnlySender(getHandAndPlaceCardInfoText("Auto", @nick_e));
   end
-  
+
   def tapCard(command)
     okCardList = []
     ngCardList = []
-    
+
     unless(@canTapCard and @card_place)
       return okCardList, ngCardList
     end
-    
+
     unless( /(c-(un)?tap(\d+)\[((,)?#{@cardRegExp})+\])/ =~ command )
       return okCardList, ngCardList
     end
-    
+
     place = $3.to_i;
     isUntap = $2
     cardsText = $1
-    
+
     okCardList, ngCardList = tapCardByCardsTextAndPlace(cardsText, place, isUntap)
     return okCardList, ngCardList, isUntap
   end
-  
+
   def tapCardByCardsTextAndPlace(cardsText, place, isUntap)
     okCardList = []
     ngCardList = []
-    
+
     if( /\[(#{@cardRegExp}(,#{@cardRegExp})*)\]/ =~ cardsText)
       cards = $1.split(/,/)
       cards.each do |card|
         okCard, ngCard = tapOneCardByCardAndPlace(card, place, isUntap);
-        
+
         okCardList << okCard unless(okCard.nil?)
         ngCardList << ngCard unless(ngCard.nil?)
       end
     end
-    
+
     return okCardList, ngCardList;
   end
-  
+
   def tapOneCardByCardAndPlace(card, place, isUntap);
     card = card.upcase
     result = ""
-    
+
     # return result unless(@canTapCard > 0)
     # タップ処理をカードの場の移動で扱う(90度タップ、180度タップが将来必要になるかも)
-    
+
     nick_e_original = @nick_e
     @nick_e = @nick_e.upcase
-    
+
     nick_to = ""
     if( isUntap )
       destination = "#{place * 2 - 1}#{@nick_e}"
@@ -1216,11 +1216,11 @@ class CardTrader
       destination = "#{place * 2}#{@nick_e}"
       nick_to = "#{place * 2 - 1}#{@nick_e}"
     end
-    
+
     result = transferOneCard(card, nick_to, destination)
-    
+
     @nick_e = nick_e_original
-    
+
     if( result == $okResult )
       return card, nil
     else
@@ -1238,7 +1238,7 @@ class CardTrader
       sendMessage(@channel, "カードが残っていません");
     end
   end
-  
+
   # 山からカードをめくって即座に捨てる
   def getCardMilstone(commandText)
     command = "c-draw";
@@ -1247,12 +1247,12 @@ class CardTrader
       count = $1.to_i
       command += "[#{count}]"
     end
-    
+
     cards = drawCard(command)
     debug("cards", cards)
-    
+
     text = ""
-    
+
     if(cards.length > 0)
       cardInfo = getCardsTextFromCards(cards)
       okCount, ngCount, text = discardCards("c-discard[#{ cardInfo }]")
@@ -1261,20 +1261,20 @@ class CardTrader
     else
       count = 0;
     end
-    
+
     debug("count", count)
     debug("cardInfo", cardInfo)
-    
+
     return count, cardInfo;    # めくれた枚数と出たカードを返す
   end
-  
+
 
   # 全員の場に出たカードを捨てる（手札はそのまま）
   def clearAllPlaceAllPlayerCards
     @deal_cards.each do |place, cards|
       clearAllPlayerCardsWhenPlayedPlace(place, cards)
     end
-    
+
     return '場のカードを捨てました';
   end
 
@@ -1283,16 +1283,16 @@ class CardTrader
       clearAllPlayerCards(place, cards)
     end
   end
-  
+
   def clearAllPlayerCards(place, cards)
     cardset = cards.join(',')
     discardCards("c-discard[#{cardset}]", place);
-    
+
     @deal_cards[place] ||= []
     @deal_cards[place].clear
   end
-  
-  
+
+
   # 捨て札をデッキに戻す
   def returnCards
     @deal_cards[ 'card_played' ] ||= []
@@ -1301,41 +1301,41 @@ class CardTrader
     while(cards.length > 0)
       @cardRest.push(cards.shift)
     end
-    
+
     return "捨て札を山に戻しました";
   end
-  
+
   def getBurriedCard
     @deal_cards[ 'card_played' ] ||= []
     cards = @deal_cards[ 'card_played' ]
-    
+
     cards.length
   end
-  
+
 ####################             その他            ########################
   def reviewCards
     @cardRest.join(',')
   end
-  
+
   def getAllCardLocation   # 今のカード配置を見る
     allText = "山札:#{ @cardRest.length }枚 捨札:#{ getBurriedCard }枚";
     allPlaceText = "";
-    
+
     @deal_cards.each do |place, cards|
       next if(place == 'card_played')
-      
+
       text, placeText = getCardLocationOnPlace(place, cards)
       allText += text
       allPlaceText += placeText
     end
-    
+
     return allText, allPlaceText;   # 山札＆捨て札＆各自の手札枚数表示 と 各自の場札表示の配列を返す。(表示レイアウトの関係)
   end
-  
+
   def getCardLocationOnPlace(place, cards)
     text = ""
     placeText = ""
-    
+
     if(place =~ /^(\d+)(#{$ircNickRegExp})/)
       placeNumber = $1;
       cnick = $2;
@@ -1343,10 +1343,10 @@ class CardTrader
     else
       text = " #{place}:#{cards.length}枚";
     end
-    
+
     return text, placeText
   end
-  
+
   def getCardLocationOnNumberdPlace(cards, placeNumber, cnick)
     cardText = getCardsText(cards)
     if( isTapCardPlace(placeNumber) )
@@ -1355,48 +1355,48 @@ class CardTrader
       return " #{cnick}の場札:#{cardText}";
     end
   end
-    
+
   def getHandAndPlaceCardInfoText(str, destination = nil)    # 自分の手札と場札の確認
     debug("getHandAndPlaceCardInfoText(str, destination)", str, destination)
-    
+
     destination = @nick_e if( destination.nil? )
     destination = destination.upcase
-    
+
     hand = getHandCardInfoText(destination)
     debug("hand", hand)
-    
+
     place = getPlaceCardInfoText(destination)
     debug("place", place)
-    
+
     return hand + place
   end
-  
-  
+
+
   def getHandCardInfoText(destination)
     destination = destination.upcase
     debug("getHandCardInfoText destination", destination)
-    
+
     out_msg = getDealCardsText(destination)
-    
+
     if( out_msg.empty? )
       out_msg = "カードを持っていません";
     end
-    
+
     return out_msg
   end
-  
-  
+
+
   def getDealCardsText(destination)
     debug("getDealCardsText destination", destination)
-    
+
     cards = @deal_cards[destination]
     debug("@deal_cards", @deal_cards)
     debug("getDealCardsText cards", cards)
-    
+
     return '' if( cards.nil? )
-    
+
     cardsText = getCardsTextFromCards(cards)
-    
+
     return "[ #{cardsText} ]";
   end
 
@@ -1408,91 +1408,91 @@ class CardTrader
       a <=> b
     end
   end
-  
+
   def compareCardByCardNumber(a, b)
     /([^\d]+)(\d+)/ =~ a
     a1 = $1;
     a2 = $2;
-    
+
     /([^\d]+)(\d+)/ =~ b
     b1 = $1;
     b2 = $2;
-    
+
     result = [a1, a2] <=> [b1, b2]
-    
+
     return result
   end
 
 
   def getPlaceCardInfoText(destination)
     destination = destination.upcase
-    
+
     out_msg = "";
-    
+
     unless( @card_place > 0 )
       return out_msg
     end
-    
+
     place_max = @card_place;
     place_max *= 2 if(@canTapCard);
-    
+
     debug("place_max", place_max)
     place_max.times do |i|
       index = i + 1
-      
+
       dealCardsKey = "#{index}#{destination}"
       debug("dealCardsKey", dealCardsKey)
-      
+
       cards = @deal_cards[dealCardsKey]
       cards ||= []
-      
+
       cardsText = getCardsTextFromCards(cards);
-      
+
       if( isTapCardPlace(index) )
         out_msg += " タップした場札:[ #{cardsText} ]";
       else
         out_msg += " 場札:[ #{cardsText} ]";
       end
     end
-    
+
     return out_msg;
   end
-  
+
   def getCardsText(cardsText)    # 汎用カードセット用カードタイトルの表示
     cards = cardsText.split(/,/)
     return getCardsTextFromCards(cards)
   end
-  
+
   def getCardsTextFromCards(cards)
     if( $isHandSort )
       cards = cards.sort{|a, b| compareCard(a, b)}
     end
-    
+
     if( @cardTitles.empty? )
       return cards.join(',')
     end
-    
+
     out_msg = "";
-    
+
     cards.each do |cardNumber|
       out_msg += "," if(out_msg != "");
       title = @cardTitles[cardNumber]
       out_msg += "#{cardNumber}-#{title}"
     end
-    
+
     out_msg = '無し' if(out_msg == "");
-  
+
     return out_msg;
   end
-  
+
   def isTapCardPlace(index)
     return false unless(@canTapCard)
-    
+
     return ((index % 2) == 0)
   end
 
 ####################           復活の呪文          ########################
-  
+
   def printCardRestorationSpellResult(spellText)
     output_msg = throwCardRestorationSpell(spellText);
     if(output_msg == "readSpell")
@@ -1501,13 +1501,13 @@ class CardTrader
       sendMessage(@channel, output_msg);
     end
   end
-  
-  
+
+
   def throwCardRestorationSpell(spellText)
     output = '0';
-    
+
     debug("spellText", spellText)
-    
+
     # 呪文の取得
     if( spellText.nil? )
       debug("getNewSpellText")
@@ -1517,46 +1517,46 @@ class CardTrader
       debug("setNewSpellText")
       output = setNewSpellText( spellText )
     end
-    
+
     debug("throwCardRestorationSpell output", output)
     return output; # 結果を返す
   end
-  
-  
+
+
   def getNewSpellText
     debug("getNewSpellText begin")
-    
+
     textList = []
-    
+
     placeNames = @deal_cards.keys.sort
     textList << placeNames
-    
+
     spellWords = getSpellWords
     textList << spellWords
-    
+
     return textList.join(",")
   end
-  
-  
+
+
   def getSpellWords
     spellWords = ""
-    
+
     @card_val.each do |card|
       index = getDealCardIndex(card)
       indexWord = getIndexWord(index)
       spellWords << indexWord
     end
-    
+
     spellWords = shrinkSpellWords(spellWords)
-    
+
     return spellWords
   end
-  
-  
+
+
   def getIndexWord(index)
     @card_spell[index + 1]
   end
-  
+
   def getDealCardIndex(card)
     @deal_cards.keys.sort.each_with_index do |place, index|
       cards = @deal_cards[place]
@@ -1564,67 +1564,67 @@ class CardTrader
         return index
       end
     end
-    
+
     return -1
   end
-  
-  
+
+
   def shrinkSpellWords(spellWords)
     @card_spell.each do |word|
       spellWords = spellWords.gsub(/#{word}(#{word}+)/){ word + ($1.length + 1).to_s }
     end
-    
+
     return spellWords
   end
-  
-  
+
+
   def setNewSpellText(spellText)
     shuffleCards()
-    
+
     textList = spellText.split(',')
     spellWords = textList.pop
     placeNames = textList
-    
-    
+
+
     debug("placeNames", placeNames)
     debug("spellWords", spellWords)
-    
+
     spellWords = expandSpellWords(spellWords)
     debug("expanded spellWords", spellWords)
-    
+
     placeNames.each_with_index do |place, index|
       indexWord = getIndexWord(index)
       cards = getCardsFromIndexWordAndSpellText(indexWord, spellWords)
       @deal_cards[place] = cards
     end
-    
+
     debug("setNewSpellText @deal_cards", @deal_cards)
-    
+
     return "readSpell"
   end
-  
+
   def expandSpellWords(spellWords)
     @card_spell.each do |word|
       spellWords = spellWords.gsub(/#{word}(\d+)/){ word * $1.to_i }
     end
-    
+
     return spellWords
   end
-  
+
   def getCardsFromIndexWordAndSpellText(indexWord, spellText)
     cards = []
-    
+
     spellText.split(//).each_with_index do |word, index|
       next unless(indexWord == word)
-      
+
       card = @card_val[index]
       isDelete = @cardRest.delete_if{|i| i == card}
       next unless( isDelete )
-      
+
       cards << card
     end
-    
+
     return cards
   end
-  
+
 end

--- a/src/CountHolder.rb
+++ b/src/CountHolder.rb
@@ -1,4 +1,4 @@
-#!/bin/ruby -Ku 
+#!/bin/ruby -Ku
 # -*- coding: utf-8 -*-
 
 require 'log'
@@ -6,7 +6,7 @@ require 'configBcDice.rb'
 
 
 class CountHolder
-  
+
   def initialize(bcdice, countInfos)
     @bcdice = bcdice
     @countInfos = countInfos
@@ -14,18 +14,18 @@ class CountHolder
     # {:channelName => {:characterName => (カウンター情報) }
     # という形式でデータを保持します。
   end
-  
+
   def executeCommand( command, nick, channel, pointerMode )
     debug("point_counter_command begin(command, nick, channel, pointerMode)", command, nick, channel, pointerMode )
-    
+
     @command = command
     @nick = @bcdice.getNick(nick)
     @channel = channel
     @pointerMode = pointerMode
-    
+
     output = "1";
     isSecret = (pointerMode == :sameNick)
-    
+
     case @command
     when /^#OPEN!/i
       output = get_point_list();
@@ -41,7 +41,7 @@ class CountHolder
         output = "#{nick}: #{output}";
         isSecret = false  # 出力は常にPublic側
       end
-      
+
     else
       if( /^#/ =~ @command )
         output = executeSetCommand();
@@ -50,12 +50,12 @@ class CountHolder
         end
       end
     end
-    
+
     debug("point_counter_command END output, isSecret", output, isSecret)
-    
+
     return output, isSecret
   end
-  
+
 
 #=========================================================================
 #**                       汎用ポイントカウンタ
@@ -64,19 +64,19 @@ class CountHolder
 ####################          カウンタ操作         ########################
   def executeSetCommand
     debug("setCountHolder nick, channel, pointerMode", @nick, @channel, @pointerMode)
-    
+
     @characterName = @nick
-    
+
     @tagName = nil
     @currentValue = nil
     @maxValue = nil
     @modifyText = nil
-    
+
     debug("$point_counter", $point_counter)
     output = '1';
-    
+
     debug("@command", @command)
-    
+
     case @command
     when /^#([^:：]+)(:|：)(\w+?)\s*(\d+)(\/(\d+))?/
       debug(" #(識別名):(タグ)(現在値)/(最大値) で指定します。最大値がないものは省略できます。")
@@ -116,20 +116,20 @@ class CountHolder
       debug("not match command", @command)
       return ''
     end
-    
+
     unless( @maxValue.nil? )
       @maxValue = @maxValue.to_i
     end
-    
+
     debug("characterName", @characterName)
     debug("tagName", @tagName)
     debug("@currentValue", @currentValue)
     debug("@maxValue", @maxValue)
     debug("@modifyText", @modifyText)
-    
+
     return setCountHolderByParams
   end
-  
+
   def setCountHolderByParams
     debug("@modifyText", @modifyText)
     if( @modifyText.nil? )
@@ -138,100 +138,100 @@ class CountHolder
       return changeCount
     end
   end
-  
-  
+
+
   def setCount
     @countInfos[@channel] ||= {}
     characterInfoList = getCharacterInfoList
     characterInfoList[@characterName] ||= {}
     characterInfo = characterInfoList[@characterName]
-    
+
     characterInfo[@tagName] = {
       :currentValue => @currentValue,
       :maxValue => @maxValue,
     }
-    
+
     debug('setCount @nick, @characterName', @nick, @characterName)
-    
+
     output = ""
     output << "#{@characterName.downcase}" if(@nick != @characterName)
     output << "(#{@tagName}) #{@currentValue}";
-    
+
     debug("setCount @maxValue", @maxValue)
     unless( @maxValue.nil? )
       output << "/#{@maxValue}";
     end
-    
+
     return output
   end
-  
+
   def changeCount
     debug("changeCount begin")
-    
+
     modifyValue = @bcdice.parren_killer("(0#{ @modifyText })").to_i
     characterInfo = getCharacterInfo(@channel, @characterName)
-    
+
     info = characterInfo[@tagName]
     debug("characterInfo", characterInfo)
     debug("info", info)
     return "" if( info.nil? )
-    
+
     currentValue = info[:currentValue]
     maxValue = info[:maxValue]
-    
+
     preText = getValueText(currentValue, maxValue)
-    
+
     debug("currentValue", currentValue)
     debug("modifyValue", modifyValue)
     currentValue += modifyValue
     info[:currentValue] = currentValue
-    
+
     nowText = getValueText(currentValue, maxValue)
-    
+
     output = ""
     output << "#{@characterName.downcase}" if(@nick != @characterName)
     output << "(#{@tagName}) #{preText} -> #{nowText}";
-    
+
     debug("changeCount end output", output)
-    
+
     return output
   end
-  
+
   def getValueText(currentValue, maxValue)
     text = "#{currentValue}"
     text += "/#{maxValue}" unless( maxValue.nil? )
-    
+
     return text
   end
-  
+
   def getCharacterInfoList(channel = nil)
     channel ||= @channel
-    
+
     @countInfos[channel] ||= {}
     characterInfoList = @countInfos[channel]
-    
+
     return characterInfoList
   end
-  
+
   def getCharacterInfo(channel, characterName)
     characterName ||= @characterName
-    
+
     characterInfoList = getCharacterInfoList(channel)
-    
+
     characterInfoList[characterName] ||= {}
     characterInfo = characterInfoList[characterName]
-    
+
     return characterInfo
   end
-  
+
 ####################          カウンタ一覧         ########################
   def get_point_list
     debug("get_point_list(command, nick, channel, pointerMode)", @command, @nick, @channel, @pointerMode)
-    
+
     output = "1";
-    
+
     return output unless(/^#OPEN![\s]*(\w*)(\s|$)/ =~ @command)
-    
+
     tag = $1;
     case @pointerMode
     when :sameNick
@@ -245,15 +245,15 @@ class CountHolder
         output = pc_out unless(pc_out.empty?);
       end
     end
-    
+
     return output;
   end
-  
-  
+
+
   def getPointListAtSameNick(command, nick, channel, pointerMode, tag)
     debug("getPointListAtSameNick(command, nick, channel, pointerMode, tag)", command, nick, channel, pointerMode, tag)
     debug("同一Nick, 自キャラの一覧表示(パラメータ指定不要)")
-    
+
     pc_list = $point_counter[nick];
     pc_out = "";
     if( pc_list )
@@ -288,7 +288,7 @@ class CountHolder
           end
         end
       end
-      
+
       if(tag)
         out_pc = "";
         pc_sorted = sort_point_hash(sort_pc);
@@ -333,109 +333,109 @@ class CountHolder
         end
       end
     end
-    
+
     return pc_out
   end
-  
+
   def getPointListAtSameChannel(tagName)
     debug("getPointListAtSameChannel(command, nick, channel, pointerMode, tagName)", @command, @nick, @channel, @pointerMode, tagName)
     debug("同一チャンネル特定タグ(ポイント)の表示")
-    
+
     output = ""
-    
+
     output << "#{tagName}:" unless( tagName.empty? )
-                              
+
     debug("getPointListAtSameChannel @countInfos", @countInfos)
     characterInfoList = getCharacterInfoList
-    
+
     characterInfoList.keys.sort.each do |characterName|
       characterInfo = characterInfoList[characterName]
-      
+
       tagText = ''
       characterInfo.keys.sort.each do |currentTag|
         unless( tagName.empty? )
           next unless( tagName == currentTag )
         end
-        
+
         info = characterInfo[currentTag]
         currentValue = info[:currentValue]
         maxValue = info[:maxValue]
-        
+
         tagText << "#{currentValue}"
         tagText << "/#{maxValue}" unless( maxValue.nil? )
       end
-      
+
       unless( tagText.empty? )
         output << " " unless( output.empty? )
         output << "#{characterName}(#{tagText})"
       end
     end
-    
+
     return output
   end
-  
+
 ####################          識別名の交換         ########################
   def rename_point_counter
     debug("rename_point_counter @command, @nick", @command, @nick)
-    
+
     output = "1"
-    
+
     return output unless( /^#RENAME!\s*(.+?)\s*\-\>\s*(.+?)(\s|$)/ =~ @command )
-    
+
     oldName = $1;
     newName = $2;
     debug("oldName, newName", oldName, newName)
-    
+
     # {:channelName => {:characterName => (カウンター情報) }
     characterInfoList = getCharacterInfoList(@channel)
 
     counterInfo = characterInfoList.delete(oldName)
     return output if( counterInfo.nil? )
-    
+
     characterInfoList[newName] = counterInfo
-    
+
     output = "#{oldName}->#{newName}";   # 変更メッセージ
     return output;
   end
-  
+
 
 ####################          その他の処理         ########################
 
   def setPointCounters(nick, pc, target)
     key = "#{nick},#{pc}"
     setPointCounter(key, pc)
-    
+
     key = "#{nick},#{pc},#{target}"
     setPointCounter(key, target)
   end
-  
+
   def setPointCounter(key, data)
     debug("setPointCounter begin key, data", key, data)
-    
+
     unless( $point_counter.include?(key) )
       debug("$point_counterにkeyが存在しないので新規作成")
       $point_counter[key] = data
       return
     end
-    
+
     debug("$point_counterにkeyが存在する場合")
-    
+
     cnt_list = $point_counter[key]
     unless( cnt_list.include?( data ) )
       cnt_list << data
     end
   end
-  
-  
+
+
   def sort_point_hash(base_hash)
     keys = base_hash.keys
-    
+
     pc_sorted = keys.sort_by do |a, b|
       a_current, a_max = getPointHashCurrentAndMax(a)
       b_current, b_max = getPointHashCurrentAndMax(b)
-      
+
       # 現在値が小さい方が後ろ、同じ時はダメージが大きい方が後ろ(後方が危険)
-      
+
       compare = (b_crr <=> a_crr)
       if( compare == 0 )
         compare = (a_max <=> b_max)
@@ -443,13 +443,13 @@ class CountHolder
           compare = (a <=> b)
         end
       end
-      
+
       compare
     end
-    
+
     return pc_sorted;
   end
-  
+
   def getPointHashCurrentAndMax(key)
     if(/(\d+)[\/](\d+)/ =~ key)
       current = $1;
@@ -461,5 +461,5 @@ class CountHolder
 
 
 
-  
+
 end

--- a/src/bcdice.rb
+++ b/src/bcdice.rb
@@ -1,4 +1,4 @@
-#!/bin/ruby -Ku 
+#!/bin/ruby -Ku
 # -*- coding: utf-8 -*-
 
 $LOAD_PATH << File.dirname(__FILE__) # require_relative対策
@@ -8,15 +8,15 @@ require 'configBcDice.rb'
 class Cli
   def quit
   end
-  
+
   def sendMessage(to, message)
     print message
   end
-  
+
   def sendMessageToOnlySender(nick_e, message)
     print message
   end
-  
+
   def sendMessageToChannels(message)
     print message
   end
@@ -30,16 +30,16 @@ def mainBcDiceCli(args)
     gameType = args[0]
     message = args[1]
   end
-  
-  
+
+
   print message
   print "\n"
-  
+
   bcdiceMaker = BCDiceMaker.new
   bcdice = bcdiceMaker.newBcDice()
   bcdice.setIrcClient( Cli.new )
   bcdice.setGameByTitle( gameType )
-  
+
   bcdice.setMessage(message)
   channel = ""
   bcdice.setChannel(channel)
@@ -48,7 +48,7 @@ end
 
 
 if $0 === __FILE__
-  
+
   if( ARGV.length < 1 or ARGV[0] == "createExe" )
     require 'bcdiceGui.rb'
     mainBcDiceGui
@@ -56,5 +56,5 @@ if $0 === __FILE__
     require 'bcdiceCore.rb'
     mainBcDiceCli(ARGV)
   end
-  
+
 end

--- a/src/bcdiceCore.rb
+++ b/src/bcdiceCore.rb
@@ -1,4 +1,4 @@
-#!/bin/ruby -Ku 
+#!/bin/ruby -Ku
 # -*- coding: utf-8 -*-
 
 require 'log'
@@ -60,29 +60,29 @@ require 'dice/RerollDice'
 
 
 class BCDiceMaker
-  
+
   def initialize
     @diceBot = DiceBot.new
     @cardTrader = CardTrader.new
     @cardTrader.initValues
-    
+
     @counterInfos = {}
-    
+
     @master = ""
     @quitFunction = nil
   end
-  
+
   attr_accessor :master
   attr_accessor :quitFunction
   attr_accessor :diceBot
   attr_accessor :diceBotPath
-  
+
   def newBcDice
     bcdice = BCDice.new(self, @cardTrader, @diceBot, @counterInfos, nil)
-    
+
     return bcdice
   end
-  
+
 end
 
 
@@ -94,14 +94,14 @@ class BCDice
 
   def initialize(parent, cardTrader, diceBot, counterInfos, tableFileData)
     @parent = parent
-    
+
     setDiceBot(diceBot)
-    
+
     @cardTrader = cardTrader
     @cardTrader.setBcDice(self)
     @counterInfos = counterInfos
     @tableFileData = tableFileData
-    
+
     @nick_e = ""
     @tnick = ""
     @isMessagePrinted = false
@@ -110,38 +110,38 @@ class BCDice
     @randResults = nil
     @isIrcMode = true
   end
-  
+
   # Unused method
   def setDir(dir, prefix)
     nil
   end
-  
+
   def isKeepSecretDice(b)
     @isKeepSecretDice = b
   end
-  
+
   def getGameType
     @diceBot.gameType
   end
-  
+
   def setDiceBot(diceBot)
     return if( diceBot.nil? )
-    
+
     @diceBot = diceBot
     @diceBot.bcdice = self
     @parent.diceBot = @diceBot
   end
-  
+
   attr_reader :nick_e
-  
+
   def readExtraCard(cardFileName)
     @cardTrader.readExtraCard(cardFileName)
   end
-  
+
   def setIrcClient(client)
     @ircClient = client
   end
-  
+
   def setMessage(message)
     # 設定で変化し得るためopen系はここで正規表現を作る
     openPattern = /\A\s*(?:#{$OPEN_DICE}|#{$OPEN_PLOT})\s*\z/i
@@ -160,16 +160,16 @@ class BCDice
     @message = @messageOriginal.upcase
     debug("@message", @message)
   end
-  
+
   def getOriginalMessage
     @messageOriginal
   end
-  
+
   #直接TALKでは大文字小文字を考慮したいのでここでオリジナルの文字列に変更
   def changeMessageOriginal
     @message = @messageOriginal
   end
-  
+
   def recieveMessage(nick_e, tnick)
     begin
       recieveMessageCatched(nick_e, tnick)
@@ -177,58 +177,58 @@ class BCDice
       printErrorMessage(e)
     end
   end
-  
+
   def printErrorMessage(e)
     sendMessageToOnlySender("error " + e.to_s + $@.join("\n"))
   end
-  
+
   def recieveMessageCatched(nick_e, tnick)
     debug('recieveMessage nick_e, tnick', nick_e, tnick)
-    
+
     @nick_e = nick_e
     @cardTrader.setTnick( @nick_e )
-    
+
     @tnick = tnick
     @cardTrader.setTnick( @tnick )
-    
+
     debug("@nick_e, @tnick", @nick_e, @tnick)
-    
+
     # ===== 設定関係 ========
     setMatches = @message.match(SET_COMMAND_PATTERN)
     if setMatches
       setCommand(setMatches[1])
       return
     end
-    
+
     # ポイントカウンター関係
     executePointCounter
-    
+
     # プロット入力処理
     addPlot(@messageOriginal.clone)
-    
-    
+
+
     # ボット終了命令
     case @message
     when $quitCommand
       quit
-      
+
     when /^mode$/i
       # モード確認
       checkMode()
-      
+
     when /^help$/i
       # 簡易オンラインヘルプ
       printHelp()
-      
+
     when /^c-help$/i
       @cardTrader.printCardHelp()
-      
+
     end
   end
-  
+
   def quit
     @ircClient.quit
-    
+
     if( @parent.quitFunction.nil? )
       sleepForIrc( 3 )
       exit( 0 )
@@ -236,7 +236,7 @@ class BCDice
       @parent.quitFunction.call()
     end
   end
-  
+
   def setQuitFuction(func)
     @parent.quitFunction = func
   end
@@ -290,8 +290,8 @@ class BCDice
       readCardSet()
     end
   end
-  
-  
+
+
   def setMaster()
     if( @parent.master != "" )
       setMasterWhenMasterAlreadySet()
@@ -299,7 +299,7 @@ class BCDice
       setMasterWhenMasterYetSet()
     end
   end
-  
+
   def setMasterWhenMasterAlreadySet()
     if( @nick_e == @parent.master )
       setMasterByCurrentMasterOwnself()
@@ -307,7 +307,7 @@ class BCDice
       sendMessageToOnlySender("Masterは#{@parent.master}さんになっています")
     end
   end
-  
+
   def setMasterByCurrentMasterOwnself()
     if( @tnick != "" )
       @parent.master = @tnick
@@ -317,8 +317,8 @@ class BCDice
       sendMessageToChannels("Master設定を解除しました")
     end
   end
-  
-  
+
+
   def setMasterWhenMasterYetSet()
     if( @tnick != "" )
       @parent.master = @tnick
@@ -327,153 +327,153 @@ class BCDice
     end
     sendMessageToChannels("#{@parent.master}さんをMasterに設定しました")
   end
-  
-  
+
+
   def setGame()
     messages = setGameByTitle(@tnick)
     sendMessageToChannels(messages)
   end
-  
-  
+
+
   def isMaster()
     return ((@nick_e == @parent.master) or (@parent.master == ""))
   end
-  
-  
+
+
   def setDisplayMode()
     return unless( isMaster() )
-    
+
     return unless( /(\d+)/  =~ @tnick )
-    
+
     mode = $1.to_i
     @diceBot.setSendMode(mode)
-    
+
     sendMessageToChannels("ViewMode#{@diceBot.sendMode}に変更しました")
   end
-  
-  
+
+
   def setUpplerRollThreshold()
     return unless( isMaster() )
-    
+
     return unless( /(\d+)/  =~ @tnick )
     @diceBot.upplerRollThreshold = $1.to_i
-    
+
     if( @diceBot.upplerRollThreshold > 0 )
       sendMessageToChannels("上方無限ロールを#{@diceBot.upplerRollThreshold}以上に設定しました")
     else
       sendMessageToChannels("上方無限ロールの閾値設定を解除しました")
     end
   end
-  
+
   def setRerollLimit()
     return unless( isMaster() )
-    
+
     return unless( /(\d+)/  =~ @tnick )
     @diceBot.rerollLimitCount = $1.to_i
-    
+
     if(@diceBot.rerollLimitCount > 0)
       sendMessageToChannels("個数振り足しロール回数を#{@diceBot.rerollLimitCount}以下に設定しました")
     else
       sendMessageToChannels("個数振り足しロールの回数を無限に設定しました")
     end
   end
-  
+
   def setRatingTable()
     return unless( isMaster() )
-    
+
     output = @diceBot.setRatingTable(@tnick)
     return if( output == '1' )
-    
+
     sendMessageToChannels(output)
   end
-  
-  
+
+
   def setSortMode()
     return unless( isMaster() )
-    
+
     return unless( /(\d+)/  =~ @tnick )
     sortType = $1.to_i
     @diceBot.setSortType(sortType)
-    
+
     if( @diceBot.sortType != 0 )
       sendMessageToChannels("ソート有りに変更しました")
     else
       sendMessageToChannels("ソート無しに変更しました")
     end
   end
-  
+
   def setCardMode()
     return unless( isMaster() )
-    
+
     @cardTrader.setCardMode()
   end
-  
-  
+
+
   def setSpellMode()
     return unless( isMaster() )
-    
+
     return unless( /(\d+)/  =~ @tnick )
     @isShortSpell = ($1.to_i != 0 )
-    
+
     if( @isShortSpell )
       sendMessageToChannels("短い呪文モードに変更しました")
     else
       sendMessageToChannels("通常呪文モードに変更しました")
     end
   end
-  
+
   def setTapMode()
     return unless( isMaster() )
-    
+
     return unless( /(\d+)/  =~ @tnick )
     @canTapCard = ($1.to_i != 0)
-    
+
     if( @canTapCard )
       sendMessageToChannels("タップ可能モードに変更しました")
     else
       sendMessageToChannels("タップ不可モードに変更しました")
     end
   end
-  
-  
+
+
   def readCardSet()
     return unless( isMaster() )
-    
+
     @cardTrader.readCardSet()
   end
-  
-  
+
+
   def executePointCounter
     arg = @messages
     debug("executePointCounter arg", arg)
-    
+
     unless(arg =~ /^#/)
       debug("executePointCounter is NOT matched")
       return
     end
-    
+
     channel = getPrintPlotChannel(@nick_e)
     debug("getPrintPlotChannel get channel", channel)
-    
+
     if( channel == "1")
       sendMessageToOnlySender("表示チャンネルが登録されていません")
       return
     end
-    
-    
+
+
     arg += "->#{@tnick}" unless( @tnick.empty? )
-    
+
     pointerMode = :sameNick
     output, pointerMode = countHolder.executeCommand(arg, @nick_e, channel, pointerMode)
     debug("point_counter_command called, line", __LINE__)
     debug("output", output)
     debug("pointerMode", pointerMode)
-    
+
     if( output == "1" )
       debug("executePointCounter point_counter_command output is \"1\"")
       return
     end
-    
+
     case pointerMode
     when :sameNick
       debug("executePointCounter:Talkで返事")
@@ -482,23 +482,23 @@ class BCDice
       debug("executePointCounter:publicで返事")
       sendMessage(channel, output)
     end
-    
+
     debug("executePointCounter end")
   end
-  
+
   def addPlot(arg)
     debug("addPlot begin arg", arg)
-    
+
     unless(/#{$ADD_PLOT}[:：](.+)/i =~ arg)
       debug("addPlot exit")
       return
     end
     plot = $1
-    
+
     channel = getPrintPlotChannel(@nick_e)
-    
+
     debug('addPlot channel', channel)
-    
+
     if( channel.nil? )
       debug('channel.nil?')
       sendMessageToOnlySender("プロット出力先が登録されていません")
@@ -507,24 +507,24 @@ class BCDice
       addToSecretDiceResult(plot, channel, 1)
       sendMessage(channel, "#{@nick_e} さんがプロットしました")
     end
-    
+
   end
-  
-  
+
+
   def getPrintPlotChannel(nick)
     nick = getNick(nick)
     return  $plotPrintChannels[nick]
   end
-  
-  
+
+
   def checkMode()
     return unless( isMaster() )
-    
+
     output = "GameType = " + @diceBot.gameType + ", ViewMode = " + @diceBot.sendMode + ", Sort = " + @diceBot.sortType
     sendMessageToOnlySender(output)
   end
-  
-  
+
+
   # 簡易オンラインヘルプを表示する
   def printHelp
     send_to_sender = lambda { |message| sendMessageToOnlySender message }
@@ -581,12 +581,12 @@ class BCDice
 
     sendMessageToOnlySender "  -- END ---"
   end
-  
+
   def setChannel(channel)
     debug("setChannel called channel", channel)
     @channel = channel
   end
-  
+
   def recievePublicMessage(nick_e)
     begin
       recievePublicMessageCatched(nick_e)
@@ -594,38 +594,38 @@ class BCDice
       printErrorMessage(e)
     end
   end
-  
+
   def recievePublicMessageCatched(nick_e)
     debug("recievePublicMessageCatched begin nick_e", nick_e)
     debug("recievePublicMessageCatched @channel", @channel)
     debug("recievePublicMessageCatched @message", @message)
-    
+
     @nick_e = nick_e
-    
+
     mynick = ''#self.nick
     secret = false
-    
+
     # プロットやシークレットダイス用に今のチャンネル名を記憶
     setChannelForPlotOrSecretDice
-    
+
     #プロットの表示
     if(/(^|\s+)#{$OPEN_PLOT}(\s+|$)/i =~ @message)
       debug('print plot', @message)
       printPlot()
     end
-    
+
     # シークレットロールの表示
     if(/(^|\s+)#{$OPEN_DICE}(\s+|$)/i =~ @message)
       debug('print secret roll', @message)
       printSecretRoll()
     end
-    
+
     # ポイントカウンター関係
     executePointCounterPublic
-    
+
     # ダイスロールの処理
     executeDiceRoll
-    
+
     # 四則計算代行
     if(/(^|\s)C([-\d]+)\s*$/i =~ @message)
       output = $2
@@ -633,26 +633,26 @@ class BCDice
         sendMessage(@channel, "#{@nick_e}: 計算結果 ＞ #{output}")
       end
     end
-    
+
     #ここから大文字・小文字を考慮するようにメッセージを変更
     changeMessageOriginal
-    
+
     # カード処理
     executeCard
-    
+
     unless( @isMessagePrinted ) # ダイスロール以外の発言では捨てダイス処理を
       # rand 100 if($isRollVoidDiceAtAnyRecive)
     end
-    
+
     debug("\non_public end")
   end
-  
-  
+
+
   def printPlot
     debug("printPlot begin")
     messageList = openSecretRoll(@channel, 1)
     debug("messageList", messageList)
-    
+
     messageList.each do |message|
       if( message.empty?)
         debug("message is empty")
@@ -664,53 +664,53 @@ class BCDice
       end
     end
   end
-  
+
   def setChannelForPlotOrSecretDice
     debug("setChannelForPlotOrSecretDice Begin")
-    
+
     return if( isTalkChannel )
-    
+
     channel = getPrintPlotChannel(@nick_e)
     if( channel.nil? )
       setPrintPlotChannel
     end
   end
-  
-  
+
+
   def isTalkChannel
     (not (/^#/ === @channel))
   end
-  
+
   def printSecretRoll
     outputs = openSecretRoll(@channel, 0)
-    
+
     outputs.each do |diceResult|
       next if( diceResult.empty?)
-      
+
       sendMessage(@channel, diceResult)
       sleepForIrc 1
     end
   end
-  
+
   def executePointCounterPublic
     debug("executePointCounterPublic begin")
-    
+
     if(/^#{$READY_CMD}(\s+|$)/i =~ @message)
       setPrintPlotChannel
       sendMessageToOnlySender("表示チャンネルを設定しました")
       return
     end
-    
+
     unless( /^#/ =~ @message)
       debug("executePointCounterPublic NOT match")
       return
     end
-    
+
     pointerMode = :sameChannel
     countHolder = CountHolder.new(self, @counterInfos)
     output, secret = countHolder.executeCommand(@message, @nick_e, @channel, pointerMode)
     debug("executePointCounterPublic output, secret", output, secret)
-    
+
     if( secret )
       debug("is secret")
       sendMessageToOnlySender(output) if(output != "1")
@@ -719,37 +719,37 @@ class BCDice
       sendMessage(@channel, output) if(output != "1")
     end
   end
-  
+
   def executeDiceRoll
     debug("executeDiceRoll begin")
     debug("channel", @channel)
-    
+
     output, secret = dice_command
-    
+
     unless( secret )
       debug("executeDiceRoll @channel", @channel)
       sendMessage(@channel,  output) if(output != "1")
       return
     end
-    
+
     # 隠しロール
     return if( output == "1" )
-    
+
     if( @isTest )
       output += "###secret dice###"
     end
-    
+
     broadmsg(output, @nick_e)
-    
+
     if( @isKeepSecretDice )
       addToSecretDiceResult(output, @channel, 0)
     end
   end
-  
+
   def setTest(isTest)
     @isTest = isTest
   end
-  
+
   def executeCard
     debug('executeCard begin')
     @cardTrader.setNick( @nick_e )
@@ -757,122 +757,122 @@ class BCDice
     @cardTrader.executeCard(@message, @channel)
     debug('executeCard end')
   end
-  
+
   ###########################################################################
   #**                         各種コマンド処理
   ###########################################################################
-  
+
   #=========================================================================
   #**                           コマンド分岐
   #=========================================================================
   def dice_command   # ダイスコマンドの分岐処理
     arg = @message.upcase
-    
+
     debug('dice_command arg', arg)
-    
+
     output, secret = @diceBot.dice_command(@message, @nick_e)
     return output, secret if( output != '1' )
-    
+
     output, secret = rollD66(arg)
     return output, secret unless( output.nil? )
-    
+
     output, secret = checkAddRoll(arg)
     return output, secret unless( output.nil? )
-    
+
     output, secret = checkBDice(arg)
     return output, secret unless( output.nil? )
-    
+
     output, secret = checkRnDice(arg)
     return output, secret unless( output.nil? )
-    
+
     output, secret = checkUpperRoll(arg)
     return output, secret unless( output.nil? )
-    
+
     output, secret = checkChoiceCommand(arg)
     return output, secret unless( output.nil? )
-    
+
     output, secret = getTableDataResult(arg)
     return output, secret unless( output.nil? )
-    
+
     output = '1'
     secret = false
     return output, secret
   end
-  
+
   def checkAddRoll(arg)
     debug("check add roll")
-    
+
     dice = AddDice.new(self, @diceBot)
     output = dice.rollDice(arg)
     return nil if(output == '1')
-    
+
     secret = ( /S[-\d]+D[\d+-]+/ === arg )
-    
+
     return output, secret
   end
-  
+
   def checkBDice(arg)
     debug("check barabara roll")
-    
+
     output = bdice(arg)
     return nil if(output == '1')
-    
+
     secret = (/S[\d]+B[\d]+/i === arg)
-    
+
     return output, secret
   end
-  
+
   def checkRnDice(arg)
     debug('check xRn roll arg', arg)
-    
+
     return nil unless( /(S)?[\d]+R[\d]+/i === arg)
     secret = (not $1.nil?)
-    
+
     output = @diceBot.dice_command_xRn(arg, @nick_e)
     return nil if( output.nil? or output == '1' )
-    
+
     if( output.empty? )
       dice = RerollDice.new(self, @diceBot)
       output = dice.rollDice(arg)
     end
-    
+
     return nil if( output.nil? or output == '1' )
-    
+
     debug('xRn output', output)
-    
+
     return output, secret
   end
-  
+
   def checkUpperRoll(arg)
     debug("check upper roll")
-    
+
     return nil unless(/(S)?[\d]+U[\d]+/i === arg)
     secret = (not $1.nil?)
-    
+
     dice = UpperDice.new(self, @diceBot)
     output = dice.rollDice(arg)
     return nil if(output == '1')
-    
+
     return output, secret
   end
-  
+
   def checkChoiceCommand(arg)
     debug("check choice command")
-    
+
     return nil unless(/((^|\s)(S)?choice\[[^,]+(,[^,]+)+\]($|\s))/i === arg)
-    
+
     secret = (not $3.nil?)
     output = choice_random($1)
-    
+
     return output, secret
   end
-  
+
   # Unused method.
   def getTableDataResult(arg)
     nil
   end
-  
-  
+
+
   def getTableIndexDiceValueAndDiceText(dice)
     if( /(\d+)D(\d+)/i === dice )
       diceCount = $1
@@ -880,18 +880,18 @@ class BCDice
       value, diceText = roll(diceCount, diceType)
       return value, diceText
     end
-    
+
     string, secret, count, swapMarker = getD66Infos(dice)
     unless( string.nil? )
       value = getD66ValueByMarker(swapMarker)
       diceText = (value / 10).to_s  + "," + (value % 10).to_s
       return value, diceText
     end
-    
+
     return nil
   end
-  
-  
+
+
   def rollTableMessageDiceText(text)
     message = text.gsub(/(\d+)D(\d+)/) do
       diceCount = $1
@@ -899,11 +899,11 @@ class BCDice
       value, = roll(diceCount, diceMax)
       "#{$1}D#{$2}(=>#{value})"
     end
-    
+
     return message
   end
-  
-  
+
+
   #=========================================================================
   #**                           ランダマイザ
   #=========================================================================
@@ -912,7 +912,7 @@ class BCDice
     dice_cnt = dice_cnt.to_i
     dice_max = dice_max.to_i
     dice_re = dice_re.to_i
-    
+
     total = 0
     dice_str = ""
     numberSpot1 = 0
@@ -922,105 +922,105 @@ class BCDice
     d9_on = false
     rerollCount = 0
     dice_result = []
-    
+
     #dice_add = 0 if( ! dice_add )
-    
+
     if( (@diceBot.d66Type != 0) and (dice_max == 66) )
       dice_sort = 0
       dice_cnt = 2
       dice_max = 6
     end
-    
+
     if( @diceBot.isD9 and (dice_max == 9))
       d9_on = true
       dice_max += 1
     end
-    
+
     unless( (dice_cnt <= $DICE_MAXCNT) and (dice_max <= $DICE_MAXNUM) )
       return total, dice_str, numberSpot1, cnt_max, n_max, cnt_suc, rerollCount
     end
-    
+
     dice_cnt.times do |i|
       i += 1
       dice_now = 0
       dice_n = 0
       dice_st_n = ""
       round = 0
-      
+
       loop do
         if( round >= 1 )
           # 振り足し時のダイス読み替え処理用（ダブルクロスはクリティカルでダイス10に読み替える)
           dice_now += @diceBot.getJackUpValueOnAddRoll(dice_n)
         end
-        
+
         dice_n = rand(dice_max).to_i + 1
         dice_n -=1 if( d9_on )
-        
+
         dice_now += dice_n
-        
+
         debug('@diceBot.sendMode', @diceBot.sendMode)
         if( @diceBot.sendMode >= 2 )
           dice_st_n += "," unless( dice_st_n.empty? )
           dice_st_n += "#{dice_n}"
         end
         round += 1
-        
+
         break unless ( (dice_add > 1) and (dice_n >= dice_add) )
       end
-      
+
       total +=  dice_now
-      
+
       if( dice_ul != '' )
         suc = check_hit(dice_now, dice_ul, dice_diff)
         cnt_suc += suc
       end
-      
+
       if( dice_re )
         rerollCount += 1 if(dice_now >= dice_re)
       end
-      
+
       if( (@diceBot.sendMode >= 2) and (round >= 2) )
         dice_result.push( "#{dice_now}[#{dice_st_n}]" )
       else
         dice_result.push( dice_now )
       end
-        
+
       numberSpot1 += 1 if( dice_now == 1 )
       cnt_max += 1 if( dice_now == dice_max )
       n_max = dice_now if( dice_now > n_max)
     end
-    
+
     if( dice_sort != 0 )
       dice_str = dice_result.sort_by{|a| dice_num(a)}.join(",")
     else
       dice_str = dice_result.join(",")
     end
-    
+
     return total, dice_str, numberSpot1, cnt_max, n_max, cnt_suc, rerollCount
   end
-  
+
   def setRandomValues(rands)
     @rands = rands
   end
-  
+
   def rand(max)
     debug('rand called @rands', @rands)
-    
-    value = 0 
+
+    value = 0
     if( @rands.nil? )
       value = randNomal(max)
     else
       value = randFromRands(max)
     end
-    
-    unless( @randResults.nil? ) 
+
+    unless( @randResults.nil? )
       @randResults << [(value + 1), max]
     end
-    
+
     return value
   end
-  
-  
+
+
   def setCollectRandResult(b)
     if( b )
       @randResults = []
@@ -1028,44 +1028,44 @@ class BCDice
       @randResults = nil
     end
   end
-  
+
   def getRandResults
     @randResults
   end
-  
+
   def randNomal(max)
     Kernel.rand(max)
   end
-  
+
   def randFromRands(targetMax)
     nextRand = @rands.shift
-    
+
     if( nextRand.nil? )
       #return randNomal(targetMax)
       raise "nextRand is nil, so @rands is empty!! @rands:#{@rands.inspect}"
     end
-    
+
     value, max = nextRand
     value = value.to_i
     max = max.to_i
-    
+
     if( max != targetMax )
       #return randNomal(targetMax)
       raise "invalid max value! [ #{value} / #{max} ] but NEED [ #{targetMax} ] dice"
     end
-    
+
     return (value - 1)
   end
-  
+
   def dice_num(dice_str)
     dice_str = dice_str.to_s
     return dice_str.sub(/\[[\d,]+\]/, '').to_i
   end
-  
+
   #==========================================================================
   #**                            ダイスコマンド処理
   #==========================================================================
-  
+
   ####################         バラバラダイス       ########################
   def bdice(string) # 個数判定型ダイスロール
     total_n = 0
@@ -1073,14 +1073,14 @@ class BCDice
     signOfInequality = ""
     diff = 0
     output = ""
-    
+
     string = string.gsub(/-[\d]+B[\d]+/, '')   # バラバラダイスを引き算しようとしているのを除去
-    
+
     unless( /(^|\s)S?(([\d]+B[\d]+(\+[\d]+B[\d]+)*)(([<>=]+)([\d]+))?)($|\s)/ =~ string )
       output = '1'
       return output
     end
-    
+
     string = $2
     if( $5 )
       signOfInequality = marshalSignOfInequality( $6 )
@@ -1090,16 +1090,16 @@ class BCDice
       signOfInequality = marshalSignOfInequality($1)
       diff = $2.to_i
     end
-    
+
     dice_a = string.split(/\+/)
     dice_cnt_total = 0
     numberSpot1 = 0
-    
+
     dice_a.each do |dice_o|
       dice_cnt, dice_max, = dice_o.split(/[bB]/)
       dice_cnt = dice_cnt.to_i
       dice_max = dice_max.to_i
-      
+
       dice_dat = roll(dice_cnt, dice_max, (@diceBot.sortType & 2), 0, signOfInequality, diff)
       suc += dice_dat[5]
       output += "," if(output != "")
@@ -1107,70 +1107,70 @@ class BCDice
       numberSpot1 += dice_dat[2]
       dice_cnt_total += dice_cnt
     end
-    
+
     if(signOfInequality != "")
       string += "#{signOfInequality}#{diff}"
       output = "#{output} ＞ 成功数#{suc}"
       output += @diceBot.getGrichText(numberSpot1, dice_cnt_total, suc)
     end
     output = "#{@nick_e}: (#{string}) ＞ #{output}"
-    
+
     return output
   end
-  
+
   def isReRollAgain(dice_cnt, round)
     debug("isReRollAgain dice_cnt, round", dice_cnt, round)
     ( (dice_cnt > 0) and ((round < @diceBot.rerollLimitCount) or (@diceBot.rerollLimitCount == 0)) )
   end
-  
+
   ####################             D66ダイス        ########################
   def rollD66(string)
     return nil unless( /^S?D66/i === string )
     return nil if(@diceBot.d66Type == 0)
-    
+
     debug("match D66 roll")
     output, secret = d66dice(string)
-    
+
     return output, secret
   end
-  
+
   def d66dice(string)
     string = string.upcase
     secret = false
     output = '1'
-    
+
     string, secret, count, swapMarker = getD66Infos(string)
     return output, secret if( string.nil? )
-    
+
     debug('d66dice count', count)
-      
+
     d66List = []
     count.times do |i|
       d66List << getD66ValueByMarker(swapMarker)
     end
     d66Text = d66List.join(',')
     debug('d66Text', d66Text)
-    
+
     output = "#{@nick_e}: (#{string}) ＞ #{d66Text}"
-    
+
     return output, secret
   end
-  
-  
+
+
   def getD66Infos(string)
     debug("getD66Infos, string", string)
-    
+
     return nil unless(/(^|\s)(S)?((\d+)?D66(N|S)?)(\s|$)/i === string)
-    
+
     secret = (not $2.nil?)
     string = $3
     count = ($4 || 1).to_i
     swapMarker = ($5 || "").upcase
-    
+
     return string, secret, count, swapMarker
   end
-  
-  
+
+
   def getD66ValueByMarker(swapMarker)
     case swapMarker
     when "S"
@@ -1183,22 +1183,22 @@ class BCDice
       getD66Value()
     end
   end
-  
+
   def getD66Value(mode = nil)
     mode ||= @diceBot.d66Type
-    
+
     isSwap = ( mode > 1)
     getD66(isSwap)
   end
-  
+
   def getD66(isSwap)
     output = 0
-    
+
     dice_a = rand(6) + 1
     dice_b = rand(6) + 1
     debug("dice_a", dice_a)
     debug("dice_b", dice_b)
-    
+
     if( isSwap and (dice_a > dice_b))
       # 大小でスワップするタイプ
       output = dice_a + dice_b * 10
@@ -1206,141 +1206,141 @@ class BCDice
       # 出目そのまま
       output = dice_a * 10 + dice_b
     end
-    
+
     debug("output", output)
-    
+
     return output
   end
-  
-  
+
+
   ####################        その他ダイス関係      ########################
   def openSecretRoll(channel, mode)
     debug("openSecretRoll begin")
     channel = channel.upcase
-    
+
     messages = []
-    
+
     memberKey = getSecretRollMembersHolderKey(channel, mode)
     members = $secretRollMembersHolder[memberKey]
-    
+
     if( members.nil? )
       debug("openSecretRoll members is nil. messages", messages)
       return messages
     end
-    
+
     members.each do |member|
       diceResultKey = getSecretDiceResultHolderKey(channel, mode, member)
       debug("openSecretRoll diceResulyKey", diceResultKey)
-      
+
       diceResult = $secretDiceResultHolder[diceResultKey]
       debug("openSecretRoll diceResult", diceResult)
-      
+
       if( diceResult )
         messages.push( diceResult )
         $secretDiceResultHolder.delete(diceResultKey)
       end
     end
-    
+
     if(mode <= 0)  # 記録しておいたデータを削除
       debug("delete recorde data")
       $secretRollMembersHolder.delete(channel)
     end
-    
+
     debug("openSecretRoll result messages", messages)
-    
+
     return messages
   end
-  
+
   def getNick(nick = nil)
     nick ||= @nick_e
     nick = nick.upcase
-    
+
     /[_\d]*(.+)[_\d]*/ =~ nick
     nick = $1   # Nick端の数字はカウンター変わりに使われることが多いので除去
-    
+
     return nick
   end
-  
+
   def addToSecretDiceResult(diceResult, channel, mode)
     nick = getNick()
     channel = channel.upcase
-    
+
     # まずはチャンネルごとの管理リストに追加
     addToSecretRollMembersHolder(channel, mode)
-    
+
     # 次にダイスの出力結果を保存
     saveSecretDiceResult(diceResult, channel, mode)
-    
+
     @isMessagePrinted = true
   end
-  
+
   def addToSecretRollMembersHolder(channel, mode)
     key = getSecretRollMembersHolderKey(channel, mode)
-    
+
     $secretRollMembersHolder[key] ||= []
     members = $secretRollMembersHolder[key]
-    
+
     nick = getNick()
-    
+
     unless( members.include?(nick) )
       members.push(nick)
     end
   end
-  
+
   def getSecretRollMembersHolderKey(channel, mode)
     "#{mode},#{channel}"
   end
-  
+
   def saveSecretDiceResult(diceResult, channel, mode)
     nick = getNick()
-    
+
     if( mode != 0 )
       diceResult = "#{nick}: #{diceResult}" # プロットにNickを追加
     end
-    
+
     key = getSecretDiceResultHolderKey(channel, mode, nick)
     $secretDiceResultHolder[key] = diceResult    # 複数チャンネルも一応想定
-    
+
     debug("key", key)
     debug("secretDiceResultHolder", $secretDiceResultHolder)
   end
-  
+
   def getSecretDiceResultHolderKey(channel, mode, nick)
     key = "#{mode},#{channel},#{nick}"
     return key
   end
-  
+
   def setPrintPlotChannel
     nick = getNick()
     $plotPrintChannels[nick] = @channel
   end
-  
-  
+
+
   #==========================================================================
   #**                            その他の機能
   #==========================================================================
   def choice_random(string)
     output = "1"
-    
+
     unless(/(^|\s)((S)?choice\[([^,]+(,[^,]+)+)\])($|\s)/i =~ string)
       return output
     end
-    
+
     string = $2
     targetList = $4
-    
+
     unless(targetList)
       return output
     end
-    
+
     targets = targetList.split(/,/)
     index = rand(targets.length)
     target = targets[ index ]
     output = "#{@nick_e}: (#{string}) ＞ #{target}"
-    
+
     return output
   end
-  
+
   #==========================================================================
   #**                            結果判定関連
   #==========================================================================
@@ -1348,7 +1348,7 @@ class BCDice
     return "" if( text.nil? )
     return marshalSignOfInequality(text)
   end
-  
+
   def marshalSignOfInequality(signOfInequality)  # 不等号の整列
     case signOfInequality
     when /(<=|=<)/
@@ -1364,20 +1364,20 @@ class BCDice
     when /[=]+/
       return "="
     end
-    
+
     return signOfInequality
   end
-  
+
   def check_hit(dice_now, signOfInequality, diff) # 成功数判定用
     suc = 0
-    
+
     if( diff.is_a?(String) )
       unless( /\d/ =~ diff )
         return suc
       end
       diff = diff.to_i
     end
-    
+
     case signOfInequality
     when /(<=|=<)/
       if( dice_now <= diff)
@@ -1404,130 +1404,130 @@ class BCDice
         suc += 1
       end
     end
-    
+
     return suc
   end
-  
-  
+
+
   ####################       ゲーム別成功度判定      ########################
   def check_suc(*check_param)
-    
+
     total_n, dice_n, signOfInequality, diff, dice_cnt, dice_max, n1, n_max = *check_param
-    
+
     debug('check params : total_n, dice_n, signOfInequality, diff, dice_cnt, dice_max, n1, n_max',
           total_n, dice_n, signOfInequality, diff, dice_cnt, dice_max, n1, n_max)
-    
+
     return "" unless(/((\+|\-)?[\d]+)[)]?$/ =~ total_n.to_s)
-    
+
     total_n = $1.to_i
     diff = diff.to_i
-    
+
     check_paramNew = [total_n, dice_n, signOfInequality, diff, dice_cnt, dice_max, n1, n_max]
-    
+
     text = getSuccessText(*check_paramNew)
     text ||= ""
-    
+
     if( text.empty? )
       if( signOfInequality != "" )
         debug('どれでもないけど判定するとき')
         return check_nDx(*check_param)
       end
     end
-    
+
     return text
   end
-  
-  
+
+
   def getSuccessText(*check_param)
     debug('getSuccessText begin')
-    
+
     total_n, dice_n, signOfInequality, diff, dice_cnt, dice_max, n1, n_max = *check_param
-    
+
     debug("dice_max, dice_cnt", dice_max, dice_cnt)
-    
+
     if((dice_max == 100) and (dice_cnt == 1))
       debug('1D100判定')
       return @diceBot.check_1D100(*check_param)
     end
-    
+
     if((dice_max == 20) and (dice_cnt == 1))
       debug('1d20判定')
       return @diceBot.check_1D20(*check_param)
     end
-    
+
     if(dice_max == 10)
       debug('d10ベース判定')
       return @diceBot.check_nD10(*check_param)
     end
-    
+
     if(dice_max == 6)
       if(dice_cnt == 2)
         debug('2d6判定')
         result = @diceBot.check_2D6(*check_param)
         return result unless( result.empty? )
       end
-      
+
       debug('xD6判定')
       return @diceBot.check_nD6(*check_param)
     end
-    
+
     return ""
   end
-  
+
   def check_nDx(total_n, dice_n, signOfInequality, diff, dice_cnt, dice_max, n1, n_max)  # ゲーム別成功度判定(ダイスごちゃ混ぜ系)
     debug('check_nDx begin diff', diff)
     success = check_hit(total_n, signOfInequality, diff)
     debug('check_nDx success', success)
-    
+
     if(success >= 1)
       return " ＞ 成功"
     end
-    
+
     return " ＞ 失敗"
   end
-  
+
   ###########################################################################
   #**                              出力関連
   ###########################################################################
-  
+
   def broadmsg(output, nick)
     debug("broadmsg output, nick", output, nick)
     debug("@nick_e", @nick_e)
-    
+
     if(output == "1")
       return
     end
-    
+
     if( nick == @nick_e )
       sendMessageToOnlySender(output) #encode($ircCode, output))
     else
       sendMessage(nick, output)
     end
   end
-  
+
   def sendMessage(to, message)
     debug("sendMessage to, message", to, message)
     @ircClient.sendMessage(to, message)
     @isMessagePrinted = true
   end
-  
+
   def sendMessageToOnlySender(message)
     debug("sendMessageToOnlySender message", message)
     debug("@nick_e", @nick_e)
     @ircClient.sendMessageToOnlySender(@nick_e, message)
     @isMessagePrinted = true
   end
-  
+
   def sendMessageToChannels(message)
     @ircClient.sendMessageToChannels(message)
     @isMessagePrinted = true
   end
-  
-  
+
+
   ####################         テキスト前処理        ########################
   def parren_killer(string)
     debug("parren_killer input", string)
-    
+
     while( /^(.*?)\[(\d+[Dd]\d+)\](.*)/ =~ string )
       str_before = ""
       str_after = ""
@@ -1537,25 +1537,25 @@ class BCDice
       rolled, dmy = rollDiceAddingUp(dice_cmd)
       string = "#{str_before}#{rolled}#{str_after}"
     end
-    
+
     string = changeRangeTextToNumberText(string)
-    
+
     while(/^(.*?)(\([\d\/*+-]+?\))(.*)/ =~ string)
       debug("while string", string)
-      
+
       str_a = $3
       str_a ||= ""
-      
+
       str_b = $1
       str_b ||= ""
       debug("str_b", str_b)
-      
+
       par_i = $2
-      
+
       debug("par_i", par_i)
       par_o = paren_k(par_i)
       debug("par_o", par_o)
-      
+
       if(par_o != 0)
         if(par_o < 0)
           if(/(.+?)(\+)$/ =~ str_b)
@@ -1573,83 +1573,83 @@ class BCDice
         string = "#{str_b}0#{str_a}"
       end
     end
-    
+
     debug("diceBot.changeText(string) begin", string)
     string = @diceBot.changeText(string)
     debug("diceBot.changeText(string) end", string)
-    
+
     string = string.gsub(/([\d]+[dD])([^\d\w]|$)/) {"#{$1}6#{$2}"}
-    
+
     debug("parren_killer output", string)
-    
+
     return string
   end
-  
+
   def rollDiceAddingUp(*arg)
     dice = AddDice.new(self, @diceBot)
     dice.rollDiceAddingUp(*arg)
   end
-  
+
   # [1...4]D[2...7] -> 2D7 のように[n...m]をランダムな数値へ変換
   def changeRangeTextToNumberText(string)
     debug('[st...ed] before string', string)
-    
+
     while(/^(.*?)\[(\d+)[.]{3}(\d+)\](.*)/ =~ string )
       beforeText = $1
       beforeText ||= ""
-      
+
       rangeBegin = $2.to_i
       rangeEnd = $3.to_i
-      
+
       afterText = $4
       afterText ||= ""
-      
+
       if(rangeBegin < rangeEnd)
         range = (rangeEnd - rangeBegin + 1)
         debug('range', range)
-        
+
         rolledNumber, = roll(1, range)
         resultNumber = rangeBegin - 1 + rolledNumber
         string = "#{beforeText}#{resultNumber}#{afterText}"
       end
     end
-    
+
     debug('[st...ed] after string', string)
-    
+
     return string
   end
-  
+
   def paren_k(string)
     result = 0
-    
+
     return result unless (/([\d\/*+-]+)/ =~ string)
-    
+
     string = $1
-    
+
     #ex: --X => +X
     string.gsub!(/\-\-/, '+')
-    
+
     debug("paren_k string", string )
     list = split_plus_minus(string)
     debug("paren_k list", list)
-    
+
     result = 0
-    
+
     list.each do |text|
       result += paren_k_loop(text)
     end
-    
+
     return result
   end
-  
+
   def split_plus_minus(string)
-    
+
     list = string.scan(/[\+\-]?[^\+\-]+/)
-    
+
     debug('split_plus_minus list', list)
-    
+
     result = []
-    
+
     list.length.times do |i|
       unless result.empty?
         if /(\*|\/)$/ === result.last
@@ -1657,46 +1657,46 @@ class BCDice
           next
         end
       end
-      
-      result << list[i] 
+
+      result << list[i]
     end
-    
+
     debug('split_plus_minus result', result)
     return result
   end
-  
-  
+
+
   def paren_k_loop(string)
     debug("paren_k_plus Begin", string)
-    
+
     result = paren_k_calculate_multiple_divide_text(string)
     debug("paren_k_plus End result", result)
-    
+
     return result
   end
-  
-  
+
+
   def paren_k_calculate_multiple_divide_text(string)
     multi = 1
     divide = 1
-    
+
     #ex: X*Y(...) => X(...) & multi(=*Y)
     string, multi = paren_k_multi(string)
-    
+
     #ex: X/Y(...) => X(...) & divide(=/Y)
     string, divide = paren_k_devide(string)
-    
+
     # 掛け算・割り算
     result = calculate_multiple_divide(string, multi, divide)
     return result
   end
-  
+
 
   #ex: X*Y(...) => X(...) & multi(=*Y)
   def paren_k_multi(string)
     debug("paren_k_multi Begin string", string)
     multi = 1
-    
+
     while(/(.*?)(\*[-\d]+)(.*)/ =~ string)
       before = $1
       after = $3
@@ -1706,18 +1706,18 @@ class BCDice
         multi = multi * $1.to_i
       end
     end
-    
+
     debug("paren_k_multi End multi", multi)
     debug("paren_k_multi End", string)
-    
+
     return string, multi
   end
-  
-  
+
+
   #ex: X/Y(...) => X(...) & divide(=/Y)
   def paren_k_devide(string)
     divide = 1
-    
+
     while(/(.*?)(\/[-\d]+)(.*)/ =~ string)
       before = $1
       after = $3
@@ -1727,20 +1727,20 @@ class BCDice
         divide = divide * $1.to_i
       end
     end
-    
+
     return string, divide
   end
-  
-  
+
+
   def calculate_multiple_divide(string, multi, divide)
-    
+
     result = 0
-    
+
     return result if( divide == 0 )
     return result unless(/([-\d]+)/ =~ string)
-    
+
     work = ($1.to_i) * multi
-    
+
     case @diceBot.fractionType
     when "roundUp"  # 端数切り上げ
       result = (work / divide + 0.999).to_i
@@ -1749,7 +1749,7 @@ class BCDice
     else #切り捨て
       result = (work / divide).to_i
     end
-    
+
     return result
   end
 
@@ -1777,17 +1777,17 @@ class BCDice
 
     return message
   end
-  
-  
+
+
   def setIrcMode(mode)
     @isIrcMode = mode
   end
-  
-  
+
+
   def sleepForIrc(second)
     if( @isIrcMode  )
       sleep( second )
     end
   end
-  
+
 end

--- a/src/cgiDiceBot.rb
+++ b/src/cgiDiceBot.rb
@@ -8,26 +8,26 @@ end
 require 'bcdiceCore.rb'
 
 class CgiDiceBot
-  
+
   def initialize
     @rollResult = ""
     @isSecret = false
     @rands = nil #テスト以外ではnilで良い。ダイス目操作パラメータ
     @isTest = false
     @bcdice = nil
-    
+
     $SEND_STR_MAX = 99999 # 最大送信文字数(本来は500byte上限)
   end
-  
+
   attr :isSecret
-  
+
   def rollFromCgi()
     cgi = CGI.new
     @cgiParams = @cgi.params
-    
+
     rollFromCgiParams(cgiParams)
   end
-  
+
   def rollFromCgiParamsDummy()
     @cgiParams = {
       'message' => 'STG20',
@@ -38,18 +38,18 @@ class CgiDiceBot
       'sendto' => 'sendto',
       'color' => '999999',
     }
-    
+
     rollFromCgiParams
   end
-  
+
   def rollFromCgiParams
     message = @cgiParams['message']
     gameType = @cgiParams['gameType']
     gameType ||= 'diceBot';
     # $rand_seed = @cgiParams['randomSeed']
-    
+
     result = ""
-    
+
     result += "##>customBot BEGIN<##"
     result += getDiceBotParamText('channel')
     result += getDiceBotParamText('name')
@@ -60,48 +60,48 @@ class CgiDiceBot
     rollResult, randResults = roll(message, gameType)
     result += rollResult
     result += "##>customBot END<##"
-    
+
     return result
   end
-  
+
   def getDiceBotParamText(paramName)
     param = @cgiParams[paramName]
     param ||= ''
-    
+
     "#{param}\t"
   end
-  
+
   def roll(message, gameType, dir = nil, prefix = '', isNeedResult = false)
     rollResult, randResults, gameType = executeDiceBot(message, gameType, dir, prefix, isNeedResult)
-    
+
     result = ""
-    
+
     unless( @isTest )
       # result += "##>isSecretDice<##" if( @isSecret )
     end
-    
+
     # 多言語対応のダイスボットは「GameType:Language」という書式なので、
     # ここで言語名を削って表示する。（内部的には必要だが、表示では不要のため）
     gameType = gameType.gsub(/:.+$/, '')
-    
+
     unless( rollResult.empty? )
       result += "\n#{gameType} #{rollResult}"
     end
-    
+
     return result, randResults
   end
-  
+
   def setTest()
     @isTest = true
   end
-  
+
   def setRandomValues(rands)
     @rands = rands
   end
-  
+
   def executeDiceBot(message, gameType, dir = nil, prefix = '', isNeedResult = false)
     bcdice = newBcDice
-    
+
     bcdice.setIrcClient(self)
     bcdice.setRandomValues(@rands)
     bcdice.isKeepSecretDice(@isTest)
@@ -109,66 +109,66 @@ class CgiDiceBot
     bcdice.setCollectRandResult(isNeedResult)
     bcdice.setDir(dir, prefix)
     bcdice.setIrcMode(false)
-    
+
     if( bcdice.getGameType != gameType )
       bcdice.setGameByTitle( gameType )
       gameType = bcdice.getGameType
     end
-    
+
     bcdice.setMessage(message)
-    
+
     channel = ""
     nick_e = ""
     bcdice.setChannel(channel)
     bcdice.recievePublicMessage(nick_e)
-    
+
     rollResult = @rollResult
     @rollResult = ""
-    
+
     randResults = bcdice.getRandResults
-    
+
     return rollResult, randResults, gameType
   end
-  
+
   def newBcDice
     if( @bcdice.nil? )
       bcdiceMaker = BCDiceMaker.new
       @bcdice = bcdiceMaker.newBcDice()
     end
-    
+
     return @bcdice
   end
-  
+
   # Unused method
   def getGameCommandInfos(dir, prefix)
     return []
   end
-  
+
   def sendMessage(to, message)
     @rollResult += message
   end
-  
+
   def sendMessageToOnlySender(nick_e, message)
     @isSecret = true
     @rollResult += message
   end
-  
+
   def sendMessageToChannels(message)
     @rollResult += message
   end
-  
+
 end
 
 
 if( $0 === __FILE__ )
   bot = CgiDiceBot.new
-  
+
   result = ''
   if( ARGV.length > 0 )
     result, randResults = bot.roll(ARGV[0], ARGV[1])
   else
     result = bot.rollFromCgiParamsDummy
   end
-  
+
   print( result + "\n" )
 end

--- a/src/dice/AddDice.rb
+++ b/src/dice/AddDice.rb
@@ -2,36 +2,36 @@
 
 
 class AddDice
-  
+
   def initialize(bcdice, diceBot)
     @bcdice = bcdice
     @diceBot = diceBot
     @nick_e = @bcdice.nick_e
   end
-  
-  ####################             加算ダイス        ########################  
+
+  ####################             加算ダイス        ########################
 
   def rollDice(string)
     debug("AddDice.rollDice() begin string", string)
-    
+
     unless( /(^|\s)S?(([\d\+\*\-]*[\d]+D[\d\/UR@]*[\d\+\*\-D\/UR]*)(([<>=]+)([?\-\d]+))?)($|\s)/i =~ string )
       return "1"
     end
-    
+
     string = $2
     judgeText = $4 # '>=10'といった成否判定文字
     judgeOperator = $5 # '>=' といった判定の条件演算子 文字
     diffText = $6
-    
+
     signOfInequality = ""
     isCheckSuccess = false
-    
+
     if( judgeText )
       isCheckSuccess = true
       signOfInequality = @bcdice.marshalSignOfInequality(judgeOperator)
       string = $3
     end
-    
+
     dice_cnt = 0
     dice_max = 0
     total_n = 0
@@ -39,49 +39,49 @@ class AddDice
     output = ""
     n1 = 0
     n_max = 0
-    
+
     addUpTextList = string.split(/\+/)
-    
+
     addUpTextList.each do |addUpText|
-      
+
       subtractTextList = addUpText.split(/-/)
-      
+
       subtractTextList.each_with_index do |subtractText, index|
         next if( subtractText.empty? )
-        
+
         debug("begin rollDiceAddingUp(subtractText, isCheckSuccess)", subtractText, isCheckSuccess)
         dice_now, dice_n_wk, dice_str, n1_wk, n_max_wk, cnt_wk, max_wk = rollDiceAddingUp(subtractText, isCheckSuccess)
         debug("end rollDiceAddingUp(subtractText, isCheckSuccess) -> dice_now", dice_now)
-        
+
         #return "1" if(dice_now <= 0)
-        
+
         rate = (index == 0 ? 1 : -1)
-        
+
         total_n += (dice_now) * rate
         dice_n += dice_n_wk * rate
         n1 += n1_wk
         n_max += n_max_wk
         dice_cnt += cnt_wk
         dice_max = max_wk if(max_wk > dice_max)
-        
+
         next if(@diceBot.sendMode == 0)
-        
+
         operatorText = getOperatorText(rate, output)
         output += "#{operatorText}#{dice_str}"
       end
     end
-    
+
     if( signOfInequality != "" )
       string += "#{signOfInequality}#{diffText}"
     end
-    
+
     @diceBot.setDiceText(output)
     @diceBot.setDiffText(diffText)
-    
+
     #ダイス目による補正処理（現状ナイトメアハンターディープ専用）
     addText, revision = @diceBot.getDiceRevision(n_max, dice_max, total_n)
     debug('addText, revision', addText, revision)
-    
+
     debug("@nick_e", @nick_e)
     if( @diceBot.sendMode > 0 )
       if( output =~ /[^\d\[\]]+/ )
@@ -92,32 +92,32 @@ class AddDice
     else
       output = "#{@nick_e}: (#{string}) ＞ #{total_n}#{addText}"
     end
-    
+
     total_n += revision
-    
+
     if( signOfInequality != "" )   # 成功度判定処理
       successText = @bcdice.check_suc(total_n, dice_n, signOfInequality, diffText, dice_cnt, dice_max, n1, n_max)
       debug("check_suc successText", successText)
       output += successText
     end
-    
-    
+
+
     #ダイスロールによるポイント等の取得処理用（T&T悪意、ナイトメアハンター・ディープ宿命、特命転校生エクストラパワーポイントなど）
     output += @diceBot.getDiceRolledAdditionalText(n1, n_max, dice_max)
-    
+
     if( (dice_cnt == 0) or (dice_max == 0) )
       output = '1'
     end
-    
+
     debug("AddDice.rollDice() end output", output)
     return output
   end
-  
-  
-  
+
+
+
   def rollDiceAddingUp( string, isCheckSuccess = false)   # 加算ダイスロール(個別処理)
     debug("rollDiceAddingUp() begin string", string)
-    
+
     dice_max = 0
     dice_total = 1
     dice_n = 0
@@ -126,7 +126,7 @@ class AddDice
     n_max = 0
     dice_cnt_total = 0
     double_check = false
-    
+
     if( @diceBot.sameDiceRerollCount != 0 ) # 振り足しありのゲームでダイスが二個以上
       if( @diceBot.sameDiceRerollType <= 0 )  # 判定のみ振り足し
         debug('判定のみ振り足し')
@@ -138,11 +138,11 @@ class AddDice
         double_check = true
       end
     end
-    
+
     debug("double_check", double_check)
-    
+
     while(/(^([\d]+\*[\d]+)\*(.+)|(.+)\*([\d]+\*[\d]+)$|(.+)\*([\d]+\*[\d]+)\*(.+))/ =~ string)
-      
+
       if( $2 )
         string = parren_killer('(' + $2 + ')') + '*' + $3
       elsif( $5 )
@@ -151,11 +151,11 @@ class AddDice
         string = $6 + '*' + parren_killer('(' + $7 + ')') + '*' + $8
       end
     end
-    
+
     debug("string", string)
-    
+
     emptyResult = [dice_total, dice_n, output, n1, n_max, dice_cnt_total, dice_max]
-    
+
     mul_cmd = string.split(/\*/)
     mul_cmd.each do |mul_line|
       if( /([\d]+)D([\d]+)(@(\d+))?(\/\d+[UR]?)?/i =~ mul_line )
@@ -163,34 +163,34 @@ class AddDice
         dice_max = $2.to_i
         critical = $4.to_i
         slashMark = $5
-        
+
         return emptyResult if( (critical != 0) and (not @diceBot.is2dCritical) )
         return emptyResult if( dice_max > $DICE_MAXNUM )
-        
+
         dice_max, dice_now, output_tmp, n1_count, max_number_tmp, result_dice_count =
           rollDiceAddingUpCommand(dice_count, dice_max, slashMark, double_check, isCheckSuccess, critical)
-        
+
         output += "*" if( output != "" )
         output += output_tmp
-        
+
         dice_total *= dice_now
-        
+
         dice_n += dice_now
         dice_cnt_total += result_dice_count
         n1 += n1_count
         n_max += max_number_tmp
-        
+
       else
         mul_line = mul_line.to_i
         debug('dice_total', dice_total)
         debug('mul_line', mul_line)
-        
+
         dice_total *= mul_line
-        
+
         unless(output.empty?)
           output += "*"
         end
-        
+
         if( mul_line < 0)
           output += "(#{mul_line})"
         else
@@ -198,14 +198,14 @@ class AddDice
         end
       end
     end
-    
+
     debug("rollDiceAddingUp() end output", dice_total, dice_n, output, n1, n_max, dice_cnt_total, dice_max)
     return dice_total, dice_n, output, n1, n_max, dice_cnt_total, dice_max
   end
-  
-  
+
+
   def rollDiceAddingUpCommand(dice_count, dice_max, slashMark, double_check, isCheckSuccess, critical)
-    
+
     result_dice_count = 0
     dice_now = 0
     n1_count = 0
@@ -214,69 +214,69 @@ class AddDice
     dice_arry = []
     dice_arry.push( dice_count )
     loop_count = 0
-    
+
     debug("before while dice_arry", dice_arry)
-    
+
     while( not dice_arry.empty? )
       debug("IN while dice_arry", dice_arry)
-      
+
       dice_wk = dice_arry.shift
       result_dice_count += dice_wk
-      
+
       debug('dice_wk', dice_wk)
       debug('dice_max', dice_max)
       debug('(sortType & 1)', (@diceBot.sortType & 1))
-      
+
       dice_dat = rollLocal(dice_wk, dice_max, (@diceBot.sortType & 1))
       debug('dice_dat', dice_dat)
-      
+
       dice_new = dice_dat[0]
       dice_now += dice_new
-      
+
       debug('slashMark', slashMark)
       dice_now = getSlashedDice(slashMark, dice_now)
-      
+
       dice_str += "][" if( dice_str != "")
       debug('dice_str', dice_str)
-      
+
       dice_str += dice_dat[1]
       n1_count += dice_dat[2]
       max_number += dice_dat[3]
-      
+
       if( double_check and (dice_wk >= 2) )     # 振り足しありでダイスが二個以上
         addDiceArrayByAddDiceCount(dice_dat, dice_max, dice_arry, dice_wk)
       end
-      
+
       @diceBot.check2dCritical(critical, dice_new, dice_arry, loop_count)
       loop_count += 1
     end
-    
+
     #ダイス目文字列からダイス値を変更する場合の処理（現状クトゥルフ・テック専用）
     dice_now = @diceBot.changeDiceValueByDiceText(dice_now, dice_str, isCheckSuccess, dice_max)
-    
+
     output = ""
     if( @diceBot.sendMode > 1 )
       output += "#{dice_now}[#{dice_str}]"
     elsif( @diceBot.sendMode > 0 )
       output += "#{dice_now}"
     end
-    
+
     return dice_max, dice_now, output, n1_count, max_number, result_dice_count
   end
-  
-  
+
+
   def addDiceArrayByAddDiceCount(dice_dat, dice_max, dice_arry, dice_wk)
     dice_num = dice_dat[1].split(/,/).collect{|s|s.to_i}
     dice_face = []
-        
+
     dice_max.times do |i|
       dice_face.push( 0 )
     end
-    
+
     dice_num.each do |dice_o|
       dice_face[dice_o - 1] += 1
     end
-    
+
     dice_face.each do |dice_o|
       if( @diceBot.sameDiceRerollCount == 1) # 全部同じ目じゃないと振り足しなし
         dice_arry.push(dice_o) if( dice_o == dice_wk )
@@ -285,19 +285,19 @@ class AddDice
       end
     end
   end
-  
-  
+
+
   def getSlashedDice(slashMark, dice)
-    
+
     return dice unless( /^\/(\d+)(.)?$/i === slashMark )
-    
+
     rate = $1.to_i
     mark = $2
-    
+
     return dice if( rate == 0 )
-    
+
     value = (1.0 * dice / rate)
-    
+
     case mark
     when "U"
       dice = value.ceil
@@ -306,46 +306,46 @@ class AddDice
     else
       dice = value.floor
     end
-    
+
     return dice
   end
-  
-  
+
+
   def rollLocal(dice_wk, dice_max, sortType)
     if( dice_max == 66 )
       return rollD66(dice_wk)
     end
-    
+
     return @bcdice.roll(dice_wk, dice_max, sortType)
   end
-  
+
   def rollD66(count)
-    
+
     d66List = []
-    
+
     count.times do |i|
       d66List << @bcdice.getD66Value()
     end
-    
+
     total = d66List.inject{|sum, i| sum + i}
     text = d66List.join(',')
     n1Count = d66List.collect{|i| i == 1}.length
     nMaxCount = d66List.collect{|i| i == 66}.length
-    
+
     result = [total, text, n1Count, nMaxCount, 0, 0, 0]
   end
-  
-  
+
+
   def marshalSignOfInequality(*arg)
     @bcdice.marshalSignOfInequality(*arg)
   end
-  
+
   def getOperatorText(rate, output)
     return '-' if(rate < 0)
     return '' if(output.empty?)
-    return "+" 
+    return "+"
   end
-  
+
   def parren_killer(*args)
     @bcdice.parren_killer(*args)
   end

--- a/src/dice/AddDice.rb
+++ b/src/dice/AddDice.rb
@@ -43,7 +43,6 @@ class AddDice
     addUpTextList = string.split(/\+/)
 
     addUpTextList.each do |addUpText|
-
       subtractTextList = addUpText.split(/-/)
 
       subtractTextList.each_with_index do |subtractText, index|

--- a/src/dice/RerollDice.rb
+++ b/src/dice/RerollDice.rb
@@ -2,49 +2,49 @@
 
 
 class RerollDice
-  
+
   def initialize(bcdice, diceBot)
     @bcdice = bcdice
     @diceBot = diceBot
     @nick_e = @bcdice.nick_e
   end
-  
+
   ####################        個数振り足しダイス     ########################
   def rollDice(string)
-    
+
     output = ''
-    
+
     begin
       output = rollDiceCatched(string)
     rescue => e
       output = "#{string} ＞ " + e.to_s
     end
-    
+
     return "#{@nick_e}: #{output}"
   end
-  
+
   def rollDiceCatched(string)
     debug('RerollDice.rollDice string', string)
-    
+
     successCount = 0;
     signOfInequality = "";
     output = "";
     next_roll = 0;
-    
+
     string = string.gsub(/-[\d]+R[\d]+/, '');   # 振り足しロールの引き算している部分をカット
-    
+
     unless( /(^|\s)S?([\d]+R[\d\+R]+)(\[(\d+)\])?(([<>=]+)([\d]+))?(\@(\d+))?($|\s)/ =~ string )
       debug("is invaild rdice", string)
       return '1';
     end
-    
+
     string = $2;
     rerollNumber_1 = $4
     rerollNumber_2 = $9
     judgeText = $5
     operator = $6
     diff = $7
-    
+
     if( judgeText )
       diff = diff.to_i
       signOfInequality = @bcdice.marshalSignOfInequality( operator )
@@ -55,33 +55,33 @@ class RerollDice
         signOfInequality = @bcdice.marshalSignOfInequality( operator )
       end
     end
-    
+
     rerollNumber = getRerollNumber(rerollNumber_1, rerollNumber_2, judgeText, diff)
     debug('rerollNumber', rerollNumber)
-    
+
     debug("diff", diff)
-    
+
     numberSpot1Total = 0
     dice_cnt_total =0
     dice_max = 0
-    
+
     dice_a = string.split(/\+/)
     debug('dice_a', dice_a)
-    
+
     dice_a.each do |dice_o|
       debug('dice_o', dice_o)
-      
+
       dice_cnt, dice_max = dice_o.split(/[rR]/).collect{|s|s.to_i}
       debug('dice_cnt', dice_cnt)
       debug('dice_max', dice_max)
-      
+
       checkReRollRule(dice_max, signOfInequality, diff)
-      
+
       total, dice_str, numberSpot1, cnt_max, n_max, success, rerollCount =
         @bcdice.roll(dice_cnt, dice_max, (@diceBot.sortType & 2), 0, signOfInequality, diff, rerollNumber)
       debug('bcdice.roll : total, dice_str, numberSpot1, cnt_max, n_max, success, rerollCount',
             total, dice_str, numberSpot1, cnt_max, n_max, success, rerollCount)
-      
+
       successCount += success
       output += "," if(output != "")
       output += dice_str
@@ -89,67 +89,67 @@ class RerollDice
       numberSpot1Total += numberSpot1
       dice_cnt_total += dice_cnt
     end
-    
-    output2, round, success, dice_cnt = 
+
+    output2, round, success, dice_cnt =
       reRollNextDice(next_roll, dice_max, signOfInequality, diff, rerollNumber)
-    
+
     successCount += success
     dice_cnt_total += dice_cnt
-    
+
     output = "#{output}#{output2} ＞ 成功数#{successCount}"
     string += "[#{rerollNumber}]#{signOfInequality}#{diff}"
-    
+
     debug("string", string)
     output += @diceBot.getGrichText(numberSpot1Total, dice_cnt_total, successCount)
-    
+
     output = "(#{string}) ＞ #{output}"
-    
+
     if( output.length > $SEND_STR_MAX )    # 長すぎたときの救済
       output = "(#{string}) ＞ ... ＞ 回転数#{round} ＞ 成功数#{successCount}"
     end
-    
+
     return output
   end
-  
-  
+
+
   def reRollNextDice(next_roll, dice_max, signOfInequality, diff, rerollNumber)
     debug('rerollNumber Begin')
-    
+
     dice_cnt = next_roll
     debug('dice_cnt', dice_cnt)
-    
+
     output = ""
     round = 0
     successCount = 0
     dice_cnt_total = 0
-    
+
     if( next_roll <= 0 )
       return output, round, successCount, dice_cnt_total
     end
-    
+
     loop do
-      total, dice_str, numberSpot1, cnt_max, n_max, success, rerollCount = 
+      total, dice_str, numberSpot1, cnt_max, n_max, success, rerollCount =
         @bcdice.roll(dice_cnt, dice_max, (@diceBot.sortType & 2), 0, signOfInequality, diff, rerollNumber)
       debug('total, dice_str, numberSpot1, cnt_max, n_max, success, rerollCount',
             total, dice_str, numberSpot1, cnt_max, n_max, success, rerollCount)
-      
+
       successCount += success
       round += 1
       dice_cnt_total += dice_cnt
       dice_cnt = rerollCount
       debug('dice_str', dice_str)
       output += " + #{dice_str}"
-      
+
       break unless ( @bcdice.isReRollAgain(dice_cnt, round) )
     end
-    
+
     debug('output', output)
     debug('rerollNumber End')
-    
+
     return output, round, successCount, dice_cnt_total
   end
-  
-  
+
+
   def getRerollNumber(rerollNumber_1, rerollNumber_2, judgeText, diff)
     if( rerollNumber_1 )
       return rerollNumber_1.to_i
@@ -163,14 +163,14 @@ class RerollDice
       raiseErroForJudgeRule()
     end
   end
-  
+
   def raiseErroForJudgeRule()
     raise "条件が間違っています。2R6>=5 あるいは 2R6[5] のように振り足し目標値を指定してください。"
   end
-  
+
   def checkReRollRule(dice_max, signOfInequality, diff)   # 振り足しロールの条件確認
     valid = true
-    
+
     case signOfInequality
     when '<='
       valid = false if(diff >= dice_max)
@@ -183,11 +183,11 @@ class RerollDice
     when '>'
       valid = false if(diff < 1)
     end
-    
+
     unless( valid )
       raiseErroForJudgeRule()
     end
   end
-  
-  
+
+
 end

--- a/src/dice/UpperDice.rb
+++ b/src/dice/UpperDice.rb
@@ -2,54 +2,54 @@
 
 
 class UpperDice
-  
+
   def initialize(bcdice, diceBot)
     @bcdice = bcdice
     @diceBot = diceBot
     @nick_e = @bcdice.nick_e
   end
-  
-  
+
+
    # 上方無限型ダイスロール
   def rollDice(string)
     debug('udice begin string', string)
-    
+
     output = '1';
-    
+
     string = string.gsub(/-[sS]?[\d]+[uU][\d]+/, '')   # 上方無限の引き算しようとしてる部分をカット
-    
+
     unless(/(^|\s)[sS]?(\d+[uU][\d\+\-uU]+)(\[(\d+)\])?([\+\-\d]*)(([<>=]+)(\d+))?(\@(\d+))?($|\s)/ =~ string)
       return output;
     end
-    
+
     command = $2;
     signOfInequalityText = $7
     diff = $8.to_i;
     upperTarget1 = $4
     upperTarget2 = $10
-    
+
     modify = $5
     debug('modify', modify)
     modify ||= ''
-    
+
     debug('p $...', [$1, $2, $3, $4, $5, $6, $7, $8, $9, $10])
-    
+
     string = command
-    
+
     @signOfInequality = @bcdice.getMarshaledSignOfInequality( signOfInequalityText )
     @upper = getAddRollUpperTarget(upperTarget1, upperTarget2)
-    
+
     if(@upper <= 1)
       output = "#{@nick_e}: (#{string}\[#{@upper}\]#{modify}) ＞ 無限ロールの条件がまちがっています"
       return output
     end
-    
+
     dice_a = (string + modify).split(/\+/)
     debug('dice_a', dice_a)
-    
+
     diceCommands = []
     bonusValues = []
-    
+
     dice_a.each do |dice_o|
       if(/[Uu]/ =~ dice_o)
         diceCommands.push( dice_o );
@@ -57,109 +57,109 @@ class UpperDice
         bonusValues.push( dice_o );
       end
     end
-    
+
     bonus = getBonusValue( bonusValues )
     debug('bonus', bonus)
-    
+
     diceDiff = diff - bonus
-    
+
     totalDiceString, totalSuccessCount, totalDiceCount, maxDiceValue, totalValue = getUpperDiceCommandResult(diceCommands, diceDiff)
-    
+
     output = totalDiceString
-    
+
     if(bonus > 0)
       output += "+#{bonus}";
     elsif(bonus < 0)
       output += "#{bonus}";
     end
-    
+
     maxValue = maxDiceValue + bonus
     totalValue += bonus
-    
+
     string += "[#{@upper}]" + modify;
-    
+
     if( @diceBot.isPrintMaxDice and (totalDiceCount > 1) )
       output = "#{output} ＞ #{totalValue}";
     end
-    
+
     if(@signOfInequality != "")
       output = "#{output} ＞ 成功数#{totalSuccessCount}";
       string += "#{@signOfInequality}#{diff}";
     else
       output += getMaxAndTotalValueResultStirng(maxValue, totalValue, totalDiceCount)
     end
-    
+
     output = "#{@nick_e}: (#{string}) ＞ #{output}";
-    
+
     if (output.length > $SEND_STR_MAX)
       output ="#{@nick_e}: (#{string}) ＞ ... ＞ #{totalValue}";
       if(@signOfInequality == "")
         output += getMaxAndTotalValueResultStirng(maxValue, totalValue, totalDiceCount)
       end
     end
-    
+
     return output;
   end
-  
+
   def getMaxAndTotalValueResultStirng(maxValue, totalValue, totalDiceCount)
     return " ＞ #{maxValue}/#{totalValue}(最大/合計)"
   end
-  
-  
+
+
   def getAddRollUpperTarget(target1, target2)
     if( target1 )
       return target1.to_i
     end
-    
+
     if( target2 )
       return target2.to_i
     end
-    
+
     if(@diceBot.upplerRollThreshold == "Max")
       return 2
-    else 
+    else
       return @diceBot.upplerRollThreshold;
     end
   end
-  
+
   def getBonusValue( bonusValues )
     return 0 if( bonusValues.empty? )
-    
+
     diceBonusText = bonusValues.join("+")
     bonus = @bcdice.parren_killer("(" + diceBonusText + ")").to_i
-    
+
     return bonus
   end
-  
+
   def getUpperDiceCommandResult(diceCommands, diceDiff)
     diceStringList = []
     totalSuccessCount = 0;
     totalDiceCount = 0
     maxDiceValue = 0;
     totalValue = 0
-    
+
     diceCommands.each do |diceCommand|
       diceCount, diceMax = diceCommand.split(/[uU]/).collect{|s|s.to_i}
-      
+
       if( @diceBot.upplerRollThreshold == "Max" )
         @upper = diceMax;
       end
-      
-      total, diceString, cnt1, cnt_max, maxDiceResult, successCount, cnt_re = 
+
+      total, diceString, cnt1, cnt_max, maxDiceResult, successCount, cnt_re =
         @bcdice.roll(diceCount, diceMax, (@diceBot.sortType & 2), @upper, @signOfInequality, diceDiff);
-      
+
       diceStringList << diceString
-      
+
       totalSuccessCount += successCount;
       maxDiceValue = maxDiceResult if(maxDiceResult > maxDiceValue)
       totalDiceCount += diceCount;
       totalValue += total
     end
-    
+
     totalDiceString = diceStringList.join(",")
 
     return totalDiceString, totalSuccessCount, totalDiceCount, maxDiceValue, totalValue
   end
-  
+
 
 end

--- a/src/diceBot/Arianrhod.rb
+++ b/src/diceBot/Arianrhod.rb
@@ -1,52 +1,52 @@
 # -*- coding: utf-8 -*-
 
 class Arianrhod < DiceBot
-  
+
   def initialize
     super
     @sendMode = 2
     @sortType = 1
     @d66Type = 1
   end
-  
+
   def gameName
     'アリアンロッド'
   end
-  
+
   def gameType
     "Arianrhod"
   end
-  
+
   def getHelpMessage
     return <<INFO_MESSAGE_TEXT
 ・クリティカル、ファンブルの自動判定を行います。(クリティカル時の追加ダメージも表示されます)
 ・D66ダイスあり
 INFO_MESSAGE_TEXT
   end
-  
+
   def check_2D6(total_n, dice_n, signOfInequality, diff, dice_cnt, dice_max, n1, n_max)  # ゲーム別成功度判定(2D6)
     check_nD6(total_n, dice_n, signOfInequality, diff, dice_cnt, dice_max, n1, n_max)
   end
-  
+
   def check_nD6(total_n, dice_n, signOfInequality, diff, dice_cnt, dice_max, n1, n_max) # ゲーム別成功度判定(nD6)
     debug("check_nD6 begin")
-    
+
     # 全部１の目ならファンブル
     return " ＞ ファンブル" if(n1 >= dice_cnt)
-    
+
     # ２個以上６の目があったらクリティカル
     return " ＞ クリティカル(+#{n_max}D6)" if(n_max >= 2)
-    
+
     result = ''
-    
+
     return result unless(signOfInequality == ">=")
     return result if(diff == "?")
-    
+
     if(total_n >= diff)
       return " ＞ 成功"
     end
-    
+
     return " ＞ 失敗"
   end
-  
+
 end

--- a/src/diceBot/BeastBindTrinity.rb
+++ b/src/diceBot/BeastBindTrinity.rb
@@ -96,7 +96,7 @@ INFO_MESSAGE_TEXT
       debug("not mutch")
       return output
     end
-    
+
     # 各種値の初期設定
     humanity = 99					# 人間性（ゲームプレイ中の上限は60）
     critical = 12					# クリティカル値（基本値=12）
@@ -105,7 +105,7 @@ INFO_MESSAGE_TEXT
     nofumble = false				# ファンブルしても達成値が0にならないモードかどうかの判別
     dicepull = false				# 「出目●未満のダイス」を出目●として扱うモードが有効かどうかの判別
     pul_flg  = false				# 出目引き上げ機能が適用されたかどうかの確認
-    
+
     # 各種文字列の取得
     string    = $2					# ダイスボットで読み込んだ判定文全体
     dice_c    = $3.to_i				# 振るダイス数の取得
@@ -114,7 +114,7 @@ INFO_MESSAGE_TEXT
     diff      = 0					# 難易度
     bonusText = $4					# 修正値の取得
     bonus     = parren_killer("(0" + bonusText + ")").to_i unless( bonusText.nil? )
-    
+
     if($5)
       humanity = $6.to_i if($6)		# 人間性からクリティカル値を取得
       debug("▼現在人間性 取得 #{humanity}")
@@ -129,32 +129,32 @@ INFO_MESSAGE_TEXT
           debug("▼現在人間性からC値取得 #{critical}")
       end
     end
-    
+
     if($7)
       str_critical = $8 if($8)		# クリティカル値の文字列を取得
         debug("▼C値文字列 取得 #{str_critical}")
     end
-    
+
     if($9)
       nofumble = true if($10)		# ファンブル耐性指定
         debug("▼F値耐性 #{nofumble}")
       str_fumble = $11 if($11)		# ファンブル値の文字列を取得
         debug("▼F値文字列 取得 #{str_fumble}")
     end
-    
+
     if($12)
       str_dicesubs = $13 if($13)	# ダイス差し替え用の文字列を取得
         debug("▼出目予約用の文字列 取得 #{str_dicesubs}")
     end
-    
+
     if($14)
       dicepull = $15.to_i if($15)	# ダイス引き上げ用の文字列を取得
         debug("▼出目引き上げモード 取得 #{dicepull}")
     end
-    
+
     signOfInequality = $17 if($17);
     diff = $18.to_i if($18);
-    
+
     # 数値・数式からクリティカル値を決定
     if(str_critical)
       n_cri = eval(str_critical)
@@ -162,7 +162,7 @@ INFO_MESSAGE_TEXT
       critical = str_critical.match(/^[\+\-][\+\-\d]+/) ? [critical + n_cri, 12].min : n_cri
         debug("▼クリティカル値 #{critical}")
     end
-    
+
     # 数値・数式からファンブル値を決定
     if(str_fumble)
       n_fum = eval(str_fumble)
@@ -170,25 +170,25 @@ INFO_MESSAGE_TEXT
       fumble = str_fumble.match(/^[\+\-][\+\-\d]+/) ? fumble + n_fum : n_fum
         debug("▼ファンブル値 #{fumble}")
     end
-    
+
     # 出目予約の有無を確認
     if(str_dicesubs)
       for i in str_dicesubs.split(//) do dicesubs.push(i.to_i) if(dicesubs.size < dice_c) end
       debug("▼ダイス出目予約 #{dicesubs}")
     end
-    
+
     dice_now = 0
     dice_str = ""
     n_max = 0
     total_n = 0
-    
+
     cri_flg   = false
     cri_bonus = 0
     fum_flg   = false
     rer_num  = []
-    
+
     dice_tc = dice_c - dicesubs.size
-    
+
     if(dice_tc > 0)
       _, dice_str, = roll(dice_tc, 6, (sortType & 1))					# ダイス数修正、並べ替えせずに出力
       dice_num = (dice_str.split(/,/) + dicesubs).collect{|n|n.to_i} 	# 差し換え指定のダイスを挿入
@@ -197,50 +197,50 @@ INFO_MESSAGE_TEXT
     else
       dice_num = dicesubs												# 差し換えのみの場合は差し換え指定のみ（ダイスを振らない）
     end
-    
+
     dice_num.sort!														# 並べ替え
-    
+
     if(dicepull)														# 出目引き上げ機能
       debug("▼出目引き上げ #{dicepull}")
       dice_num_old = dice_num.dup
       for i in 0...dice_num.size do dice_num[i] = [dice_num[i], dicepull].max end
       pul_flg = dice_num == dice_num_old ? false : true
       debug("▼出目引き上げの有無について #{pul_flg}")
-      
+
       dice_num.sort!													# 置換後、再度並べ替え
       dold_str = dice_num_old.join(",")									# 置換前のダイス一覧を作成
     end
-    
+
     dice_str = dice_num.join(",")										# dice_strの取得
     if dice_c == 1
       dice_now = dice_num[dice_c - 1]									# ダイス数が1の場合、通常の処理だと配列の引数が「0」と「-1」となって二重に計算されるので処理を変更
     else
       dice_now = dice_num[dice_c - 2] + dice_num[dice_c - 1]			# 判定の出目を確定
     end
-    
+
     if(dice_now >= critical)											# クリティカル成立の判定
       cri_flg = true
       cri_bonus = 20
     end
-    
+
     total_n = [dice_now + bonus + cri_bonus, 0].max						# 達成値の最小値は0
-    
+
     if(fumble >= dice_now)												# ファンブル成立の判定
       fum_flg = true
       total_n = 0 unless nofumble
     end
-    
+
     dice_str = "[#{dice_str}]"
-    
+
     # 表示文章の作成
     output = ""
-    
+
     if(pul_flg)
       output += "[#{dold_str}] ＞ "
     end
-    
+
     output += "#{dice_now}#{dice_str}"
-    
+
     if(fum_flg == true && nofumble == false)
       output += "【ファンブル】"
     else
@@ -252,7 +252,7 @@ INFO_MESSAGE_TEXT
       end
       output += "+#{cri_bonus}【クリティカル】" if(cri_flg)
     end
-    
+
     showstring = "#{dice_c}R6"										# 結果出力文におけるダイスロール式の作成
     if(bonus > 0)													# （結果出力の時に必ずC値・F値を表示するようにする）
       showstring += "+#{bonus}"
@@ -263,7 +263,7 @@ INFO_MESSAGE_TEXT
     if(signOfInequality != "")
       showstring += "#{signOfInequality}#{diff}"
     end
-    
+
     if(sendMode > 0)												# 出力文の完成
       if(/[^\d\[\]]+/ =~ output)
         output = "#{@nick_e}: (#{showstring}) ＞ #{output} ＞ #{total_n}"
@@ -273,27 +273,27 @@ INFO_MESSAGE_TEXT
     else
       output = "#{@nick_e}: (#{showstring}) ＞ #{total_n}"
     end
-    
+
     if(signOfInequality != "")  # 成功度判定処理
       output += check_suc(total_n, dice_now, signOfInequality, diff, 2, 6, 0, 0)
     end
-    
+
     return output
   end
-  
+
   ####################           ビーストバインド トリニティ          ########################
   def rollDiceCommand(command)
     output = '1'
     type = ""
     total_n = 0
-    
+
     case command
-    
+
     # 邂逅表(d66)
     when /^EMO/i
       type = '邂逅表'
       output, total_n = bbt_emotion_table
-    
+
     # 暴露表
     when /^EXPO_([ABIJ])/
       case $1
@@ -311,7 +311,7 @@ INFO_MESSAGE_TEXT
           tabletype = 4
       end
       output, total_n = bbt_exposure_table(tabletype)
-      
+
     # 正体判明チャート
     when /^FACE_([ABC])/
       case $1
@@ -326,16 +326,16 @@ INFO_MESSAGE_TEXT
           tabletype = 3
       end
       output, total_n = bbt_face_table(tabletype)
-      
+
     end
-    
+
     if(output != '1')
       output = "#{type}(#{total_n}) ＞ #{output}"
     end
-    
+
     return output
   end
-  
+
   #**邂逅表(d66)
   def bbt_emotion_table
     table = [
@@ -346,10 +346,10 @@ INFO_MESSAGE_TEXT
       '友情',      '友情',      '忠誠',      '忠誠',      '恐怖',      '恐怖',
       '執着',      '執着',      '軽蔑',      '軽蔑',      '憎悪',      '憎悪',
     ]
-    
+
     return get_table_by_d66(table)
   end
-  
+
   #**暴露表（暴露表、魔獣化暴露表、アイドル専用暴露表、アイドル専用魔獣化暴露表）
   def bbt_exposure_table(type)
     case type
@@ -396,7 +396,7 @@ INFO_MESSAGE_TEXT
     end
     return get_table_by_1d6(table)
   end
-  
+
   #**正体判明チャート（正体判明チャートA～C）
   def bbt_face_table(type)
     case type

--- a/src/diceBot/ChaosFlare.rb
+++ b/src/diceBot/ChaosFlare.rb
@@ -12,34 +12,34 @@ class ChaosFlare < DiceBot
       @@bcdice.cardTrader.canTapCard = false
     end
   end
-  
+
   def gameName
     'カオスフレア'
   end
-  
+
   def gameType
     "Chaos Flare"
   end
-  
+
   def getHelpMessage
     return <<INFO_MESSAGE_TEXT
 失敗、成功の判定。差分値の計算も行います。
 ファンブル時は達成値を-20します。
 INFO_MESSAGE_TEXT
   end
-  
-  
+
+
   # ゲーム別成功度判定(2D6)
   def check_2D6(total_n, dice_n, signOfInequality, diff, dice_cnt, dice_max, n1, n_max)
     output = ''
-    
+
     if(dice_n <= 2)
       total_n -= 20
       output += " ＞ ファンブル(-20)"
     end
-    
+
     return output unless(signOfInequality == ">=")
-    
+
     if(total_n >= diff)
       output += " ＞ 成功"
       if(total_n > diff)
@@ -49,8 +49,8 @@ INFO_MESSAGE_TEXT
       output += " ＞ 失敗"
       output += " ＞ 差分値#{total_n-diff}"
     end
-    
+
     return output
   end
-  
+
 end

--- a/src/diceBot/Chill3.rb
+++ b/src/diceBot/Chill3.rb
@@ -1,15 +1,15 @@
 # -*- coding: utf-8 -*-
 
 class Chill3 < DiceBot
-  
+
   def gameName
     'Chill 3'
   end
-  
+
   def gameType
     "Chill3"
   end
-  
+
   def getHelpMessage
     info = <<INFO_MESSAGE_TEXT
 ・1D100で判定時に成否、Botchを判定
@@ -17,19 +17,19 @@ class Chill3 < DiceBot
 　　　Chill3 : (1D100<=50) ＞ 55 ＞ Botch
 INFO_MESSAGE_TEXT
   end
-  
+
   def check_1D100(total_n, dice_n, signOfInequality, diff, dice_cnt, dice_max, n1, n_max)     # ゲーム別成功度判定(1D100)
-    
+
     return '' unless(signOfInequality == "<=")
-    
+
     #ゾロ目ならC-ResultかBotch
     s10 = dice_n.div(10)  # 10'sダイスの出目
     s1 = dice_n % 10  # 1'sダイスの出目
-    
+
     if( s10 == 10 )
       s10 = 0  # 10'sと1'sの表記をそろえる
     end
-    
+
     if(s10 == s1)
       if((total_n > diff) || (dice_n == 100))   # 00は必ず失敗
         if(diff > 100)  # 目標値が100を超えている場合は、00を振ってもBotchにならない
@@ -39,14 +39,14 @@ INFO_MESSAGE_TEXT
       end
       return " ＞ Ｃ成功"
     end
-    
+
     if((total_n <= diff) || (dice_n == 1))  #01は必ず成功
       if(total_n <= (diff / 2))
         return " ＞ Ｈ成功"
       end
       return " ＞ Ｌ成功"
     end
-    
+
     return " ＞ 失敗"
   end
 

--- a/src/diceBot/CthulhuTech.rb
+++ b/src/diceBot/CthulhuTech.rb
@@ -1,21 +1,21 @@
 # -*- coding: utf-8 -*-
 
 class CthulhuTech < DiceBot
-  
+
   def initialize
     super
     @sendMode = 2
     @sortType = 1
   end
-  
+
   def gameName
     'クトゥルフテック'
   end
-  
+
   def gameType
     "CthulhuTech"
   end
-  
+
   def getHelpMessage
     return <<INFO_MESSAGE_TEXT
 テストのダイス計算を実装。
@@ -23,67 +23,67 @@ class CthulhuTech < DiceBot
 コンバットテスト(防御側有利なので「>=」ではなく「>」で入力)の時はダメージダイスも表示。
 INFO_MESSAGE_TEXT
   end
-  
+
   def check_nD10(total_n, dice_n, signOfInequality, diff, dice_cnt, dice_max, n1, n_max)# ゲーム別成功度判定(nD10)
     if(signOfInequality == ">=")    # 通常のテスト
       @isCombatTest = false
       return check_nD10_nomalTest(total_n, dice_n, signOfInequality, diff, dice_cnt, dice_max, n1, n_max)
     end
-    
+
     if(signOfInequality == ">") # コンバットテスト
       @isCombatTest = true
       return check_nD10_combatTest(total_n, dice_n, signOfInequality, diff, dice_cnt, dice_max, n1, n_max)
     end
-    
+
   end
-  
-  
+
+
   def check_nD10_nomalTest(total_n, dice_n, signOfInequality, diff, dice_cnt, dice_max, n1, n_max)
-    
+
     if( n1 >= (dice_cnt / 2 + 0.9).to_i )
       return " ＞ ファンブル"
     end
-    
+
     isSuccess = false
     if( @isCombatTest )
       isSuccess = (total_n > diff)
     else
       isSuccess = (total_n >= diff)
     end
-    
+
     unless( isSuccess )
       return " ＞ 失敗"
     end
-    
+
     if(total_n >= diff + 10)
       return " ＞ クリティカル"
     end
-    
+
     return " ＞ 成功"
   end
-  
-  
+
+
   def check_nD10_combatTest(total_n, dice_n, signOfInequality, diff, dice_cnt, dice_max, n1, n_max)
     result = check_nD10_nomalTest(total_n, dice_n, signOfInequality, diff, dice_cnt, dice_max, n1, n_max)
-    
+
     case result
     when " ＞ クリティカル", " ＞ 成功"
       result += getDamageDice(total_n, diff)
     end
-    
+
     return result
   end
-  
+
   def getDamageDice(total_n, diff)
     debug('getDamageDice total_n, diff', total_n, diff)
     damageDiceCount = ((total_n - diff) / 5.0).ceil
     debug('damageDiceCount', damageDiceCount)
     damageDice = "(#{damageDiceCount}d10)"   # ダメージダイスの表示
-    
+
     return damageDice
   end
-  
-  
+
+
   #ダイス目文字列からダイス値を変更する場合の処理
   #クトゥルフ・テックの判定用ダイス計算
   def changeDiceValueByDiceText(dice_now, dice_str, isCheckSuccess, dice_max)
@@ -94,27 +94,27 @@ INFO_MESSAGE_TEXT
       dice_now = cthulhutech_check(dice_str)
     end
     debug('dice_str, dice_now', dice_str, dice_now)
-    
+
     return dice_now
   end
-  
-  
+
+
   ####################           CthulhuTech         ########################
   #CthulhuTechの判定用ダイス計算
   def cthulhutech_check (dice_str)
     dice_aRR = dice_str.split(/,/).collect{|i|i.to_i}
-    
+
     dice_num = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
     max_num = 0
-    
+
     dice_aRR.each do |dice_n|
       dice_num[(dice_n - 1)] += 1
-      
+
       if(dice_n > max_num)  # 1.個別のダイスの最大値
         max_num = dice_n
       end
     end
-    
+
     if(dice_aRR.length >= 2)  # ダイスが2個以上ロールされている
       10.times do |i|
         if(dice_num[i] > 1) # 2.同じ出目の合計値
@@ -122,29 +122,29 @@ INFO_MESSAGE_TEXT
           max_num = dice_now if(dice_now > max_num)
         end
       end
-      
+
       if(dice_aRR.length >= 3)  # ダイスが3個以上ロールされている
         10.times do |i|
           break if( dice_num[i + 2] == nil )
-          
+
           if(dice_num[i] > 0)
             if( (dice_num[i + 1] > 0) and (dice_num[i + 2] > 0) )    # 3.連続する出目の合計
               dice_now = i * 3 + 6  # ($i+1) + ($i+2) + ($i+3) = $i*3 + 6
-              
+
               ((i + 3)...10).step do |i2|
                 break if(dice_num[i2] == 0)
-                
+
                 dice_now += i2 + 1
               end
-              
+
               max_num = dice_now if(dice_now > max_num)
             end
           end
         end
       end
     end
-    
+
     return max_num
   end
-  
+
 end

--- a/src/diceBot/DarkDaysDrive.rb
+++ b/src/diceBot/DarkDaysDrive.rb
@@ -74,10 +74,10 @@ INFO_MESSAGE_TEXT
     when 'RTT'   # ランダム特技決定表
       return getRandomSkillTableResult(command)
     end
-    
+
     return getTableDiceCommandResult(command)
   end
-  
+
 
   # 指定特技ランダム決定表
   def getRandomSkillTableResult(command)
@@ -133,7 +133,7 @@ INFO_MESSAGE_TEXT
 
     return "#{name}(#{number}) ＞ #{text}"
   end
-  
+
   def getD66Table(table)
     table.map do |item|
       if item.kind_of?(String) and  /^(\d+):(.*)/ === item
@@ -143,8 +143,8 @@ INFO_MESSAGE_TEXT
       end
     end
   end
-  
-  
+
+
   @@tables =
     {
     'ABRT' => {
@@ -173,7 +173,7 @@ INFO_MESSAGE_TEXT
 56:用心棒(P158)
 66:料理人(P158)
 },},
-    
+
     'DT' => {
       :name => "ダメージ表",
       :type => '1D6',

--- a/src/diceBot/DiceBot.rb
+++ b/src/diceBot/DiceBot.rb
@@ -49,10 +49,10 @@ class DiceBot
   clearPrefixes
 
   @@bcdice = nil
-  
+
   @@DEFAULT_SEND_MODE = 2                  # デフォルトの送信形式(0=結果のみ,1=0+式,2=1+ダイス個別)
 
-  
+
   def initialize
     @sendMode = @@DEFAULT_SEND_MODE #(0=結果のみ,1=0+式,2=1+ダイス個別)
     @sortType = 0      #ソート設定(1 = 足し算ダイスでソート有, 2 = バラバラロール（Bコマンド）でソート有, 3 = １と２両方ソート有）
@@ -66,7 +66,7 @@ class DiceBot
     @defaultSuccessTarget = ""      #目標値が空欄の時の目標値
     @rerollLimitCount = 10000    #振り足し回数上限
     @fractionType = "omit"     #端数の処理 ("omit"=切り捨て, "roundUp"=切り上げ, "roundOff"=四捨五入)
-    
+
     @gameType = 'DiceBot'
 
     if !prefixs.empty? && self.class.prefixes.empty?
@@ -76,13 +76,13 @@ class DiceBot
       self.class.setPrefixes(prefixs)
     end
   end
-  
+
   attr_accessor :rerollLimitCount
-  
+
   attr_reader :sendMode, :sameDiceRerollCount, :sameDiceRerollType, :d66Type
   attr_reader :isPrintMaxDice, :upplerRollThreshold, :unlimitedRollDiceType
   attr_reader :defaultSuccessTarget, :rerollNumber, :fractionType
-  
+
   # ダイスボット設定後に行う処理
   # @return [void]
   #
@@ -90,7 +90,7 @@ class DiceBot
   def postSet
     # 何もしない
   end
-  
+
   def info
     {
       'name' => gameName,
@@ -99,7 +99,7 @@ class DiceBot
       'info' => getHelpMessage,
     }
   end
-  
+
   def gameName
     gameType
   end
@@ -116,121 +116,121 @@ class DiceBot
   def gameType
     @gameType
   end
-  
+
   def setGameType(type)
     @gameType = type
   end
-  
+
   def setSendMode(m)
     @sendMode = m
   end
-  
+
   def upplerRollThreshold=(v)
     @upplerRollThreshold = v
   end
-  
+
   def bcdice=(b)
     @@bcdice = b
   end
-  
+
   def bcdice
     @@bcdice
   end
-  
+
   def rand(max)
     @@bcdice.rand(max)
   end
-  
+
   def check_suc(*params)
     @@bcdice.check_suc(*params)
   end
-  
+
   def roll(*args)
     @@bcdice.roll(*args)
   end
-  
+
   def marshalSignOfInequality(*args)
     @@bcdice.marshalSignOfInequality(*args)
   end
-  
+
   def unlimitedRollDiceType
     @@bcdice.unlimitedRollDiceType
   end
-  
+
   def sortType
     @sortType
   end
-  
+
   def setSortType(s)
     @sortType = s
   end
-  
-  
+
+
   def d66(*args)
     @@bcdice.getD66Value(*args)
   end
-  
+
   def rollDiceAddingUp(*arg)
     @@bcdice.rollDiceAddingUp(*arg)
   end
-  
+
   def getHelpMessage
     ''
   end
-  
+
   def parren_killer(string)
     @@bcdice.parren_killer(string)
   end
-  
+
   def changeText(string)
     debug("DiceBot.parren_killer_add called")
     string
   end
-  
+
   def dice_command(string, nick_e)
     string = @@bcdice.getOriginalMessage if( isGetOriginalMessage )
-    
+
     debug('dice_command Begin string', string)
     secret_flg = false
-    
+
     unless self.class.prefixesPattern =~ string
       debug('not match in prefixes')
-      return '1', secret_flg 
+      return '1', secret_flg
     end
-    
+
     secretMarker = $2
     command = $3
-    
+
     command = removeDiceCommandMessage(command)
     debug("dicebot after command", command)
-    
+
     debug('match')
-    
+
     output_msg, secret_flg = rollDiceCommandCatched(command)
     output_msg = '1' if( output_msg.nil? or output_msg.empty? )
     secret_flg ||= false
-    
+
     output_msg = "#{nick_e}: #{output_msg}" if(output_msg != '1')
-    
+
     if( secretMarker )   # 隠しロール
       secret_flg = true if(output_msg != '1')
     end
-    
+
     return output_msg, secret_flg
   end
-  
+
   #通常ダイスボットのコマンド文字列は全て大文字に強制されるが、
   #これを嫌う場合にはこのメソッドを true を返すようにオーバーライドすること。
   def isGetOriginalMessage
     false
   end
-  
+
   def removeDiceCommandMessage(command)
     # "2d6 Attack" のAttackのようなメッセージ部分をここで除去
     command.sub(/[\s　].+/, '')
   end
-  
-  
+
+
   def rollDiceCommandCatched(command)
     result = nil
     begin
@@ -239,42 +239,42 @@ class DiceBot
     rescue => e
       debug("executeCommand exception", e.to_s, $@.join("\n"))
     end
-    
+
     debug('rollDiceCommand result', result)
-    
+
     return result, secret_flg
   end
-  
+
   def rollDiceCommand(command)
     nil
   end
 
-  
+
   def setDiceText(diceText)
     debug("setDiceText diceText", diceText)
     @diceText = diceText
   end
-  
+
   def setDiffText(diffText)
     @diffText = diffText
   end
-  
+
   def dice_command_xRn(string, nick_e)
     ''
   end
-  
+
   def check_2D6(total_n, dice_n, signOfInequality, diff, dice_cnt, dice_max, n1, n_max)  # ゲーム別成功度判定(2D6)
     ''
   end
-  
+
   def check_nD6(total_n, dice_n, signOfInequality, diff, dice_cnt, dice_max, n1, n_max) # ゲーム別成功度判定(nD6)
     ''
   end
-  
+
   def check_nD10(total_n, dice_n, signOfInequality, diff, dice_cnt, dice_max, n1, n_max)# ゲーム別成功度判定(nD10)
     ''
   end
-  
+
   def check_1D100(total_n, dice_n, signOfInequality, diff, dice_cnt, dice_max, n1, n_max)    # ゲーム別成功度判定(1d100)
     ''
   end
@@ -282,94 +282,94 @@ class DiceBot
   def check_1D20(total_n, dice_n, signOfInequality, diff, dice_cnt, dice_max, n1, n_max)     # ゲーム別成功度判定(1d20)
     ''
   end
-  
-  
+
+
   def get_table_by_2d6(table)
     get_table_by_nD6(table, 2)
   end
-  
+
   def get_table_by_1d6(table)
     get_table_by_nD6(table, 1)
   end
-  
+
   def get_table_by_nD6(table, count)
     get_table_by_nDx(table, count, 6)
   end
-  
+
   def get_table_by_nDx(table, count, diceType)
     num, = roll(count, diceType)
-    
+
     text = getTableValue(table[num - count])
-    
+
     return '1', 0  if( text.nil? )
     return text, num
   end
-  
-  
+
+
   def get_table_by_1d3(table)
     debug("get_table_by_1d3")
 
     count = 1
     num, = roll(count, 6)
     debug("num", num)
-    
+
     index = ((num - 1)/ 2)
     debug("index", index)
-    
+
     text = table[index]
-    
+
     return '1', 0  if( text.nil? )
     return text, num
   end
-  
+
   def getD66(isSwap)
     number = bcdice.getD66(isSwap)
   end
-  
+
   # D66 ロール用（スワップ、たとえば出目が【６，４】なら「６４」ではなく「４６」とする
   def get_table_by_d66_swap(table)
     isSwap = true
     number = bcdice.getD66(isSwap)
     return get_table_by_number(number, table), number
   end
-  
+
   # D66 ロール用
   def get_table_by_d66(table)
     dice1, dummy = roll(1, 6)
     dice2, dummy = roll(1, 6)
-    
+
     num = (dice1 - 1) * 6 + (dice2 - 1)
-    
+
     text = table[num]
-    
+
     indexText = "#{dice1}#{dice2}"
-    
+
     return '1', indexText  if( text.nil? )
     return text, indexText
   end
-  
-  
-  
+
+
+
   #ダイスロールによるポイント等の取得処理用（T&T悪意、ナイトメアハンター・ディープ宿命、特命転校生エクストラパワーポイントなど）
   def getDiceRolledAdditionalText(n1, n_max, dice_max)
     ''
   end
-  
+
   #ダイス目による補正処理（現状ナイトメアハンターディープ専用）
   def getDiceRevision(n_max, dice_max, total_n)
     return '', 0
   end
-  
+
   #ダイス目文字列からダイス値を変更する場合の処理（現状クトゥルフ・テック専用）
   def changeDiceValueByDiceText(dice_now, dice_str, isCheckSuccess, dice_max)
     dice_now
   end
-  
+
   #SW専用
   def setRatingTable(nick_e, tnick, channel_to_list)
     '1'
   end
-  
+
   #振り足し時のダイス読み替え処理用（ダブルクロスはクリティカルでダイス10に読み替える)
   def getJackUpValueOnAddRoll(dice_n)
     0
@@ -379,44 +379,44 @@ class DiceBot
   def isD9
     false
   end
-  
+
   #シャドウラン4版用グリッチ判定
   def getGrichText(numberSpot1, dice_cnt_total, suc)
     ''
   end
-  
+
   # SW2.0 の超成功用
   def check2dCritical(critical, dice_new, dice_arry, loop_count)
   end
-  
+
   def is2dCritical
     false
   end
-  
+
   def getDiceList
     getDiceListFromDiceText(@diceText)
   end
-  
+
   def getDiceListFromDiceText(diceText)
     debug("getDiceList diceText", diceText)
-    
+
     diceList = []
-    
+
     if( /\[([\d,]+)\]/ =~ diceText )
       diceText = $1
     end
-    
+
     return diceList unless( /([\d,]+)/ =~ diceText )
-    
+
     diceString = $1
     diceList = diceString.split(/,/).collect{|i| i.to_i}
-    
+
     debug("diceList", diceList)
-    
+
     return diceList
   end
 
-  
+
   #** 汎用表サブルーチン
   def get_table_by_number(index, table, default = '1')
     table.each do |item|
@@ -425,43 +425,43 @@ class DiceBot
         return getTableValue( item[1] )
       end
     end
-    
+
     return getTableValue( default )
   end
-  
+
   def getTableValue(data)
     if( data.kind_of?( Proc ) )
       return data.call()
     end
-    
+
     return data
   end
-  
-  
-  
+
+
+
   def analyzeDiceCommandResultMethod(command)
-    
+
     # get～DiceCommandResultという名前のメソッドを集めて実行、
     # 結果がnil以外の場合それを返して終了。
     methodList = public_methods(false).select do |method|
       /^get.+DiceCommandResult$/ === method.to_s
     end
-    
+
     methodList.each do |method|
       result = send(method, command)
       return result unless result.nil?
     end
-    
+
     return nil
   end
-  
-  
+
+
   def get_table_by_nDx_extratable(table, count, diceType)
     number, diceText = roll(count, diceType)
     text = getTableValue(table[number - count])
     return text, number, diceText
   end
-  
+
   def getTableCommandResult(command, tables, isPrintDiceText = true)
 
     info = tables[command]
@@ -474,8 +474,8 @@ class DiceBot
     if type == 'D66' and @d66Type == 2
       type = 'D66S'
     end
-    
-    
+
+
     text, number, diceText =
       case type
       when /(\d+)D(\d+)/
@@ -503,13 +503,13 @@ class DiceBot
 
     text = text.gsub("\\n", "\n")
     text = @@bcdice.rollTableMessageDiceText(text)
-    
+
     return nil if( text.nil? )
 
     return "#{name}(#{number}[#{diceText}]) ＞ #{text}" if isPrintDiceText and (not diceText.nil?)
     return "#{name}(#{number}) ＞ #{text}"
   end
-  
+
   def getTableInfoFromExtraTableText(text, count = nil)
     if text.kind_of?(String)
       text = text.split(/\n/)
@@ -528,8 +528,8 @@ class DiceBot
         raise "invalid table size:#{newTable.size}\n#{newTable.inspect}"
       end
     end
-    
+
     return newTable
   end
-  
+
 end

--- a/src/diceBot/DungeonsAndDoragons.rb
+++ b/src/diceBot/DungeonsAndDoragons.rb
@@ -1,23 +1,23 @@
 # -*- coding: utf-8 -*-
 
 class DungeonsAndDoragons < DiceBot
-  
+
   def initialize
     super
   end
-  
+
   def gameName
     'ダンジョンズ＆ドラゴンズ'
   end
-  
+
   def gameType
     "DungeonsAndDoragons"
   end
-  
+
   def getHelpMessage
     return <<MESSAGETEXT
 ※このダイスボットは部屋のシステム名表示用となります。
 MESSAGETEXT
   end
-  
+
 end

--- a/src/diceBot/EclipsePhase.rb
+++ b/src/diceBot/EclipsePhase.rb
@@ -1,46 +1,46 @@
 # -*- coding: utf-8 -*-
 
 class EclipsePhase < DiceBot
-  
+
   def initialize
     super
   end
   def gameName
     'エクリプス・フェイズ'
   end
-  
+
   def gameType
     "EclipsePhase"
   end
-  
+
   def getHelpMessage
     return <<INFO_MESSAGE_TEXT
 1D100<=m 方式の判定で成否、クリティカル・ファンブルを自動判定
 INFO_MESSAGE_TEXT
   end
-  
-  
+
+
   def check_1D100(total_n, dice_n, signOfInequality, diff, dice_cnt, dice_max, n1, n_max)\
-    
+
     return '' unless signOfInequality == '<='
-    
+
     diceValue = total_n % 100 # 出目00は100ではなく00とする
     dice_ten_place = diceValue / 10
     dice_one_place = diceValue % 10
-    
+
     debug("total_n", total_n)
     debug("dice_ten_place, dice_one_place", dice_ten_place, dice_one_place)
-    
+
     if dice_ten_place == dice_one_place
       return ' ＞ 決定的失敗' if diceValue == 99
       return ' ＞ 00 ＞ 決定的成功' if diceValue == 0
       return ' ＞ 決定的成功' if total_n <= diff
       return ' ＞ 決定的失敗'
     end
-    
-    
+
+
     diff_threshold = 30
-    
+
     if (total_n <= diff)
       return ' ＞ エクセレント' if total_n >= diff_threshold
       return ' ＞ 成功'
@@ -48,8 +48,8 @@ INFO_MESSAGE_TEXT
       return ' ＞ シビア' if (total_n - diff) >= diff_threshold
       return ' ＞ 失敗'
     end
-    
+
   end
-  
-  
+
+
 end

--- a/src/diceBot/Elric.rb
+++ b/src/diceBot/Elric.rb
@@ -4,31 +4,31 @@ class Elric < DiceBot
   def gameName
     'エルリック！'
   end
-  
+
   def gameType
     "Elric!"
   end
-  
+
   def getHelpMessage
     return <<INFO_MESSAGE_TEXT
 貫通、クリティカル、ファンブルの自動判定を行います。
 INFO_MESSAGE_TEXT
   end
-  
-  
+
+
   # ゲーム別成功度判定(1d100)
   def check_1D100(total_n, dice_n, signOfInequality, diff, dice_cnt, dice_max, n1, n_max)
     return '' unless(signOfInequality == "<=")
-    
+
     # 1は常に貫通
     return " ＞ 貫通" if(total_n <= 1)
     # 100は常に致命的失敗
     return " ＞ 致命的失敗" if(total_n >= 100)
-    
-    return " ＞ 決定的成功" if(total_n <= (diff / 5 + 0.9)) 
-    return " ＞ 成功"       if(total_n <= diff) 
-    return " ＞ 致命的失敗" if((total_n >= 99) and (diff < 100)) 
+
+    return " ＞ 決定的成功" if(total_n <= (diff / 5 + 0.9))
+    return " ＞ 成功"       if(total_n <= diff)
+    return " ＞ 致命的失敗" if((total_n >= 99) and (diff < 100))
     return " ＞ 失敗"
   end
-  
+
 end

--- a/src/diceBot/FutariSousa.rb
+++ b/src/diceBot/FutariSousa.rb
@@ -1,28 +1,28 @@
 # -*- coding: utf-8 -*-
 
 class FutariSousa < DiceBot
-  
+
   def initialize
     super
     @sendMode = 2
     @d66Type = 2
-    
+
     @success_threshold = 4 # 成功の目標値（固定）
     @special_dice = 6 # スペシャルとなる出目（ダイスの種別によらず固定）
   end
-  
+
   setPrefixes(
               ['(\d+)?DT', '(\d+)?AS', 'SHRD', 'SHFM', 'SHBT', 'SHPI', 'SHEG', 'SHWP', 'SHDS', 'SHFT', 'SHIN', 'SHEM', 'EVS', 'EVW', 'EVN', 'EVC', 'EVV', 'OBT', 'ACT', 'EWT', 'WMT', 'BGDD', 'BGDG', 'BGDM', 'BGAJ', 'BGAP', 'BGAI', 'HT', 'BT', 'GRT', 'MIT', 'JBT66', 'JBT10', 'FST66', 'FST10', 'FLT66', 'FLT10', 'LDT66', 'LDT10', 'NCT66', 'NCT10',])
-  
-  
+
+
   def gameName
     'フタリソウサ'
   end
-  
+
   def gameType
     "FutariSousa"
   end
-  
+
   def getHelpMessage
     return <<MESSAGETEXT
 ・判定用コマンド
@@ -48,11 +48,11 @@ class FutariSousa < DiceBot
 呼び名表A・B　NCT66・NCT10
 MESSAGETEXT
   end
-  
+
   def changeText(string)
     string
   end
-  
+
   def rollDiceCommand(command)
     output = '1'
     type = ""
@@ -192,54 +192,54 @@ MESSAGETEXT
 
   #DT
   def get_dt(count)
-    
+
     diceList = []
-    count.times do 
+    count.times do
       dice, =  roll(1 , 10)
       diceList << dice
     end
-    
+
     output = get_dt_result(diceList)
     diceText = diceList.join(",")
-    
+
     return output, diceText
   end
-  
+
   def get_dt_result(diceList)
     max = diceList.max
-    
+
     return "ファンブル（変調を受け、助手の心労が1点上昇）" if max <= 1
     return "スペシャル（助手の余裕を1点獲得）" if diceList.include?(@special_dice)
     return "成功" if max >= @success_threshold
     return "失敗"
   end
-  
-  
+
+
   #AS
   def get_as(count)
-    
+
     diceList = []
-    count.times do 
+    count.times do
       dice, =  roll(1 , 6)
       diceList << dice
     end
-    
+
     output = get_as_result(diceList)
     diceText = diceList.join(",")
-    
+
     return output, diceText
   end
 
   def get_as_result(diceList)
     max = diceList.max
-    
+
     return "ファンブル（変調を受け、心労が1点上昇）" if max <= 1
     return "スペシャル（余裕2点と、探偵から助手への感情を獲得）" if diceList.include?(@special_dice)
     return "成功（余裕1点と、探偵から助手への感情を獲得）"  if max >= @success_threshold
     return "失敗"
   end
-  
-  
+
+
 
   def getTableResult(table, dice)
     number, text, command = table.assoc(dice)
@@ -247,11 +247,11 @@ MESSAGETEXT
     if command.respond_to?(:call)
       text += command.call(self)
     end
-    
+
     return number, text
   end
 
-  
+
   def getAddRollProc(command)
     # 引数なしのlambda
     # Ruby 1.8と1.9以降で引数の個数の解釈が異なるため || が必要
@@ -282,10 +282,10 @@ MESSAGETEXT
              [10,'好きな「異常な癖」の表を使用する。'],
             ]
     diceText, = roll(1 , 10)
-    output = get_table_by_number(diceText, table)    
+    output = get_table_by_number(diceText, table)
     return output, diceText
   end
-  
+
   def get_strange_habit_from_mouth
     table = [
              [1, '猛烈に感謝の言葉を述べる'],
@@ -303,7 +303,7 @@ MESSAGETEXT
     output = get_table_by_number(diceText , table)
     return output, diceText
   end
-  
+
   def get_strange_habit_bull_through
     table = [
              [1, '勝手に捜査対象の鞄や引き出しを開ける'],
@@ -321,7 +321,7 @@ MESSAGETEXT
     output = get_table_by_number(diceText , table)
     return output, diceText
   end
-  
+
   def get_strange_habit_play_innocent
     table = [
              [1, '自分の身分を偽って関係者に話を聞く'],
@@ -339,7 +339,7 @@ MESSAGETEXT
     output = get_table_by_number(diceText , table)
     return output, diceText
   end
-  
+
   def get_strange_habit_engrossed
     table = [
              [1, 'パートナーの体を使って事件を再現しようとする'],
@@ -357,7 +357,7 @@ MESSAGETEXT
     output = get_table_by_number(diceText , table)
     return output, diceText
   end
-  
+
   def get_strange_habit_with_partner
     table = [
              [1, 'パートナーの信頼に甘える'],
@@ -393,7 +393,7 @@ MESSAGETEXT
     output = get_table_by_number(diceText , table)
     return output, diceText
   end
-  
+
   def get_strange_habit_fantastic
     table = [
              [1, 'やめろと言われていることをする'],
@@ -429,7 +429,7 @@ MESSAGETEXT
     output = get_table_by_number(diceText , table)
     return output, diceText
   end
-  
+
   def get_strange_habit_emotion
     table = [
              [1, '急に泣く'],
@@ -496,7 +496,7 @@ MESSAGETEXT
             ]
     return get_table_by_1d6(table)
   end
-  
+
   def get_event_vs
     table = [
              "容疑者の嘘（P.189）\n　人は、何か後ろめたいことがあったとき、嘘をつく。\n　この容疑者は嘘をついている。\n　なら、何を隠しているのだろうか？",
@@ -508,7 +508,7 @@ MESSAGETEXT
             ]
     return get_table_by_1d6(table)
   end
-  
+
   #調査の障害表
   def get_obstruction_table
     table = [
@@ -564,7 +564,7 @@ MESSAGETEXT
     return get_table_by_1d6(table)
   end
 
-  #迷宮入り表  
+  #迷宮入り表
   def get_wrapped_in_mystery_table
     table = [
              [1, '真犯人とは別の人間が犯人にされてしまい、実刑を食らってしまった。その証拠はないが、そう直感できる。'],
@@ -583,7 +583,7 @@ MESSAGETEXT
     output = get_table_by_number(diceText , table)
     return output, diceText
   end
-  
+
   #背景表
   def get_background_detective_destiny
     table = [
@@ -600,10 +600,10 @@ MESSAGETEXT
             ]
     diceText, = roll(1 , 10)
     output = get_table_by_number(diceText, table)
-    
+
     return output, diceText
   end
-  
+
   def get_background_detective_genius
     table = [
              [1,'『超エリート』自分はエリートとして活躍すべく、あらゆる分野の訓練を行った。そして、望まれるままに優秀な人間となった。'],
@@ -619,7 +619,7 @@ MESSAGETEXT
             ]
     diceText, = roll(1 , 10)
     output = get_table_by_number(diceText, table)
-    
+
     return output, diceText
   end
 
@@ -638,10 +638,10 @@ MESSAGETEXT
             ]
     diceText, = roll(1 , 10)
     output = get_table_by_number(diceText, table)
-    
+
     return output, diceText
   end
-  
+
   def get_background_assistant_justice
     table = [
              '『お人よし』自分は他者からよくお人よしと言われている。そのため、人に頼まれて事件に絡むことがよくあった。だから、人の悩みを解決できる能力があるパートナーと一緒にいる。',
@@ -653,7 +653,7 @@ MESSAGETEXT
             ]
     return get_table_by_1d6(table)
   end
-  
+
   def get_background_assistant_passion
     table = [
              '『能力にほれ込んだ』自分はパートナーの事件に関する能力にほれ込んだ。その鋭い洞察力や、推理力、知識の深さ。すべてが自分を魅了している。',
@@ -665,7 +665,7 @@ MESSAGETEXT
             ]
     return get_table_by_1d6(table)
   end
-  
+
   def get_background_assistant_involved
     table = [
              '『一方的に気に入られた』パートナーから、一方的に気に入られている。どうしてそうなったのかはわからないが、そういうものらしい。一緒にいるのは、不本意なのだけど……。',
@@ -738,7 +738,7 @@ MESSAGETEXT
             ]
     return get_table_by_d66_swap(table)
   end
-  
+
   #思い出の品決定表
   def get_memorial_item_table
     table = [
@@ -892,7 +892,7 @@ MESSAGETEXT
 
     return get_table_by_d66_swap(table)
   end
-  
+
   #好きなもの／嫌いなもの表B
   def get_like_dislike_table_10
     table = [
@@ -989,7 +989,7 @@ MESSAGETEXT
 
     return get_table_by_d66_swap(table)
   end
-  
+
   #呼び名表B
   def get_name_to_call_table_10
     table = [
@@ -1010,5 +1010,5 @@ MESSAGETEXT
 
     return output, diceText
   end
-  
+
 end

--- a/src/diceBot/Gundog.rb
+++ b/src/diceBot/Gundog.rb
@@ -1,53 +1,53 @@
 # -*- coding: utf-8 -*-
 
 class Gundog < DiceBot
-  
+
   def gameName
     'ガンドッグ'
   end
-  
+
   def gameType
     "Gundog"
   end
-  
+
   def getHelpMessage
     return <<INFO_MESSAGE_TEXT
 失敗、成功、クリティカル、ファンブルとロールの達成値の自動判定を行います。
 nD9ロールも対応。
 INFO_MESSAGE_TEXT
   end
-  
+
   # ゲーム別成功度判定(1d100)
   def check_1D100(total_n, dice_n, signOfInequality, diff, dice_cnt, dice_max, n1, n_max)
-    
+
     return '' unless(signOfInequality == "<=")
-    
+
     if(total_n >= 100)
       return " ＞ ファンブル"
     end
-    
-    if(total_n <= 1) 
+
+    if(total_n <= 1)
       return " ＞ 絶対成功(達成値1+SL)"
     end
-    
+
     if(total_n <= diff)
       dig10 = (total_n / 10).to_i
       dig1 = (total_n) - dig10 * 10
       dig10 = 0 if(dig10 >= 10)
       dig1 = 0 if(dig1 >= 10)  # 条件的にはあり得ない(笑
-      
+
       if(dig1 <= 0)
         return " ＞ クリティカル(達成値20+SL)"
       end
-      
+
       return " ＞ 成功(達成値#{(dig10 + dig1)}+SL)"
     end
-    
+
     return " ＞ 失敗"
   end
-  
+
   def isD9
     true
   end
-  
+
 end

--- a/src/diceBot/HatsuneMiku.rb
+++ b/src/diceBot/HatsuneMiku.rb
@@ -7,7 +7,7 @@ class HatsuneMiku < DiceBot
     @sendMode = 2
     @d66Type = 2
   end
-  
+
   def gameName
     '初音ミクTRPG ココロダンジョン'
   end
@@ -25,8 +25,8 @@ class HatsuneMiku < DiceBot
 　z：スペシャル最低値（省略：6）　t：目標値（省略：4）
 　　例） RA　R2　RB+1　RC++　RD+,+2　RA>=5　RS-1@5>=6
 　結果はネイロを取得した残りで最大値を表示
-例） RB 
-　HatsuneMiku : (RB>=4) ＞ [3,5] ＞ 
+例） RB
+　HatsuneMiku : (RB>=4) ＞ [3,5] ＞
 　　ネイロに3(青)を取得した場合 5:成功
 　　ネイロに5(白)を取得した場合 3:失敗
 ・各種表
@@ -53,7 +53,7 @@ INFO_MESSAGE_TEXT
     when 'RTT'   # ランダム特技決定表
       return getRandomSkillTableResult(command)
     end
-    
+
     return getTableDiceCommandResult(command)
   end
 
@@ -64,31 +64,31 @@ INFO_MESSAGE_TEXT
     modifyText = $3
     signOfInequality = ( $7.nil? ? ">=" : $7 )
     targetText = ( $9.nil? ? "4" : $9 )
-    
+
     specialNum = $5
     specialNum ||= $11
     specialNum ||= 6
     specialNum = specialNum.to_i
     specialText = ( specialNum == 6 ? "" : "@#{specialNum}" )
-    
+
     modifyText = getChangedModifyText(modifyText)
-    
+
     commandText = "R#{skillRank}#{modifyText}"
-    
+
     rankDiceList = { "S" => 4, "A" => 3, "B" => 2, "C" => 1, "D" => 2 }
     diceCount = rankDiceList[skillRank]
     diceCount = skillRank.to_i if /^\d+$/ === skillRank
-    
+
     modify = parren_killer("(" + modifyText + ")").to_i
     target = parren_killer("(" + targetText + ")").to_i
-    
+
     isSort = 1
     _, diceText, = roll(diceCount, 6, isSort)
     diceList = diceText.split(/,/).collect{|i| i.to_i}
     diceList = [diceList.min] if( skillRank == "D" )
 
     message = "(#{commandText}#{specialText}#{signOfInequality}#{targetText}) ＞ [#{diceText}]#{modifyText} ＞ "
-    
+
     if diceList.length <= 1
       dice = diceList.first
       total = dice + modify
@@ -102,7 +102,7 @@ INFO_MESSAGE_TEXT
         dice = rests.max
         total = dice + modify
         result = check_success(total, dice, signOfInequality, target, specialNum)
-        
+
         colorList = ["黒", "赤", "青", "緑", "白", "任意"]
         color = colorList[pickup_dice - 1]
         texts << "　ネイロに#{pickup_dice}(#{color})を取得した場合 #{total}:#{result}"
@@ -110,16 +110,16 @@ INFO_MESSAGE_TEXT
       texts.uniq!
       message += "\n" + texts.join("\n")
     end
-    
+
 
     return message
   end
-  
+
   def getChangedModifyText(text)
     modifyText = ""
     values = text.split(/,/)
-    
-    values.each do |value| 
+
+    values.each do |value|
       case value
       when "++"
         modifyText += "+2"
@@ -129,7 +129,7 @@ INFO_MESSAGE_TEXT
         modifyText += value
       end
     end
-    
+
     return modifyText
   end
 
@@ -142,7 +142,7 @@ INFO_MESSAGE_TEXT
     return "失敗"
   end
 
-  
+
   def getTableDiceCommandResult(command)
 
     info = @@tables[command]
@@ -169,7 +169,7 @@ INFO_MESSAGE_TEXT
 
     return "#{name}(#{number}) ＞ #{text}"
   end
-  
+
   def getD66Table(table)
     newTable = table.map do |item|
       if item.kind_of?(String) and  /^(\d+):(.*)/ === item
@@ -178,13 +178,13 @@ INFO_MESSAGE_TEXT
         item
       end
     end
-    
-    raise "invalid table size:#{newTable.size}\n#{newTable.inspect}" if newTable.size != 21 
-    
+
+    raise "invalid table size:#{newTable.size}\n#{newTable.inspect}" if newTable.size != 21
+
     return newTable
   end
-  
-  
+
+
   @@tables =
     {
     'FT' => {
@@ -210,7 +210,7 @@ INFO_MESSAGE_TEXT
 意識はあるが、立ち上がることができない。そのキャラクターは行動不能になる。次のシーンにまだ【生命力】が０点だった場合、自動的に１点に回復する。
 奇跡的に踏みとどまり、持ちこたえる。【生命力】が１点になる。
 },},
-    
+
     'BT' => {
       :name => "休憩表",
       :type => '1D6',
@@ -275,7 +275,7 @@ INFO_MESSAGE_TEXT
 そのエリアの風景にあなたの日常が浮かび上がる。「お前は何をしている？その暮らしをどう思っている？」
 あなたの目の前に、あなたの死体が横たわっている。「お前を殺すものは何だ？お前は誰に殺される？」
 },},
-    
+
     'ST' => {
       :name => "情景表",
       :type => 'D66',
@@ -302,7 +302,7 @@ INFO_MESSAGE_TEXT
 56:深夜のコンビニ
 66:誰もいない体育館
 },},
-    
+
     'DKT' => {
       :name => "ダーク・キーワード表",
       :type => 'D66',
@@ -383,7 +383,7 @@ INFO_MESSAGE_TEXT
 56:消せない炎
 66:オーバードライブ
 },},
-    
+
     'HNT' => {
       :name => "ホット・名前表",
       :type => 'D66',
@@ -437,7 +437,7 @@ INFO_MESSAGE_TEXT
 56:素敵な贈り物
 66:ビューティフルワールド
 },},
-    
+
     'LNT' => {
       :name => "ラブ・名前表",
       :type => 'D66',
@@ -702,7 +702,7 @@ INFO_MESSAGE_TEXT
       :name => "オトダマ呼び名表",
       :type => '2D6',
       :table => %w{
-ユー 
+ユー
 （ＰＣの名前）たん／きゅん
 同志（ＰＣの名前）
 キミ
@@ -745,6 +745,6 @@ INFO_MESSAGE_TEXT
 },},
 
   }
-  
+
   setPrefixes(['R([A-DS]|\d+).*'] + @@tables.keys)
 end

--- a/src/diceBot/Hieizan.rb
+++ b/src/diceBot/Hieizan.rb
@@ -1,21 +1,21 @@
 # -*- coding: utf-8 -*-
 
 class Hieizan < DiceBot
-  
+
   def gameName
     '比叡山炎上'
   end
-  
+
   def gameType
     "Hieizan"
   end
-  
+
   def getHelpMessage
     return <<INFO_MESSAGE_TEXT
 大成功、自動成功、失敗、自動失敗、大失敗の自動判定を行います。
 INFO_MESSAGE_TEXT
   end
-  
+
   # ゲーム別成功度判定(1d100)
   def check_1D100(total_n, dice_n, signOfInequality, diff, dice_cnt, dice_max, n1, n_max)
     if(total_n <= 1)  # 1は自動成功
@@ -24,24 +24,24 @@ INFO_MESSAGE_TEXT
       end
       return " ＞ 自動成功"
     end
-    
+
     if(total_n >= 100)
       return " ＞ 大失敗"    # 00は大失敗(大失敗は自動失敗でもある)
     end
-    
+
     if(total_n >= 96)
       return " ＞ 自動失敗"  # 96-00は自動失敗
     end
-    
+
     if((total_n <= diff))
-        
+
       if(total_n <= (diff / 5))
         return " ＞ 大成功"    # 目標値の1/5以下は大成功
       end
       return " ＞ 成功"
     end
-    
+
     return " ＞ 失敗"
   end
-  
+
 end

--- a/src/diceBot/InfiniteFantasia.rb
+++ b/src/diceBot/InfiniteFantasia.rb
@@ -1,37 +1,37 @@
 # -*- coding: utf-8 -*-
 
 class InfiniteFantasia < DiceBot
-  
+
   def gameName
     '無限のファンタジア'
   end
-  
+
   def gameType
     "InfiniteFantasia"
   end
-  
+
   def getHelpMessage
     return <<INFO_MESSAGE_TEXT
 失敗、成功レベルの自動判定を行います。
 INFO_MESSAGE_TEXT
   end
-  
-  
+
+
   # ゲーム別成功度判定(1d20)
   def check_1D20(total_n, dice_n, signOfInequality, diff, dice_cnt, dice_max, n1, n_max)
-    
+
     return '' unless(signOfInequality == "<=")
-    
-    return " ＞ 失敗" unless(total_n <= diff) 
-    
-    
+
+    return " ＞ 失敗" unless(total_n <= diff)
+
+
     critical = ""
-    
+
     if(total_n <= 1)
       critical = "/クリティカル"
     end
-    
-    
+
+
     if(total_n <= (diff / 32))
       return " ＞ 32レベル成功(32Lv+)#{critical}"
     elsif(total_n <= (diff / 16))
@@ -43,9 +43,9 @@ INFO_MESSAGE_TEXT
     elsif(total_n <= (diff / 2))
       return " ＞ 2レベル成功#{critical}"
     end
-    
+
     return " ＞ 1レベル成功#{critical}"
-    
+
   end
-  
+
 end

--- a/src/diceBot/IthaWenUa.rb
+++ b/src/diceBot/IthaWenUa.rb
@@ -1,35 +1,35 @@
 # -*- coding: utf-8 -*-
 
 class IthaWenUa < DiceBot
-  
+
   def initialize
     super
   end
-  
+
   def gameName
     'イサー・ウェン＝アー'
   end
-  
+
   def gameType
     "IthaWenUa"
   end
-  
+
   def getHelpMessage
     return <<MESSAGETEXT
 1D100<=m 方式の判定で成否、クリティカル(01)・ファンブル(00)を自動判定します。
 MESSAGETEXT
   end
-  
+
   def check_1D100(total_n, dice_n, signOfInequality, diff, dice_cnt, dice_max, n1, n_max)    # ゲーム別成功度判定(1d100)
     return '' unless( signOfInequality == '<=' )
-    
+
     diceValue = total_n % 100
     dice0 = diceValue / 10 #10の位を代入
     dice1 = diceValue % 10 # 1の位を代入
-    
+
     debug("total_n", total_n)
     debug("dice0, dice1", dice0, dice1)
-    
+
     if( (dice0 == 0) and (dice1 == 1) )
 
       return ' ＞ 01 ＞ クリティカル'

--- a/src/diceBot/JamesBond.rb
+++ b/src/diceBot/JamesBond.rb
@@ -1,15 +1,15 @@
 # -*- coding: utf-8 -*-
 
 class JamesBond < DiceBot
-  
+
   def gameName
     'ジェームズ・ボンド007'
   end
-  
+
   def gameType
     "JamesBond"
   end
-  
+
   def getHelpMessage
     info = <<INFO_MESSAGE_TEXT
 ・1D100の目標値判定で、効果レーティングを1～4で自動判定。
@@ -17,34 +17,34 @@ class JamesBond < DiceBot
 　　　JamesBond : (1D100<=50) → 20 → 効果3（良）
 INFO_MESSAGE_TEXT
   end
-  
+
   def check_1D100(total_n, dice_n, signOfInequality, diff, dice_cnt, dice_max, n1, n_max)    # ゲーム別成功度判定(1d100)
-    
+
     return '' unless(signOfInequality == "<=")
-    
+
     if(total_n >= 100)   # 100は常に失敗
       return " ＞ 失敗"
     end
-    
+
     base = ((diff + 9) / 10).floor
-    
-    if(total_n <= base) 
+
+    if(total_n <= base)
       return " ＞ 効果1（完璧）"
     end
-    
-    if(total_n <= base * 2) 
+
+    if(total_n <= base * 2)
       return " ＞ 効果2（かなり良い）"
     end
-    
-    if(total_n <= base * 5) 
+
+    if(total_n <= base * 5)
       return " ＞ 効果3（良）"
     end
-    
-    if(total_n <= diff) 
+
+    if(total_n <= diff)
       return " ＞ 効果4（まあまあ）"
     end
-    
+
     return " ＞ 失敗"
   end
-  
+
 end

--- a/src/diceBot/KillDeathBusiness.rb
+++ b/src/diceBot/KillDeathBusiness.rb
@@ -139,10 +139,10 @@ INFO_MESSAGE_TEXT
 
   def rollTableCommand(command)
 
-    
+
     result = getTableCommandResult(command, @@tables)
     return result unless result.nil?
-    
+
     tableName = ""
     result = ""
 

--- a/src/diceBot/KurayamiCrying.rb
+++ b/src/diceBot/KurayamiCrying.rb
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
 class KurayamiCrying < DiceBot
-  
+
   def initialize
     super
   end
@@ -27,17 +27,17 @@ MESSAGETEXT
       info = @@tables["ACT"]
       name = info[:name]
       table = getTableInfoFromExtraTableText(info[:table])
-      
+
       text = table[number]
-      
+
       result = "#{name}(#{number}) ＞ #{text}"
       return text
     end
     result = getTableCommandResult(command, @@tables)
     return result unless result.nil?
   end
-  
-  
+
+
   @@tables =
     {
 
@@ -57,9 +57,9 @@ MESSAGETEXT
 まるで自分を支える何かが失われたように、あなたはその場に立ち尽くす。諦めと絶望が心を支配する。ああ、そうか。これが、「心が折れる」ということか……。あなたは「理性」を4点失う。
 TABLE_TEXT_END
     },
-    
+
   }
-  
+
   setPrefixes(["ACT.*"] + @@tables.keys)
 
 end

--- a/src/diceBot/LiveraDoll.rb
+++ b/src/diceBot/LiveraDoll.rb
@@ -64,7 +64,7 @@ MESSAGETEXT
         blockNo.delete(0)
         blockNo = blockNo.sort
         blockNo = blockNo.uniq
-        
+
         output = checkRoll(diceCount, blockNo)
 
       when /^(C|K|W|R|B|G|E)(L|D|O)(\d+)$/i
@@ -83,7 +83,7 @@ MESSAGETEXT
   def checkRoll(diceCount, blockNo)
     dice, diceText = roll(diceCount, 6, @sortType)
     diceArray = diceText.split(/,/).collect{|i|i.to_i}
-    
+
     resultArray = Array.new
     success = 0
     diceArray.each do |i|
@@ -94,12 +94,12 @@ MESSAGETEXT
         success += 1
       end
     end
-    
+
     blockText = blockNo.join(',')
     resultText = resultArray.join(',')
-    
+
     result = "#{diceCount}D6(Block:#{blockText}) ＞ #{diceText} ＞ #{resultText} ＞ 成功数：#{success}"
-    
+
     return result
   end
 

--- a/src/diceBot/MagicaLogia.rb
+++ b/src/diceBot/MagicaLogia.rb
@@ -808,7 +808,7 @@ INFO_MESSAGE_TEXT
              '大勢で賑わう広場。祭りでも行われているのだろうか？ 誰かを呼ぶ声が聞こえる。そのシーンに獣の魔素が1点発生する。',
              '悲劇の予感。家族の不幸、友の絶望、仲間の死......このままだと起きてしまうかもしれない出来事の幻が見える。そのシーンに闇の魔素が1点発生する。',
             ]
-    
+
     return get_table_by_2d6(table)
   end
   # 指定特技（星）
@@ -816,7 +816,7 @@ INFO_MESSAGE_TEXT
     table = [
              '黄金', '大地', '森', '道', '海', '静寂', '雨', '嵐', '太陽', '天空', '異界',
             ]
-    
+
     return get_table_by_2d6(table)
   end
   # 指定特技（獣）
@@ -824,7 +824,7 @@ INFO_MESSAGE_TEXT
     table = [
              '肉', '蟲', '花', '血', '鱗', '混沌', '牙', '叫び', '怒り', '翼', 'エロス',
             ]
-    
+
     return get_table_by_2d6(table)
   end
   # 指定特技（力）
@@ -832,7 +832,7 @@ INFO_MESSAGE_TEXT
     table = [
              '重力', '風', '流れ', '水', '波', '自由', '衝撃', '雷', '炎', '光', '円環',
             ]
-    
+
     return get_table_by_2d6(table)
   end
   # 指定特技（歌）
@@ -840,13 +840,13 @@ INFO_MESSAGE_TEXT
     table = [
              '物語', '旋律', '涙', '別れ', '微笑み', '想い', '勝利', '恋', '情熱', '癒し', '時',
             ]
-    
+
     return get_table_by_2d6(table)
   end
   # 指定特技（夢）
   def magicalogia_random_skill_dream_table
     table = ['追憶', '謎', '嘘', '不安', '眠り', '偶然', '幻', '狂気', '祈り', '希望', '未来']
-    
+
     return get_table_by_2d6(table)
   end
   # 指定特技（闇）
@@ -854,7 +854,7 @@ INFO_MESSAGE_TEXT
     table = [
              '深淵', '腐敗', '裏切り', '迷い', '怠惰', '歪み', '不幸', 'バカ', '悪意', '絶望', '死',
             ]
-    
+
     return get_table_by_2d6(table)
   end
     #特技だけ抜きたい時用(星) あまりきれいでない
@@ -901,7 +901,7 @@ INFO_MESSAGE_TEXT
             ]
     return get_table_by_1d6(table)
   end
-  # 魔法書架シーン表 
+  # 魔法書架シーン表
   def magicalogia_magic_bookshelf_scene_table
     table = [
              lambda{return "〈禁書〉の保管庫へ入ることを許可された。幾重にも張り巡らされた決壊や、鋭い目つきの書警たちが目に付く。その隙をついて、〈禁書〉が襲い掛かってきた！このシーンに登場したPCは一人だけ《#{magicalogia_random_skill_table_text_only_force}》の判定を行う。失敗すると、【魔力】が3点減少する。成功すると、【一時的魔力】を3点得る。誰かが判定すると、成否にかかわらず、この効果はなくなる。"},
@@ -916,10 +916,10 @@ INFO_MESSAGE_TEXT
              lambda{return "魔導書の閲覧室。数人の魔法使いが、熱心に魔導書を読んでいる。このシーンに登場しているPCのうち一人は、#{magicalogia_random_skill_table_text_only}の判定を行うことができる。成功すると、修得している魔法を一つ、修得可能な別の魔法に入れ替えることができる。失敗すると、「封印」の変調を受ける。誰かが判定すると、成否にかかわらず、この効果はなくなる。"},
              '本棚と本棚の間に、唐突に扉が浮かんでいる。この扉は、異界につながる戸口だ。一体どこにつながっているのだろう。異界シーン表の中からランダムに一つを選んで、その効果を適用する。',
             ]
-    
+
     return get_table_by_2d6(table)
   end
-  # 魔法学園シーン表 
+  # 魔法学園シーン表
   def magicalogia_magic_academy_scene_table
     table = [
              '目の前に美しい黒龍が現れた。学院の長、ザナルパトスだ。彼は、何を告げようとしているのだろうか。',
@@ -934,10 +934,10 @@ INFO_MESSAGE_TEXT
              lambda{return "生徒に何か魔法を見せて欲しいと乞われる。このシーンに登場しているPCは一人だけ、≪#{magicalogia_random_skill_table_text_only_dream}≫の判定を行う。失敗すると、「不運」の変調を受ける。成功すると、「夢」の魔素をを2点獲得する。誰かが判定すると、成否にかかわらず、この効果はなくなる。"},
              lambda{return "自習室。生徒たちが必死に魔導書を理解しようとしている。このシーンに登場しているPCは一人だけ、≪#{magicalogia_random_skill_table_text_only_star}≫の判定を行う。成功すると、好きな魔素をを2点獲得する。誰かが判定すると、成否にかかわらず、この効果はなくなる。"},
             ]
-    
+
     return get_table_by_2d6(table)
   end
-  # クレドの塔シーン表 
+  # クレドの塔シーン表
   def magicalogia_tower_credo_scene_table
     table = [
              '目の前に一人の少女が現れる。眠り姫の長、ラトゥナだ。ずっと眠り続けている筈の彼女が現れたのは、いったい何を告げるためなのだろうか。',
@@ -952,11 +952,11 @@ INFO_MESSAGE_TEXT
              '幻夢殿の中。眠り姫達の安らかな寝息が聞こえてくる。こちらも眠くなってくる。',
              '突然、目の前に扉が現れる。この扉は、異界につながる戸口だ。一体どこにつながっているのだろう。異界シーン表の中からランダムに一つを選んで、その効果を適用する。',
             ]
-    
+
     return get_table_by_2d6(table)
   end
 
-  # 並行世界シーン表 
+  # 並行世界シーン表
   def magicalogia_parallel_world_scene_table
     table = [
              'カフェのテーブル。FMラジオは、去年解散したはずのバンドの、先日発表した新曲を流している。このシーンに登場しているPCのうち一人は、「時の流れ表」を1回振り、効果を適用する。',
@@ -971,10 +971,10 @@ INFO_MESSAGE_TEXT
              lambda{return "小学校の前を通る。音楽室の窓から、見知らぬ音楽家の肖像が見える。≪#{magicalogia_random_skill_table_text_only_poem}≫の判定を行う。失敗すると、「封印」の変調を受ける。"},
              '目の前で、以前、経験した出来事が起きる。この世界では、これは、今から起きる出来事なのだ。このシーンに登場しているPCのうち一人は、このシーンの間、判定に+1の修正を受ける。',
             ]
-    
+
     return get_table_by_2d6(table)
   end
-  # 終末シーン表 
+  # 終末シーン表
   def magicalogia_post_apocalypse_scene_table
     table = [
              '夜。雨宿りのために足を踏み入れた寺院に危険は気配はなく、ゆっくり休めそうだ。静に時が流れていく。',
@@ -989,11 +989,11 @@ INFO_MESSAGE_TEXT
              '昼。崩壊した農村のかたわらで、美味しそうな果実を発見する。≪大地≫の判定に成功すると【魔力】が2点回復する。',
              '夕刻。錆び付いた線路。その先までたくさんのしゃれこうべが無造作に転がっている。虚憑が一体襲い掛かってくる。魔法戦を開始すること。2ラウンド経過するまでは昼、以降のラウンドは夜として処理する。この魔法戦はゲーム中に一度だけ発生する。',
             ]
-    
+
     return get_table_by_2d6(table)
   end
 
-  # 異世界酒場シーン表 
+  # 異世界酒場シーン表
   def magicalogia_god_bar_scene_table
     table = [
              'マスターの雷神に絡まれる。このシーンに登場しているPCのうち一人は、雷神相手に「事件表」を振る。',
@@ -1008,10 +1008,10 @@ INFO_MESSAGE_TEXT
              '上の階に登ろうとすると、竜が待ち構えている。このシーンに登場しているPCのうち一人は、≪牙≫で判定を行う。失敗すると、「綻び」の変調を受ける。成否にかかわらず、この効果は一度だけ発生する。',
              '美しい女神が、鏡をのぞき込んでいる。どうやら、運命が映る鏡だと言うのだが。このシーンに登場しているPCのうち一人は、≪未来≫で判定を行っても良い。成功すると好きなアンカーとの【運命】が1点上昇する。成否にかかわらず、この効果は一度だけ発生する。',
             ]
-    
+
     return get_table_by_2d6(table)
   end
-  # ほしかげシーン表 
+  # ほしかげシーン表
   def magicalogia_starlight_scene_table
     table = [
              'あなたの持つ「切符」は無効であると車掌に告げられる。他の乗客の視線を感じる。このシーンに登場しているPCのうち一人は、もう一度「切符」を調達しなければならない。魂の特技の判定を、成功するまで繰り返すこと。',
@@ -1026,7 +1026,7 @@ INFO_MESSAGE_TEXT
              '銀河を超える渡り鳥の群れ。しばし「汽車」と並走し、やがて離れ、天の川のようにきらきらした光の帯になっていく。このシーンに登場しているPCのうち一人は、≪翼≫で判定を行うことができる。成功すると魔力をリセットできる。誰かが判定すると、成否にかかわらず、この効果はなくなる。',
              '隣の車輛から誰かが移ってきた。なんと、あなたのアンカーである。このシーンに登場しているPCをランダムに一人選び、そのPCのアンカーの中から、この異境に存在しない〈愚者〉のアンカーをランダムで一人選ぶこと。そのアンカーが、元の世界へ無事戻ることができたら、ゲーム終了時に功績点を1点獲得する。',
             ]
-    
+
     return get_table_by_2d6(table)
   end
   #世界法則追加表
@@ -1065,7 +1065,7 @@ INFO_MESSAGE_TEXT
             ]
     return get_table_by_1d6(table)
   end
-  # 旧図書館シーン表 
+  # 旧図書館シーン表
   def magicalogia_old_library_scene_table
     table = [
              lambda{return "曲がり角。唐突に〈禁書〉が現れ、襲いかかってきた！このシーンに登場するPCは、#{magicalogia_random_skill_table_text_only}で判定を行う。失敗すると、【魔力】を3点失う。"},
@@ -1084,7 +1084,7 @@ INFO_MESSAGE_TEXT
   end
   #大判時の流れ表
   def magicalogia_new_time_passage_table
-    table = [    
+    table = [
              lambda{return "波乱万丈の人生を送る。この時代に起きた有名な事件の背後では、多くの魔法的存在が暗躍していた。あなたも、その事件に関わり、〈禁書〉や〈書籍卿〉たちと戦いを繰り広げる。#{magicalogia_random_skill_table_text_only}の判定を行う。成功するとセッション終了時に追加で功績点を1点獲得する。失敗すると、自分に「運命変転」が発生する。"},
              lambda{return "冒険の日々の途中、大きな幸せがおとずれる。#{magicalogia_random_skill_table_text_only}の判定を行う。成功すると、自分のアンカーが負っている不幸か、自分が負っている疵一つを無効化する。"},
              '瞑想していたのか。それとも何か封印されていたのか。長い眠りから目を覚ます。もうそんな時間か。おかげで十分に休息できた。ランダムに魔素を三個獲得するか、自分が「魔力のリセット」を行うか、自分の受けている変調をすべて回復する。',
@@ -1094,7 +1094,7 @@ INFO_MESSAGE_TEXT
             ]
     return get_table_by_1d6(table)
   end
-  # その後表 
+  # その後表
   def magicalogia_fallen_after_table_low
     table = [
              '成就者は、邪悪な魔法の力にひかれるようになる。成就者が、そのセッションで〈断章〉に憑依されていたり、魔法災厄の犠牲になったりしていた場合、【堕落値】が1点上昇し、堕落チェックを行う。堕落チェックに失敗した場合、成就者は命を落とし、そのPCの疵となる。',
@@ -1124,7 +1124,7 @@ INFO_MESSAGE_TEXT
     if num <= 3
       outtext, outnum = magicalogia_fallen_after_table_low
       outtext = "#{outtext}"
-    else 
+    else
       outtext, outnum = magicalogia_fallen_after_table_high
       outtext = "#{outtext}"
     end

--- a/src/diceBot/NightWizard3rd.rb
+++ b/src/diceBot/NightWizard3rd.rb
@@ -3,26 +3,26 @@
 require 'diceBot/NightWizard'
 
 class NightWizard3rd < NightWizard
-  
+
   def initialize
     super
   end
-  
+
   def gameName
     'ナイトウィザード3版'
   end
-  
+
   def gameType
     "NightWizard3rd"
   end
-  
-  
+
+
   def getFumbleTextAndTotal(base, modify, dice_str)
     total = base + modify
     total += -10
     text = "#{base + modify}-10[#{dice_str}]"
     return text, total
   end
-  
-  
+
+
 end

--- a/src/diceBot/NightmareHunterDeep.rb
+++ b/src/diceBot/NightmareHunterDeep.rb
@@ -1,93 +1,93 @@
 # -*- coding: utf-8 -*-
 
 class NightmareHunterDeep < DiceBot
-  
+
   def initialize
     super
     @sendMode = 2
     @sortType = 1
   end
-  
+
   def gameName
     'ナイトメアハンター=ディープ'
   end
-  
+
   def gameType
     "NightmareHunterDeep"
   end
-  
+
   def getHelpMessage
     return <<INFO_MESSAGE_TEXT
 加算ロール時に６の個数をカウントして、その４倍を自動的に加算します。
 (出目はそのまま表示で合計値が6-10の読み替えになります)
 INFO_MESSAGE_TEXT
   end
-  
+
   def changeText(string)
     debug("parren_killer_add before string", string)
     string = string.sub(/^(.+?)Lv(\d+)(.*)/i) {"#{$1}#{ ($2.to_i * 5 - 1) }#{$3}"}
     string = string.sub(/^(.+?)NL(\d+)(.*)/i) {"#{$1}#{ ($2.to_i * 5 + 5) }#{$3}"}
     debug("parren_killer_add after string", string)
-    
+
     return string
   end
-  
+
   def check_nD6(total_n, dice_n, signOfInequality, diff, dice_cnt, dice_max, n1, n_max) # ゲーム別成功度判定(nD6)
     return '' unless($signOfInequality == ">=")
-    
+
     if(diff != "?")
       if(total_n >= diff)
         return " ＞ 成功"
       end
-      
+
       return " ＞ 失敗"
     end
-    
+
     #diff == "?"
     sucLv = 1
     sucNL = 0
-    
+
     while(total_n >= sucLv*5-1)
       sucLv += 1
     end
-    
+
     while(total_n >= (sucNL * 5 + 5))
       sucNL += 1
     end
-    
+
     sucLv -= 1
     sucNL -= 1
-    
+
     if(sucLv <= 0)
       return " ＞ 失敗"
     else
       return " ＞ Lv#{sucLv}/NL#{sucNL}成功"
     end
   end
-  
-  
+
+
   #ナイトメアハンターディープ用宿命表示
   def getDiceRolledAdditionalText(n1, n_max, dice_max)
     debug('getDiceRolledAdditionalText begin: n1, n_max, dice_max', n1, n_max, dice_max)
-    
+
     if( (n1 != 0) and (dice_max == 6) )
       return " ＞ 宿命獲得"
     end
-    
+
     return ''
   end
-  
+
   #ダイス目による補正処理（現状ナイトメアハンターディープ専用）
   def getDiceRevision(n_max, dice_max, total_n)
     addText = ''
     revision = 0
-    
+
     if( (n_max > 0) and (dice_max == 6) )
       revision = (n_max * 4)
       addText = ("+#{n_max}*4 ＞ #{total_n + revision}")
     end
-    
+
     return addText, revision
   end
-  
+
 end

--- a/src/diceBot/NjslyrBattle.rb
+++ b/src/diceBot/NjslyrBattle.rb
@@ -1,15 +1,15 @@
 # -*- coding: utf-8 -*-
 
 class NjslyrBattle < DiceBot
-  
+
   def gameName
     'NJSLYRBATTLE'
   end
-  
+
   def gameType
     "NJSLYRBATTLE"
   end
-  
+
   def getHelpMessage
     return <<INFO_MESSAGE_TEXT
 ・カラテロール
@@ -18,47 +18,47 @@ class NjslyrBattle < DiceBot
 (2D6<=5) ＞ 2[1,1] ＞ 2 ＞ 成功 重点 3 溜まる
 INFO_MESSAGE_TEXT
   end
-  
-  
+
+
   # ゲーム別成功度判定(2D6)
   def check_2D6(total_n, dice_n, signOfInequality, diff, dice_cnt, dice_max, n1, n_max)
-    
+
     return '' if(signOfInequality != "<=")
-    
+
     success = checkSuccess(total_n, diff)
     juuten = getJuuten
-    
+
     return success + juuten
   end
-  
+
   def checkSuccess(total_n, diff)
     if(total_n <= diff)
       return " ＞ 成功";
     end
-    
+
     return " ＞ 失敗";
   end
-  
+
   def getJuuten
     diceList = getDiceList
     return '' if( diceList.length != 2)
-    
+
     juuten = 0
-    
+
     diceList.each do |i|
       juuten += 1 if( i == 1 )
       juuten += 1 if( i == 6 )
     end
-    
+
     if( diceList[0] == diceList[1] )
       juuten += 1
     end
-    
+
     if( juuten > 0 )
       return " 重点 #{juuten} 溜まる"
     end
-    
+
     return ''
   end
-  
+
 end

--- a/src/diceBot/Oukahoushin3rd.rb
+++ b/src/diceBot/Oukahoushin3rd.rb
@@ -1,19 +1,19 @@
 # -*- coding: utf-8 -*-
 
 class Oukahoushin3rd < DiceBot
-  
+
   def initialize
     super
   end
-  
+
   def gameName
     '央華封神RPG第三版'
   end
-  
+
   def gameType
     "Oukahoushin3rd"
   end
-  
+
   def getHelpMessage
     return <<INFO_MESSAGE_TEXT
 ・各種表
@@ -26,16 +26,16 @@ class Oukahoushin3rd < DiceBot
 　・狂気表（KKT）
 INFO_MESSAGE_TEXT
   end
-  
+
 
   def rollDiceCommand(command)
     return getTableCommandResult(command, @@tables)
   end
-  
-  
+
+
   @@tables =
     {
-    
+
     'BKT' => {
       :name => "武器攻撃裏成功表",
       :type => '2D6',
@@ -157,7 +157,7 @@ TABLE_TEXT_END
 TABLE_TEXT_END
     },
   }
-    
+
   setPrefixes([ ] + @@tables.keys)
-    
+
 end

--- a/src/diceBot/Pathfinder.rb
+++ b/src/diceBot/Pathfinder.rb
@@ -3,23 +3,23 @@
 require 'diceBot/DungeonsAndDoragons'
 
 class Pathfinder < DungeonsAndDoragons
-  
+
   def initialize
     super
   end
-  
+
   def gameName
     'Pathfinder'
   end
-  
+
   def gameType
     "Pathfinder"
   end
-  
+
   def getHelpMessage
     return <<MESSAGETEXT
 ※このダイスボットは部屋のシステム名表示用となります。
 MESSAGETEXT
   end
-  
+
 end

--- a/src/diceBot/Pendragon.rb
+++ b/src/diceBot/Pendragon.rb
@@ -1,40 +1,40 @@
 # -*- coding: utf-8 -*-
 
 class Pendragon < DiceBot
-  
+
   def gameName
     'ペンドラゴン'
   end
-  
+
   def gameType
     "Pendragon"
   end
-  
+
   def getHelpMessage
     return <<INFO_MESSAGE_TEXT
 クリティカル、成功、失敗、ファンブルの自動判定を行います。
 INFO_MESSAGE_TEXT
   end
-  
-  
+
+
   # ゲーム別成功度判定(1d20)
   def check_1D20(total_n, dice_n, signOfInequality, diff, dice_cnt, dice_max, n1, n_max)
     return '' unless(signOfInequality == "<=")
-    
+
     if(total_n <= diff)
       if((total_n >= (40 - diff)) or (total_n == diff))
         return " ＞ クリティカル";
       end
-      
+
       return " ＞ 成功";
     else
       if(total_n == 20)
         return " ＞ ファンブル";
       end
-      
+
       return " ＞ 失敗";
     end
   end
-  
-  
+
+
 end

--- a/src/diceBot/PhantasmAdventure.rb
+++ b/src/diceBot/PhantasmAdventure.rb
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
 class PhantasmAdventure < DiceBot
-  
+
   def initialize
     super
     @sendMode = 2;
@@ -9,22 +9,22 @@ class PhantasmAdventure < DiceBot
   def gameName
     'ファンタズムアドベンチャー'
   end
-  
+
   def gameType
     "PhantasmAdventure"
   end
-  
+
   def getHelpMessage
     return <<INFO_MESSAGE_TEXT
 成功、失敗、決定的成功、決定的失敗の表示とクリティカル・ファンブル値計算の実装。
 INFO_MESSAGE_TEXT
   end
-  
-  
+
+
   # ゲーム別成功度判定(1d20)
   def check_1D20(total_n, dice_n, signOfInequality, diff, dice_cnt, dice_max, n1, n_max)
     return '' unless(signOfInequality == "<=")
-    
+
     # 技能値の修正を計算する
     skill_mod = 0;
     if(diff < 1)
@@ -32,49 +32,49 @@ INFO_MESSAGE_TEXT
     elsif(diff > 20)
       skill_mod = diff - 20;
     end
-    
+
     fumble = 20 + skill_mod;
     fumble = 20 if(fumble > 20);
     critical = 1 + skill_mod;
     dice_now, = roll(1, 20);
-    
+
     if(total_n >= fumble or total_n >= 20)
       fum_num = dice_now - skill_mod;
       fum_num = 20 if(fum_num > 20);
       fum_num = 1 if(fum_num < 1);
-        
+
       if(sendMode <= 1)
         return " ＞ 致命的失敗(#{fum_num})";
       end
-      
+
       fum_str = "#{dice_now}";
       if(skill_mod < 0)
         fum_str += "+#{skill_mod * -1}=#{fum_num}";
-      else 
+      else
         fum_str += "-#{skill_mod}=#{fum_num}";
       end
       return " ＞ 致命的失敗(#{fum_str})";
-      
+
     elsif(total_n <= critical or total_n <= 1)
       crit_num = dice_now + skill_mod;
       crit_num = 20 if(crit_num > 20);
       crit_num = 1 if(crit_num < 1);
-      
+
       if(skill_mod < 0)
         return " ＞ 成功";
       end
-      
+
       if(sendMode > 1)
         return " ＞ 決定的成功(#{dice_now}+#{skill_mod}=#{crit_num})";
       end
       return " ＞ 決定的成功(#{crit_num})";
-      
+
     elsif(total_n <= diff)
       return " ＞ 成功";
     else
       return " ＞ 失敗";
     end
-    
+
   end
-  
+
 end

--- a/src/diceBot/Postman.rb
+++ b/src/diceBot/Postman.rb
@@ -45,9 +45,9 @@ PO@5+2 → 2Dで目標値7の判定。判定の成否と達成値を表示。
 ◆自由行動シチュエーション表：FRE
 MESSAGETEXT
   end
- 
+
   def rollDiceCommand(command)
- 
+
     text =
       case command.upcase
 

--- a/src/diceBot/RoleMaster.rb
+++ b/src/diceBot/RoleMaster.rb
@@ -10,15 +10,15 @@ class RoleMaster < DiceBot
   def gameName
     'ロールマスター'
   end
-  
+
   def gameType
     "RoleMaster"
   end
-  
+
   def getHelpMessage
     return <<INFO_MESSAGE_TEXT
 上方無限ロール(xUn)の境界値を96にセットします。
 INFO_MESSAGE_TEXT
   end
-  
+
 end

--- a/src/diceBot/RuneQuest.rb
+++ b/src/diceBot/RuneQuest.rb
@@ -1,38 +1,38 @@
 # -*- coding: utf-8 -*-
 
 class RuneQuest < DiceBot
-  
+
   def gameName
     'ルーンクエスト'
   end
-  
+
   def gameType
     "RuneQuest"
   end
-  
+
   def getHelpMessage
     return <<INFO_MESSAGE_TEXT
 クリティカル、エフェクティブ(効果的成功)、ファンブルの自動判定を行います。
 INFO_MESSAGE_TEXT
   end
-  
-  
+
+
   # ゲーム別成功度判定(1d100)
   def check_1D100(total_n, dice_n, signOfInequality, diff, dice_cnt, dice_max, n1, n_max)
     return "" unless(signOfInequality == "<=")
-    
+
     cliticalValue = ((1.0 * diff / 20) + 0.5)
-    
+
     # 1は常に決定的成功
     return " ＞ 決定的成功" if((total_n <= 1) or (total_n <= cliticalValue))
-                               
+
     # 100は常に致命的失敗
-    return " ＞ 致命的失敗" if(total_n >= 100)   
-    
+    return " ＞ 致命的失敗" if(total_n >= 100)
+
     return " ＞ 効果的成功" if(total_n <= (diff / 5 + 0.5))
     return " ＞ 成功" if(total_n <= diff)
     return " ＞ 致命的失敗" if(total_n >= (95 + (diff / 20 + 0.5)))
     return " ＞ 失敗"
   end
-  
+
 end

--- a/src/diceBot/ShadowRun.rb
+++ b/src/diceBot/ShadowRun.rb
@@ -11,15 +11,15 @@ class ShadowRun < DiceBot
   def gameName
     'シャドウラン'
   end
-  
+
   def gameType
     "ShadowRun"
   end
-  
+
   def getHelpMessage
     return <<INFO_MESSAGE_TEXT
 上方無限ロール(xUn)の境界値を6にセットします。
 INFO_MESSAGE_TEXT
   end
-  
+
 end

--- a/src/diceBot/ShadowRun4.rb
+++ b/src/diceBot/ShadowRun4.rb
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
 class ShadowRun4 < DiceBot
-  
+
   def initialize
     super
     @sortType = 3
@@ -11,46 +11,46 @@ class ShadowRun4 < DiceBot
   def gameName
     'シャドウラン第４版'
   end
-  
+
   def gameType
     "ShadowRun4"
   end
-  
+
   def getHelpMessage
     return <<INFO_MESSAGE_TEXT
 個数振り足しロール(xRn)の境界値を6にセット、バラバラロール(xBn)の目標値を5以上にセットします。
 BコマンドとRコマンド時に、グリッチの表示を行います。
 INFO_MESSAGE_TEXT
   end
-  
+
   def changeText(string)
     if(string =~ /(\d+)S6/i)
       string = string.gsub(/(\d+)S6/i) {"#{$1}B6"}
     end
-    
+
     return string
   end
-  
-  
+
+
   #シャドウラン4版用グリッチ判定
   def getGrichText(numberSpot1, dice_cnt_total, successCount)
     debug("getGrichText numberSpot1", numberSpot1)
     debug("dice_cnt_total", dice_cnt_total)
     debug("successCount", successCount)
-    
+
     dice_cnt_total_half = (1.0 * dice_cnt_total / 2)
     debug("dice_cnt_total_half", dice_cnt_total_half)
-    
+
     unless( numberSpot1 >= dice_cnt_total_half )
       return ''
     end
-    
+
     # グリッチ！
-    if( successCount == 0 ) 
+    if( successCount == 0 )
       return ' ＞ クリティカルグリッチ'
     end
-      
+
     return ' ＞ グリッチ'
   end
-  
+
 end

--- a/src/diceBot/ShinMegamiTenseiKakuseihen.rb
+++ b/src/diceBot/ShinMegamiTenseiKakuseihen.rb
@@ -1,19 +1,19 @@
 # -*- coding: utf-8 -*-
 
 class ShinMegamiTenseiKakuseihen < DiceBot
-  
+
   def initialize
     super
   end
-  
+
   def gameName
     '真・女神転生TRPG　覚醒編'
   end
-  
+
   def gameType
     "SMTKakuseihen"
   end
-  
+
   def getHelpMessage
     return <<INFO_MESSAGE_TEXT
 ・判定
@@ -21,73 +21,73 @@ class ShinMegamiTenseiKakuseihen < DiceBot
 威力ダイスは nU6[6] (nはダイス個数)でロール可能です。
 INFO_MESSAGE_TEXT
   end
-  
-  
+
+
   # ゲーム別成功度判定(1d100)
   def check_1D100(total_n, dice_n, signOfInequality, diff, dice_cnt, dice_max, n1, n_max)
     return '' unless(signOfInequality == "<=")
-    
+
     total_n = total_n % 100
-    
+
     dice1, dice2 = getTwoDice
-    
+
     total1 = dice1 * 10 + dice2
     total2 = dice2 * 10 + dice1
-    
+
     #ゾロ目
     isRepdigit = ( dice1 == dice2 )
-    
+
     result = " ＞ スワップ"
     result += getCheckResultText(diff, [total1, total2].min, isRepdigit)
     result += "／通常"
     result += getCheckResultText(diff, total_n, isRepdigit)
     result += "／逆スワップ"
     result += getCheckResultText(diff, [total1, total2].max, isRepdigit)
-    
+
     return result
   end
-  
+
   def getTwoDice
     value = getDiceList.first
     value ||= 0
-    
+
     value %= 100
-    
+
     dice1 = value / 10
     dice2 = value % 10
-    
+
     return [dice1, dice2]
   end
-  
+
   def getCheckResultText(diff, total, isRepdigit)
     checkResult = getCheckResult(diff, total, isRepdigit)
     text = sprintf("(%02d)%s", total, checkResult)
     return text
   end
-  
+
   def getCheckResult(diff, total, isRepdigit)
     if( diff >= total )
       return getSuccessResult(isRepdigit)
     end
-    
+
     return getFailResult(isRepdigit)
   end
-  
+
   def getSuccessResult(isRepdigit)
     if( isRepdigit )
-      return "絶対成功" 
+      return "絶対成功"
     end
-    
+
     return "成功"
   end
-  
+
   def getFailResult(isRepdigit)
     if( isRepdigit )
       return "絶対失敗"
     end
-    
+
     return "失敗"
   end
-  
-  
+
+
 end

--- a/src/diceBot/ShinobiGami.rb
+++ b/src/diceBot/ShinobiGami.rb
@@ -57,7 +57,7 @@ INFO_MESSAGE_TEXT
 
     result = getTableCommandResult(command, @@tables)
     return result unless result.nil?
-    
+
     case string
     when /((\w)*ST)/i   # シーン表
       return sinobigami_scene_table(string)

--- a/src/diceBot/StellarKnights.rb
+++ b/src/diceBot/StellarKnights.rb
@@ -4,21 +4,21 @@ class StellarKnights < DiceBot
 
   # ダイスボットで使用するコマンドを配列で列挙する
   setPrefixes(['TT', 'STA', 'STB', 'STB2', 'STC', 'ALLS'])
-  
+
   def initialize
     super
-    
+
     @d66Type = 1
   end
-  
+
   def gameName
     '銀剣のステラナイツ'
   end
-  
+
   def gameType
     "StellarKnights"
   end
-  
+
   def getHelpMessage
     return <<MESSAGETEXT
 TT：お題表
@@ -29,19 +29,19 @@ STC ：シチュエーション表C：話題
 ALLS ：シチュエーション表全てを一括で（学園編除く）
 MESSAGETEXT
   end
-  
-  
+
+
   def rollDiceCommand(command)
     command = command.upcase
-    
+
     return analyzeDiceCommandResultMethod(command)
   end
-  
-  
+
+
   def getThemeTableDiceCommandResult(command)
-    
+
     return unless command == "TT"
-    
+
     tableName = "お題表"
     table = %w{
 未来 占い 遠雷 恋心 歯磨き 鏡
@@ -51,18 +51,18 @@ MESSAGETEXT
 思い出 うとうと 鼓動 嫉妬 ベッド 泥
 恋の話 デート ため息 内緒話 お風呂 小さな傷
 }
-    
+
     text, index = get_table_by_d66(table)
-    
+
     result = "#{tableName}(#{index}) ＞ #{text}"
     return result
   end
-  
-  
+
+
   def getSituationTableDiceCommandResult(command)
-    
+
     return unless command == "STA"
-    
+
     tableName = "シチュエーション表A：時間"
     table = %w{
 朝、誰もいない
@@ -73,18 +73,18 @@ MESSAGETEXT
 夜明け前の
 }
     text, index = get_table_by_1d6(table)
-    
+
     result = "#{tableName}(#{index}) ＞ #{text}"
     return result
   end
-  
+
 
   def getPlageTableDiceCommandResult(command)
-    
+
     return unless command == "STB"
 
     tableName = "シチュエーション表B：場所"
-    
+
     table_1_2 = [
 "教室 　小道具：窓、机、筆記用具、チョークと黒板、窓の外から聞こえる部活動の声",
 "カフェテラス　小道具：珈琲、紅茶、お砂糖とミルク、こちらに手を振っている学友",
@@ -93,7 +93,7 @@ MESSAGETEXT
 "図書館　小道具：高い天井、天井に迫る程の本棚、無数に収められた本",
 "渡り廊下　小道具：空に届きそうな高さ、遠くに別の学園が見える、隣を飛び過ぎて行く鳥",
                 ]
-    
+
     table_3_4 = [
 "花の咲き誇る温室　小道具：むせ返るような花の香り、咲き誇る花々、ガラス越しの陽光",
 "アンティークショップ　小道具：アクセサリーから置物まで、見慣れない古い機械は地球時代のもの？",
@@ -110,22 +110,22 @@ MESSAGETEXT
 "ふたりの部屋　小道具：パートナーと共に暮らすあなたの部屋、内装や小物はお気に召すまま",
 "願いの決闘場　小道具：決闘の場、ステラナイトたちの花章が咲き誇る場所",
                 ]
-    
+
     table = [table_1_2, table_1_2,
              table_3_4, table_3_4,
              table_5_6, table_5_6,].flatten
-    
+
     text, index = get_table_by_d66(table)
-    
+
     result = "#{tableName}(#{index}) ＞ #{text}"
     return result
   end
 
 
   def getSchoolTableDiceCommandResult(command)
-    
+
     return unless command == "STB2"
-    
+
     tables =
       [
        { :tableName => "アーセルトレイ公立大学",
@@ -137,7 +137,7 @@ MESSAGETEXT
 共用の広いグラウンド
 使い古された教室
 }},
-       
+
        { :tableName => "イデアグロリア芸術総合大学",
          :table => %w{
 （美術ｏｒ音楽）準備室
@@ -147,7 +147,7 @@ MESSAGETEXT
 誰もいない大型劇場
 完璧な調和を感じる温室
 }},
-       
+
        { :tableName => "シトラ女学院",
        :table => %w{
 中庭の神殿めいた温室
@@ -157,7 +157,7 @@ MESSAGETEXT
 寮生たちの秘密のお茶会室
 寮の廊下
 }},
-       
+
        { :tableName => "フィロソフィア大学",
          :table => %w{
 遠く聞こえる爆発音
@@ -167,7 +167,7 @@ MESSAGETEXT
 鳴らすと留年するという小さな鐘の前
 木漏れ日のあたたかな森
 }},
-              
+
        { :tableName => "聖アージェティア学園",
        :table => %w{
 おしゃれなカフェテラス
@@ -177,7 +177,7 @@ MESSAGETEXT
 謎のおしゃれな空き部屋
 花々の咲き乱れる温室
 }},
-       
+
      { :tableName => "スポーン・オブ・アーセルトレイ",
        :table => %w{
 人気のない教室
@@ -188,29 +188,29 @@ MESSAGETEXT
  外周環状道路へ繋がる橋
 }},
              ]
-    
+
     result = ''
-    
+
     tables.each_with_index do |table, i|
       tableName = table[:tableName]
       table = table[:table]
-      
+
       text, index = get_table_by_1d6(table)
 
       result += "\n" unless i == 0
       result += "#{tableName}(#{index}) ＞ #{text}"
     end
-    
+
     return result
   end
-  
-  
+
+
   def getTpicTableDiceCommandResult(command)
-    
+
     return unless command == "STC"
 
     tableName = "シチュエーション表C：話題"
-    
+
     table_1_3 = [
 "未来の話：決闘を勝ち抜いたら、あるいは負けてしまったら……未来のふたりはどうなるのだろう。",
 "衣服の話：冴えない服を着たりしていないか？　あるいはハイセンス過ぎたりしないだろうか。よぉし、私が選んであげよう!!",
@@ -219,7 +219,7 @@ MESSAGETEXT
 "家族の話：生徒たちは寮生活が多い。離れて暮らす家族は、どんな人たちなのか。いつかご挨拶に行きたいと言い出したりしても良いだろう。",
 "次の週末の話：週末、何をしますか？　願いをかけた決闘の合間、日常のひとときも、きっと大切な時間に違いない。",
                 ]
-    
+
     table_4_6 = [
 "好きな人の話：……好きな人、いるんですか？　これはきっと真剣な話。他の何よりも重要な話だ。",
 "子供の頃の話：ちいさな頃、パートナーはどんな子供だったのだろうか。どんな遊びをしたのだろうか。",
@@ -228,32 +228,32 @@ MESSAGETEXT
 "願いの話：叶えたい願いがあるからこそ、ふたりは出会った。この戦いに勝利したら、どんな形で願いを叶えるのだろうか。",
 "ねぇ、あの子誰？：この前見かけたパートナーと一緒にいた子。あの子誰？だーれー!?　むー!!"
                 ]
-    
-    table = [table_1_3, table_1_3, table_1_3, 
+
+    table = [table_1_3, table_1_3, table_1_3,
              table_4_6, table_4_6, table_4_6, ].flatten
-    
+
     text, index = get_table_by_d66(table)
-    
+
     result = "#{tableName}(#{index}) ＞ #{text}"
     return result
   end
-  
-  
+
+
   def getAllSituationTableDiceCommandResult(command)
-    
+
     return unless command == "ALLS"
-    
+
     commands = ['STA', 'STB', 'STC']
-    
+
     result = ""
-    
+
     commands.each_with_index do |command, i|
       result += "\n" unless i == 0
       result += analyzeDiceCommandResultMethod(command)
     end
-    
+
     return result
   end
-  
+
 
 end

--- a/src/diceBot/StratoShout.rb
+++ b/src/diceBot/StratoShout.rb
@@ -33,7 +33,7 @@ class StratoShout < DiceBot
 
   def getHelpMessage
     return <<INFO_MESSAGE_TEXT
-    
+
 VOT, GUT, BAT, KEYT, DRT: (ボーカル、ギター、ベース、キーボード、ドラム)トラブル表
 EMO: 感情表
 AT[1-6]: 特技表(空: ランダム 1: 主義 2: 身体 3: モチーフ 4: エモーション 5: 行動 6: 逆境)

--- a/src/diceBot/SwordWorld.rb
+++ b/src/diceBot/SwordWorld.rb
@@ -52,13 +52,13 @@ INFO_MESSAGE_TEXT
 
     return string
   end
-  
-  
+
+
   def getRatingCommandStrings
     "cmCM"
   end
-  
-  
+
+
   def check_2D6(totalValue, dice_n, signOfInequality, diff, dice_cnt, dice_max, n1, n_max)  # ゲーム別成功度判定(2D6)
     if(dice_n >= 12)
       return " ＞ 自動的成功";
@@ -85,9 +85,9 @@ INFO_MESSAGE_TEXT
   ####################        SWレーティング表       ########################
   def rating(string)     # レーティング表
     debug("rating string", string)
-    
+
     commands = getRatingCommandStrings
-    
+
     unless(/(^|\s)[sS]?(((k|K)[\d\+\-]+)([#{commands}]\[([\d\+\-]+)\])*([\d\+\-]*)([cmrCMR]\[([\d\+\-]+)\]|gf|GF)*)($|\s)/ =~ string)
       debug("not matched")
       return '1'
@@ -121,7 +121,7 @@ INFO_MESSAGE_TEXT
     output += "m[#{firstDiceChangeModify}]" if( firstDiceChangeModify != 0 )
     output += "m[#{firstDiceChanteTo}]" if( firstDiceChanteTo != 0)
     output += "r[#{rateUp}]" if( rateUp != 0 )
-    
+
     output, values = getAdditionalString(string, output)
 
     debug('output', output)
@@ -151,7 +151,7 @@ INFO_MESSAGE_TEXT
         dice += firstDiceChangeModify.to_i
         firstDiceChangeModify = 0;
       end
-      
+
       dice += getAdditionalDiceValue(dice, values)
 
       dice = 2 if(dice < 2)
@@ -170,7 +170,7 @@ INFO_MESSAGE_TEXT
       rateResults << ((dice > 2) ? rateValue : "**")
 
       round += 1
-      
+
       break unless(dice >= crit)
     end
 
@@ -180,18 +180,18 @@ INFO_MESSAGE_TEXT
 
     return output
   end
-  
-  
+
+
   def getAdditionalString(string, output)
     values = {}
     return output, values
   end
-  
+
   def  getAdditionalDiceValue(dice, values)
     0
   end
-  
-  
+
+
   def getCriticalFromString(string)
     crit = 10
 

--- a/src/diceBot/SwordWorld2_0.rb
+++ b/src/diceBot/SwordWorld2_0.rb
@@ -98,18 +98,18 @@ INFO_MESSAGE_TEXT
   def getAdditionalString(string, output)
 
     output, values = super(string, output)
-    
+
     isGratestFortune, string = getGratestFortuneFromString(string)
-    
+
     values['isGratestFortune'] = isGratestFortune
     output += "gf" if( isGratestFortune )
-    
+
     return output, values
   end
-  
-  
+
+
   def rollDice(values)
-    
+
     unless values['isGratestFortune']
       return super(values)
     end
@@ -121,8 +121,8 @@ INFO_MESSAGE_TEXT
 
     return dice, diceText
   end
-  
-  
+
+
   def getGratestFortuneFromString(string)
     isGratestFortune = false
 

--- a/src/diceBot/SwordWorld2_5.rb
+++ b/src/diceBot/SwordWorld2_5.rb
@@ -4,11 +4,11 @@ require 'diceBot/SwordWorld2_0'
 
 class SwordWorld2_5 < SwordWorld2_0
   setPrefixes(['K\d+.*', 'Gr(\d+)?', 'FT', 'TT'])
-  
+
   def initialize
     super
   end
-  
+
   def gameName
     'ソードワールド2.5'
   end
@@ -66,14 +66,14 @@ class SwordWorld2_5 < SwordWorld2_0
 　絡み効果表を出すことができます。
 INFO_MESSAGE_TEXT
   end
-  
-  
-  
+
+
+
   def changeText(string)
     return string unless( /(^|\s)[sS]?(K[\d]+)/i =~ string )
 
     string = super(string)
-    
+
     debug('parren_killer_add before string', string)
 
     string = string.gsub(/#([\+\-]?[\d]+)/i) do
@@ -84,40 +84,40 @@ INFO_MESSAGE_TEXT
         "a[#{value}]"
       end
     end
-    
+
     debug('parren_killer_add after string', string)
-    
+
     return string
   end
-  
-  
+
+
   def getRatingCommandStrings
     super + "aA"
   end
-  
-  
+
+
   def getAdditionalString(string, output)
     output, values = super(string, output)
-    
+
     keptDiceChangeModify, string = getKeptDiceChangesFromString(string)
-    
+
     values['keptDiceChangeModify'] = keptDiceChangeModify
     output += "a[#{keptDiceChangeModify}]" if( keptDiceChangeModify != 0 )
-    
+
     return output, values
   end
-  
-  
+
+
   def getAdditionalDiceValue(dice, values)
     keptDiceChangeModify = values['keptDiceChangeModify'].to_i
-    
+
     value = 0
     value += keptDiceChangeModify.to_i if( keptDiceChangeModify != 0 and dice != 2 )
-    
+
     return value
   end
-  
-  
+
+
   def getKeptDiceChangesFromString(string)
     keptDiceChangeModify = 0
     regexp = /a\[([\+\-]\d+)\]/i
@@ -127,5 +127,5 @@ INFO_MESSAGE_TEXT
     end
     return keptDiceChangeModify, string
   end
-  
+
 end

--- a/src/diceBot/TokumeiTenkousei.rb
+++ b/src/diceBot/TokumeiTenkousei.rb
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
 class TokumeiTenkousei < DiceBot
-  
+
   def initialize
     super
     @sendMode = 2
@@ -12,39 +12,39 @@ class TokumeiTenkousei < DiceBot
   def gameName
     '特命転攻生'
   end
-  
+
   def gameType
     "TokumeiTenkousei"
   end
-  
+
   def getHelpMessage
     return <<INFO_MESSAGE_TEXT
 「1の出目でEPP獲得」、判定時の「成功」「失敗」「ゾロ目で自動振り足し」を判定。
 INFO_MESSAGE_TEXT
   end
-  
+
   def check_nD6(total_n, dice_n, signOfInequality, diff, dice_cnt, dice_max, n1, n_max) # ゲーム別成功度判定(nD6)
     return '' unless($signOfInequality == ">=")
-    
+
     return '' if(diff == "?")
-    
+
     if(total_n >= diff)
       return " ＞ 成功"
     else
       return " ＞ 失敗"
     end
   end
-  
+
   # 特命転校生用エキストラパワーポイント獲得
   def getDiceRolledAdditionalText(n1, n_max, dice_max)
     debug('getExtraPowerPointTextForTokumeiTenkousei n1, dice_max', n1, dice_max)
-    
+
     if((n1 != 0) and (dice_max == 6))
       point = n1 * 5
       return (" ＞ #{point}EPP獲得")
     end
-    
+
     return ''
   end
-  
+
 end

--- a/src/diceBot/TokyoGhostResearch.rb
+++ b/src/diceBot/TokyoGhostResearch.rb
@@ -5,19 +5,19 @@ class TokyoGhostResearch < DiceBot
   setPrefixes([
   'OP', 'TB', 'TK?\(\d+\)'
   ])
-  
+
   def initialize
     super
   end
-  
+
   def gameName
     '東京ゴーストリサーチ'
   end
-  
+
   def gameType
     "TokyoGhostResearch"
   end
-  
+
   def getHelpMessage
     return <<MESSAGETEXT
 判定
@@ -29,15 +29,15 @@ class TokyoGhostResearch < DiceBot
   ・一般トラブル表  TB
 MESSAGETEXT
   end
-  
+
   def rollDiceCommand(command)
 
-    output = 
+    output =
       case command.upcase
-      
+
       when /TK/i
         return getCheckResult(command)
-      
+
       when 'OP'
         tgr_opening_table
       when 'TB'
@@ -45,22 +45,22 @@ MESSAGETEXT
       else
         nil
       end
-      
+
     return output
   end
 
   def getCheckResult(command)
-  
+
       output = ""
       diff = 0
-      
+
       if(/TK?<=(\d+)/i =~ command)
         diff = $2.to_i
       end
-      
+
       if (diff > 0)
         output += "(1D10<=#{diff})"
-      
+
         total_n, = roll(1, 10)
         output += ' ＞ ' + "#{total_n}"
         output += ' ＞ ' + getCheckResultText(total_n, diff)
@@ -74,10 +74,10 @@ MESSAGETEXT
     else
        result = "失敗"
     end
-    
+
     return result
   end
-  
+
   #導入表(1d10)[OP]
   def tgr_opening_table
     name = "導入表"
@@ -95,7 +95,7 @@ MESSAGETEXT
     ]
     return get_1d10_table_result(name, table)
   end
-  
+
   #一般トラブル表(1d10)[TB]
   def tgr_common_trouble_table
     name = "一般トラブル表"

--- a/src/diceBot/TokyoNova.rb
+++ b/src/diceBot/TokyoNova.rb
@@ -1,23 +1,23 @@
 # -*- coding: utf-8 -*-
 
 class TokyoNova < DiceBot
-  
+
   def initialize
     super
   end
-  
+
   def gameName
     'トーキョーＮ◎ＶＡ'
   end
-  
+
   def gameType
     "TokyoNova"
   end
-  
+
   def getHelpMessage
     return <<MESSAGETEXT
 ※このダイスボットは部屋のシステム名表示用となります。
 MESSAGETEXT
   end
-  
+
 end

--- a/src/diceBot/Torg1_5.rb
+++ b/src/diceBot/Torg1_5.rb
@@ -4,16 +4,16 @@ require 'diceBot/Torg'
 
 class Torg1_5 < Torg
   setPrefixes(Torg.prefixes)
-  
+
   def gameName
     'トーグ1.5版'
   end
-  
+
   def gameType
     "TORG1.5"
   end
-  
-  
+
+
   # 一般結果表 成功度
   def get_torg_success_level(value)
     success_table = [
@@ -22,7 +22,7 @@ class Torg1_5 < Torg
         [3, "まあよい"],
         [7, "かなりよい"],
         [12, "すごい" ]]
-    
+
     return get_torg_table_result( value, success_table )
   end
 
@@ -30,18 +30,18 @@ class Torg1_5 < Torg
   # 対人行為結果表
   # 威圧／威嚇(intimidate/Test)
   def get_torg_interaction_result_intimidate_test(value)
-    
+
     interaction_results_table = [
         [0, "萎縮"],
         [5, "技能なし"],
         [10, "逆転負け"],
         [15, "モラル崩壊"],
         [17, "プレイヤーズコール" ]]
-    
+
     return get_torg_table_result( value, interaction_results_table )
   end
-  
-  
+
+
   # 挑発／トリック(Taunt/Trick)
   def get_torg_interaction_result_taunt_trick(value)
     interaction_results_table = [
@@ -50,11 +50,11 @@ class Torg1_5 < Torg
         [10, "逆転負け"],
         [15, "高揚／逆転負け"],
         [17, "プレイヤーズコール" ]]
-    
+
     return get_torg_table_result( value, interaction_results_table )
   end
-  
-  
+
+
   # 間合い(maneuver)
   def get_torg_interaction_result_maneuver(value)
     interaction_results_table = [
@@ -63,11 +63,11 @@ class Torg1_5 < Torg
         [10, "技能なし"],
         [15, "逆転負け／疲労"],
         [17, "プレイヤーズコール" ]]
-    
+
     return get_torg_table_result( value, interaction_results_table )
   end
-  
-  
+
+
   # オーズダメージチャート
   def get_torg_damage_ords(value)
     damage_table_ords = [
@@ -90,8 +90,8 @@ class Torg1_5 < Torg
 
     return get_torg_damage(value, 4, 8, damage_table_ords)
   end
-  
-  
+
+
   # ポシビリティー能力者ダメージチャート
   def get_torg_damage_posibility(value)
     damage_table_posibility = [
@@ -111,27 +111,27 @@ class Torg1_5 < Torg
         [13, "2レベル負傷  K／O5"],
         [14, "2レベル負傷  KO5"],
         [15, "3レベル負傷  KO5"]]
-        
+
     return get_torg_damage(value, 3, 5, damage_table_posibility)
   end
-  
-  
+
+
   def get_torg_damage(value, max_damage, max_shock, damage_table)
-    
+
     if( value < 0 )
       return '1'
     end
-    
+
     table_max_value = damage_table.length - 1
-    
+
     if( value <= table_max_value )
       return get_torg_table_result( value, damage_table )
     end
-    
+
     over_kill_value = ((value - table_max_value) / 2).to_i
     over_kill_damage = max_damage + over_kill_value * 1
     over_kill_shock = max_shock + over_kill_value * 1
-    
+
     return "#{over_kill_damage}レベル負傷  KO#{over_kill_shock}"
   end
 end

--- a/src/diceBot/WARPS.rb
+++ b/src/diceBot/WARPS.rb
@@ -4,22 +4,22 @@ class WARPS < DiceBot
   def gameName
     'ワープス'
   end
-  
+
   def gameType
     "WARPS"
   end
-  
+
   def getHelpMessage
     return <<INFO_MESSAGE_TEXT
 失敗、成功度の自動判定を行います。
 INFO_MESSAGE_TEXT
   end
-  
+
   def check_2D6(total_n, dice_n, signOfInequality, diff, dice_cnt, dice_max, n1, n_max)  # ゲーム別成功度判定(2D6)
     debug('WARPS check_2D6 betgin')
     debug('diff', diff)
     debug('total_n', total_n)
-    
+
     if(dice_n <= 2)
       return " ＞ クリティカル"
     elsif(dice_n >= 12)
@@ -36,5 +36,5 @@ INFO_MESSAGE_TEXT
     end
     return output
   end
-  
+
 end

--- a/src/diceBot/WaresBlade.rb
+++ b/src/diceBot/WaresBlade.rb
@@ -1,28 +1,28 @@
 # -*- coding: utf-8 -*-
 
 class WaresBlade < DiceBot
-  
+
   def initialize
     super
   end
-  
+
   def gameName
     'ワースブレイド'
   end
-  
+
   def gameType
     "WaresBlade"
   end
-  
+
   def getHelpMessage
     return <<MESSAGETEXT
 nD10>=m 方式の判定で成否、完全成功、完全失敗を自動判定します。
 MESSAGETEXT
   end
-  
+
   def check_nD10(total_n, dice_n, signOfInequality, diff, dice_cnt, dice_max, n1, n_max)# ゲーム別成功度判定(nD10)
     return '' unless( signOfInequality == '>=' )
-    
+
     if( dice_n == 10*dice_cnt )
 
       return ' ＞ 完全成功'

--- a/src/diceBot/WorldOfDarkness.rb
+++ b/src/diceBot/WorldOfDarkness.rb
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
 
 class WorldOfDarkness < DiceBot
-  
+
   setPrefixes(['\d+st.*'])
-  
+
   def initialize
     super
     @successDice = 0
@@ -11,15 +11,15 @@ class WorldOfDarkness < DiceBot
     @rerollDice = 0
 
   end
-  
+
   def gameName
     'ワールドオブダークネス'
   end
-  
+
   def gameType
     "WorldOfDarkness"
   end
-  
+
   def getHelpMessage
     return <<INFO_MESSAGE_TEXT
 ・判定コマンド(xSTn+y or xSTSn+y)
@@ -106,7 +106,7 @@ INFO_MESSAGE_TEXT
        end
 
        diceResults[i] = dice_now
-    end 
+    end
 
 	diceResults.sort!
 

--- a/src/diceBot/YankeeYogSothoth.rb
+++ b/src/diceBot/YankeeYogSothoth.rb
@@ -69,10 +69,10 @@ INFO_MESSAGE_TEXT
     when 'RTT'   # ランダム特技決定表
       return getRandomSkillTableResult(command)
     end
-    
+
     return getTableDiceCommandResult(command)
   end
-  
+
 
   # 指定特技ランダム決定表
   def getRandomSkillTableResult(command)
@@ -95,8 +95,8 @@ INFO_MESSAGE_TEXT
 
     return output
   end
-  
-  
+
+
   def getTableDiceCommandResult(command)
 
     info = @@tables[command]
@@ -123,7 +123,7 @@ INFO_MESSAGE_TEXT
 
     return "#{name}(#{number}) ＞ #{text}"
   end
-  
+
   def getD66Table(table)
     table.map do |item|
       if item.kind_of?(String) and  /^(\d+):(.*)/ === item
@@ -133,8 +133,8 @@ INFO_MESSAGE_TEXT
       end
     end
   end
-  
-  
+
+
   @@tables =
     {
     'FT' => {
@@ -148,7 +148,7 @@ INFO_MESSAGE_TEXT
 つまらないことで怪我をする。自分の【HP】が1D6点減少する。
 逆境に燃える。テンションが1段階上昇する。
 },},
-    
+
     'WT' => {
       :name => "変調表",
       :type => '1D6',
@@ -386,6 +386,6 @@ INFO_MESSAGE_TEXT
 66:売店で売っているお菓子をコンプリートした
 },},
   }
-  
+
   setPrefixes(['RTT'] + @@tables.keys)
 end

--- a/src/diceBot/_InsaneScp.rb
+++ b/src/diceBot/_InsaneScp.rb
@@ -1,7 +1,7 @@
 #--*-coding:utf-8-*--
 
 class Insane < DiceBot
-  
+
   def initialize
     super
     @sendMode = 2
@@ -11,16 +11,16 @@ class Insane < DiceBot
   def gameName
     'インセイン'
   end
-  
+
   def gameType
     "Insane"
   end
-  
+
   def prefixes
      ['ST', 'HJST', 'MTST', 'DVST', 'DT', 'BT', 'PT', 'FT', 'JT', 'BET', 'RTT', 'TVT', 'TET', 'TPT', 'TST', 'TKT', 'TMT',
       'CHT', 'VHT', 'IHT', 'RHT', 'MHT', 'LHT', 'ECT','EMT','EAT','OPT','OHT','OWT','CNT1','CNT2','CNT3','RET', 'IRN']
   end
-  
+
   def getHelpMessage
     return <<INFO_MESSAGE_TEXT
 ・判定
@@ -54,25 +54,25 @@ class Insane < DiceBot
 ・D66ダイスあり
 INFO_MESSAGE_TEXT
   end
-  
-  
+
+
   def changeText(string)
     string
   end
-  
-  
+
+
   def dice_command_xRn(string, nick_e)
     ''
   end
-  
+
   # ゲーム別成功度判定(2D6)
   def check_2D6(total_n, dice_n, signOfInequality, diff, dice_cnt, dice_max, n1, n_max)
-    
+
     debug("total_n, dice_n, signOfInequality, diff, dice_cnt, dice_max, n1, n_max", total_n, dice_n, signOfInequality, diff, dice_cnt, dice_max, n1, n_max)
-    
+
     return '' unless(signOfInequality == ">=")
-    
-    output = 
+
+    output =
       if(dice_n <= 2)
         " ＞ ファンブル(判定失敗。山札から【狂気】を1枚獲得)"
       elsif(dice_n >= 12)
@@ -82,17 +82,17 @@ INFO_MESSAGE_TEXT
       else
         " ＞ 失敗"
       end
-    
+
     return output
   end
-  
-  
-  
+
+
+
   def rollDiceCommand(command)
     output = '1'
     type = ""
     total_n = ""
-    
+
     case command
     when 'ST'
       type = 'シーン表'
@@ -197,7 +197,7 @@ INFO_MESSAGE_TEXT
       type = '暫定整理番号作成'
       output, total_n = get_interim_reference_number
     end
-    
+
     return "#{type}(#{total_n}) ＞ #{output}"
   end
 
@@ -216,7 +216,7 @@ INFO_MESSAGE_TEXT
             '人ごみ。喧騒。けたたましい店内BGMに、調子っぱずれの笑い声。騒がしい繁華街の一角だが……？',
             '明るい光りに照らされて、ほっと一息。だが光が強いほどに、影もまた濃くなる……。',
             ]
-    
+
     return get_table_by_2d6(table)
   end
 
@@ -236,7 +236,7 @@ INFO_MESSAGE_TEXT
         '甲高い泣き声が、響き渡る。猫や子供がどこかで泣いているのか？　それとも……。',
         '寝苦しくて目を覚ます。何か悪夢を見ていたようだが……。あれ、意識はあるのに身体が動かない！',
             ]
-    
+
     return get_table_by_2d6(table)
   end
 
@@ -255,7 +255,7 @@ INFO_MESSAGE_TEXT
             '河岸に建つ工場跡。ずいぶん前に空き家になったらしく、建物は崩れかけている。どうやら浮浪者の住処になっているらしい。',
             '静かな室内。なにか、不穏な気配を感じるが……あれはなんだ？　窓に、窓に！',
              ]
-    
+
     return get_table_by_2d6(table)
   end
 
@@ -302,10 +302,10 @@ INFO_MESSAGE_TEXT
              [56, '「本体表を使用する」のような'],
              [66, '虹色に輝く'],
             ]
-    
+
     return get_table_by_d66_swap(table)
   end
-  
+
   # 本体表
   def get_body_table
     table = [
@@ -331,11 +331,11 @@ INFO_MESSAGE_TEXT
              [56, '「部位表」を使用する'],
              [66, '小人'],
             ]
-    
+
     return get_table_by_d66_swap(table)
   end
-  
-  
+
+
   # 部位表
   def get_parts_table
     table = [
@@ -361,11 +361,11 @@ INFO_MESSAGE_TEXT
              [56, '枝や葉'],
              [66, '内臓'],
             ]
-  
+
     return get_table_by_d66_swap(table)
   end
-  
-  
+
+
   # 感情表
   def get_fortunechange_table
     table = [
@@ -376,7 +376,7 @@ INFO_MESSAGE_TEXT
         '憧憬（プラス）／劣等感（マイナス）',
         '狂信（プラス）／殺意（マイナス）',
             ]
-    
+
     return get_table_by_1d6(table)
   end
 
@@ -405,7 +405,7 @@ INFO_MESSAGE_TEXT
              [56, '夜の蝶≪笑い≫≪官能≫'],
              [66, '用心棒　好きな暴力×2'],
             ]
-    
+
     return get_table_by_d66_swap(table)
   end
 
@@ -437,7 +437,7 @@ INFO_MESSAGE_TEXT
       ['知識', ['物理学', '数学', '化学', '生物学', '医学', '教養', '人類学', '歴史', '民俗学', '考古学', '天文学']],
       ['怪異', ['時間', '混沌', '深海', '死', '霊魂', '魔術', '暗黒', '終末', '夢', '地底', '宇宙']],
     ]
-    
+
     skillTable, total_n = get_table_by_1d6(skillTableFull)
     tableName, skillTable = *skillTable
     skill, total_n2 = get_table_by_2d6(skillTable)
@@ -449,7 +449,7 @@ INFO_MESSAGE_TEXT
     text, = get_random_skill_table
     return text
   end
-  
+
   # 指定特技ランダム決定(暴力)
   def get_violence_skill_table
     table = [
@@ -467,7 +467,7 @@ INFO_MESSAGE_TEXT
             ]
     return get_table_by_2d6(table)
   end
-  
+
   # 指定特技ランダム決定(情動)
   def get_emotion_skill_table
     table = [
@@ -485,7 +485,7 @@ INFO_MESSAGE_TEXT
             ]
     return get_table_by_2d6(table)
   end
-  
+
   # 指定特技ランダム決定(知覚)
   def get_perception_skill_table
     table = [
@@ -503,7 +503,7 @@ INFO_MESSAGE_TEXT
             ]
     return get_table_by_2d6(table)
   end
-  
+
   # 指定特技ランダム決定(技術)
   def get_skill_skill_table
     table = [
@@ -521,7 +521,7 @@ INFO_MESSAGE_TEXT
             ]
     return get_table_by_2d6(table)
   end
-  
+
   # 指定特技ランダム決定(知識)
   def get_knowledge_skill_table
     table = [
@@ -539,7 +539,7 @@ INFO_MESSAGE_TEXT
             ]
     return get_table_by_2d6(table)
   end
-  
+
   # 指定特技ランダム決定(怪異)
   def get_mystery_skill_table
     table = [
@@ -557,7 +557,7 @@ INFO_MESSAGE_TEXT
             ]
     return get_table_by_2d6(table)
   end
-  
+
   # 会話ホラースケープ表
   def get_conversation_horror_table
     table = [
@@ -581,7 +581,7 @@ INFO_MESSAGE_TEXT
              "指定特技：混沌\n電柱の根元に、女性がうずくまっている。お腹を押さえて、苦しそうに顔を伏せている。「大丈夫ですか？」近づいて声をかけたあなたに、女性は頷いた。「はい――ありがとうございます。」そう言って顔を上げた女性の顔には、何もなかった。つるりとした剥き玉子のような皮膚が続いているだけだった。うわっ！？のけぞった途端、意識が遠ざかって、気がつくとあなたは電柱の根元にうずくまっていた。",
              "指定特技：笑い\n駅に着くと、やけに混雑している。人身事故で電車が止まっているようだ。ツイてないな。そう思っていると、改札付近の人ごみの中から、和服の女性が急ぎ足であなたのほうへ近づいてきた。女性は満面の笑みを浮かべていた。独りごとを言っているのか、口が動いている。すれ違いざまに、女性の声が耳に入った。「やってやった。やってやった。やってやった。ざまあみろ」えっ、と思って振り返るあなたを残して、女性は人ごみの中へ消えていった。",
             ]
-    
+
     return get_table_by_1d6(table)
   end
 
@@ -595,7 +595,7 @@ INFO_MESSAGE_TEXT
              "指定特技：手触り\nぽたり。ぽたり。首筋に落ちた生暖かい水滴の感触に、あなたは眉を寄せた。気がつくと机の上に、赤い雫が落ちている。鉄臭いにおいが鼻を突く。ぽたり。ぽたり。ぽたり。雫は勢いを増し、次々と落ちてきて、机の上に広がってゆく。ゆっくりと見上げると、天井には大きく赤黒いしみが広がっていた。ぽたり。ぽたりぽたり。ぽたり。――ぼたぼたぼたっ！高まる水音にあなたは立ちすくむ。天井裏に、いったい何が……？",
              "指定特技：地底\n見慣れたはずの場所に、見慣れない扉を見つけた。開けてみると、長い下り階段が闇の中に伸びている。不審に思って下りてみると……そこは地下室だった。こんな場所があったなんて。明かりを片手に進んでいくと、何かが近づいてくる気配がする。闇の中から、何者かが、あなたの名を呼んだ。",
             ]
-    
+
     return get_table_by_1d6(table)
   end
 
@@ -609,7 +609,7 @@ INFO_MESSAGE_TEXT
              "指定特技：罠\n廃墟を歩いていると、いきなり足に激痛が走った。悲鳴をこらえて下を見ると、あなたの足首をがっちりとトラバサミが捕えている。なぜこんな場所に、こんな罠が……？苦労してトラバサミを解除して、改めて周りを見たとき、あなたは愕然とする。罠は一つだけではなかった。瓦礫の下に隠すようにして、いくつもいくつも、トラバサミが仕掛けられていた。",
              "指定特技：薬品\n不意に、シンナーの匂いが鼻を刺した。廃墟の壁にべったりと、赤いペンキの文字が書かれている。何が書いてあるのかは判然としないが、ひたすら悪意と憎しみを塗り込めたようなタッチにおぞけが走る。そのうちあることに気付いて、あなたは総毛立った。ペンキがまだ新しい。……塗り立てのように新しいのだ。",
             ]
-    
+
     return get_table_by_1d6(table)
   end
 
@@ -623,7 +623,7 @@ INFO_MESSAGE_TEXT
              "指定特技：物陰\n藪の中に廃車が埋もれている。特徴のない白いバンだ。窓は真っ黒な煤で汚れていて、何も見えない。車体は錆び付いて、塗料も剥がれ、打ち棄てられて久しい廃車であることは確実だ。――それなのに、廃車の中から刺すような視線を感じる。ロックが外れる音がして、ゆっくりと後部座席のドアが開き始める……。",
              "指定特技：焼却\nパチ……パチ……。火の燃える音がする。空き地で焚火が炎を上げていた。そばには誰もいない。心温まる思いで立ち止まり、木の枝で焚火をかき回していると、炎の中から軽やかな笑い声が聞こえた。ぎょっとするあなたの足許を、猫のような大きさの何かがするりと抜けていった。焚火に目を戻すと、そこにはただ、くすぶる骨の塊が残されているだけだった。",
             ]
-    
+
     return get_table_by_1d6(table)
   end
 
@@ -637,7 +637,7 @@ INFO_MESSAGE_TEXT
              "指定特技：魔術\n資料の中から、奇妙な古書が出てきた。皮装丁の豪華な本で、妙な臭いがする。文書は支離滅裂で、正気の人間が書いたとは思えない。だが、破れそうなページを一枚一枚めくっていくと、しだいに作者の言っていることがわかってくる。どんどん、どんどん、わかってくる。ああ、もう、わかる。完全にわかる。もう大丈夫だ。きっとこの本は、あなたに読まれるために書かれたのだ。",
              "指定特技：歴史\n表紙のないレポートが見つかった。パラパラめくってみると、まさにあなたが今調べている件についての調査報告だった。もどかしいことに、あちこち墨塗りされていて、肝心のところがわからない。察するに、どうも、軍による調査のようだ。軍？なぜ軍隊がこの件を調べていたのだろう……？",
             ]
-    
+
     return get_table_by_1d6(table)
   end
 
@@ -651,7 +651,7 @@ INFO_MESSAGE_TEXT
              "幽霊自動車×1　デッドループｐ193",
              "怨霊×1　基本ｐ245",
             ]
-    
+
     return get_table_by_1d6(table)
   end
 
@@ -665,7 +665,7 @@ INFO_MESSAGE_TEXT
              "人狼×1　基本ｐ265",
              "くねくね×1　デッドループｐ193",
             ]
-    
+
     return get_table_by_1d6(table)
   end
 
@@ -679,7 +679,7 @@ INFO_MESSAGE_TEXT
              "魔女×1　基本ｐ245",
              "這いずるもの×1　基本ｐ261",
             ]
-    
+
     return get_table_by_1d6(table)
   end
 
@@ -693,7 +693,7 @@ INFO_MESSAGE_TEXT
              "指定特技：憂い\n視界の隅を、暗い顔の男が通り過ぎるのが見えた。振り返ってみても、誰もいない。誰だ？知らないぞ、あんな奴。",
              "指定特技：暗黒\nバツン！突然の停電でフロアが闇に沈んだ。驚いて顔を上げると、闇の中にたくさんの人影が佇んで、じっとあなたを見ている……！",
             ]
-    
+
     return get_table_by_1d6(table)
   end
 
@@ -707,7 +707,7 @@ INFO_MESSAGE_TEXT
              "「ちょっと、この前の仕事だけどどうなってるんだ！」別件のクレームの電話だ！疲れた精神にダメージを負って、【正気度】マイナス1。",
              "「……ねばいいのに。」電話の向こうから地獄のような声が囁く。ぞっとして反射的に電話を切る。着信履歴は残っていない……なんだ今の！？《電子機器》で恐怖判定。",
             ]
-    
+
     return get_table_by_1d6(table)
   end
 
@@ -728,7 +728,7 @@ INFO_MESSAGE_TEXT
             ]
     return get_table_by_2d6(table)
   end
-  
+
   # 社名決定表1
   def get_corporatenameone_table
     table = [
@@ -739,7 +739,7 @@ INFO_MESSAGE_TEXT
              "クリムゾン",
              "ボンバー",
             ]
-    
+
     return get_table_by_1d6(table)
   end
 
@@ -753,7 +753,7 @@ INFO_MESSAGE_TEXT
              "ホラー",
              "インセイン",
             ]
-    
+
     return get_table_by_1d6(table)
   end
 
@@ -767,7 +767,7 @@ INFO_MESSAGE_TEXT
              "(有)",
              "(有)",
             ]
-    
+
     return get_table_by_1d6(table)
   end
 

--- a/src/diceBot/_Template.rb
+++ b/src/diceBot/_Template.rb
@@ -3,10 +3,10 @@
 class Template < DiceBot
   # ダイスボットで使用するコマンドを配列で列挙する
   setPrefixes([])
-  
+
   def initialize
     super
-    
+
     # @sendMode = @@DEFAULT_SEND_MODE #(0=結果のみ,1=0+式,2=1+ダイス個別)
     # @sortType = 0;      #ソート設定(1 = 足し算ダイスでソート有, 2 = バラバラロール（Bコマンド）でソート有, 3 = １と２両方ソート有）
     # @sameDiceRerollCount = 0;     #ゾロ目で振り足し(0=無し, 1=全部同じ目, 2=ダイスのうち2個以上同じ目)
@@ -20,45 +20,45 @@ class Template < DiceBot
     # @rerollLimitCount = 0;    #振り足し回数上限
     # @fractionType = "omit";     #端数の処理 ("omit"=切り捨て, "roundUp"=切り上げ, "roundOff"=四捨五入)
   end
-  
+
   def gameName
     'ゲーム名'
   end
-  
+
   def gameType
     "GameType"
   end
-  
+
   def getHelpMessage
     return <<MESSAGETEXT
 ヘルプメッセージ
 ダイスボットの使い方をここに記述します。
 MESSAGETEXT
   end
-  
+
   def changeText(string)
     string
   end
-  
+
   def rollDiceCommand(command)
     ''
   end
-  
+
   # ゲーム別成功度判定(2D6)
   def check_2D6(total_n, dice_n, signOfInequality, diff, dice_cnt, dice_max, n1, n_max)
     ''
   end
-  
+
   # ゲーム別成功度判定(nD6)
   def check_nD6(total_n, dice_n, signOfInequality, diff, dice_cnt, dice_max, n1, n_max)
     ''
   end
-  
+
   # ゲーム別成功度判定(nD10)
   def check_nD10(total_n, dice_n, signOfInequality, diff, dice_cnt, dice_max, n1, n_max)
     ''
   end
-  
+
   # ゲーム別成功度判定(1d100)
   def check_1D100(total_n, dice_n, signOfInequality, diff, dice_cnt, dice_max, n1, n_max)
     ''
@@ -68,8 +68,8 @@ MESSAGETEXT
   def check_1D20(total_n, dice_n, signOfInequality, diff, dice_cnt, dice_max, n1, n_max)
     ''
   end
-  
-  
+
+
   #以下のメソッドはテーブルの参照用に便利
   #get_table_by_2d6(table)
   #get_table_by_1d6(table)
@@ -78,6 +78,6 @@ MESSAGETEXT
   #get_table_by_1d3(table)
   #get_table_by_number(index, table)
   #get_table_by_d66(table)
-  
+
   #getDiceList を呼び出すとロース結果のダイス目の配列が手に入ります。
 end

--- a/src/irc/encode.rb
+++ b/src/irc/encode.rb
@@ -87,7 +87,7 @@ if RUBY_VERSION < '1.9.0' then
        self
      end
    end
-   
+
  end
- 
+
 end

--- a/src/irc/ircBot.rb
+++ b/src/irc/ircBot.rb
@@ -5,104 +5,104 @@ require 'configBcDice.rb'
 require 'ArgsAnalizer.rb'
 
 class IrcClient < Net::IRC::Client
-  
+
   def initialize(*args)
     super
-    
+
     host, port, *options = *args
-    
+
     @bcdiceMarker = BCDiceMaker.new
-    
+
     @loginChannelList = $defaultLoginChannelsText.split(',')
   end
-  
+
   def newBcDice
     bcdice = @bcdiceMarker.newBcDice()
     bcdice.setIrcClient(self)
     return bcdice
   end
-  
+
   def readExtraCard(cardFileName)
     bcdice = newBcDice()
     bcdice.readExtraCard(cardFileName)
   end
-  
+
   def ownNick
     @opts.nick
   end
-  
+
   def setRoom(room)
     @room = room
   end
-  
+
   def setGameByTitle(game_type)
     bcdice = newBcDice()
     bcdice.setGameByTitle(game_type)
   end
-  
+
   def on_connected(*args)
     printText( '  -> IRC server is connected.' )
-    
+
     channelNames = @loginChannelList.join(',')
     channelNames = encode($ircCode, channelNames)
-    
+
     join(channelNames);
     topic(channelNames);
-    
+
     printText( "login to channels(#{channelNames}), so wait a moment..." )
   end
-  
-  
+
+
   def on_rpl_welcome(message)
     printText( '  -> login to channel successed.' )
     #post JOIN, @room.encode($ircCode).force_encoding_maybe('external')
     post(JOIN, encode($ircCode, @room))
   end
-  
-  
+
+
   def on_init( event )
     args = event.args;
-    
+
     shift( args );
     debug_out("*** #{args.ispect}\n");
   end
 
   def on_part( event )
     channel = getChannel(event)
-    
+
     debug_out("*** %s has left channel %s\n", event.nick, channel);
   end
-  
-  
+
+
   def on_join( event )
     debug('on_join event', event)
-    
+
     channel = getChannel(event)
     nick_e = getNickEFromEvent(event)
     host_j = event.prefix.host;
-    
+
     debug("join nick_e, host_j, channel", nick_e, host_j, channel);
-    
+
     if ( host_j =~ /^someone\@somewhere\.else\.com$/)  # Auto-ops anyone who
       debug_out("Give  to #{nick_e}\n");
       self.mode( encode($ircCode, channel), "+o", nick_e);      # matches hostmask.
     end
   end
-  
+
   def on_invite( event )
     channel = getChannel(event)
-    
+
     debug_out("*** %s (%s) has invited me to channel %s\n",
               event.nick, event.userhost, channel);
-    
+
     addChannel(channel);
     self.join( encode($ircCode, channel) );
     self.topic( encode($ircCode, channel) );
   end
-  
+
   def on_kick( event )
     channel = getChannel(event)
-    
+
     mynick = self.nick;
     target = (event.to)[0];
 
@@ -111,141 +111,141 @@ class IrcClient < Net::IRC::Client
       deleteChannel(channel);
     end
   end
-  
+
   def on_msg( event )
     debug('on_msg begin')
-    
+
     nick_e = getNickEFromEvent(event)
     channel = getChannel(event)
-    
+
     arg = getArg(event)
     tnick = "";
     if( /->/ =~ arg )
       arg, tnick, *dummy = arg.split(/->/)
     end
-    
+
     debug("nick_e, arg, tnick", nick_e, arg, tnick)
-    
+
     bcdice = newBcDice()
     bcdice.setMessage(arg)
     bcdice.setChannel(channel)
     bcdice.recieveMessage(nick_e, tnick)
   end
-  
+
   def on_privmsg(event)
     debug("=============>on_privmsg begin event", event)
     on_public(event)
   end
-  
+
   def on_public(event)
     debug('on_public begin')
     debug('on_public event', event)
     debug('on_public begin ownNick', ownNick)
-    
+
     channel = getChannel(event)
     debug('on_public channel', channel)
 
     if( channel == ownNick )
       return on_msg( event )
     end
-    
+
     arg = getArg(event)
-    
+
     debug('on_public arg', arg)
-    
+
     nick_e = getNickEFromEvent(event)
     debug("on_public nick_e : #{nick_e}")
-    
+
     bcdice = newBcDice()
     bcdice.setMessage(arg)
     bcdice.setChannel(channel)
     bcdice.recievePublicMessage(nick_e)
   end
-  
+
   def getNickEFromEvent(event)
     nick_e = event.prefix.nick.toutf8
   end
-  
+
   def getChannel(event)
     channel = event.params[0].toutf8
   end
-  
+
   def getArg(event)
     arg = event.params[1].toutf8
   end
-  
+
   def setPrintFuction(func)
     @printFunction = func
   end
-  
+
   def printText(text)
     return if( @printFunction.nil? )
-    
+
     @printFunction.call(text)
   end
-  
+
   def on_err_nicknameinuse(event)
     debug_out("on_err_nicknameinuse being !")
     debug_out("@opts.nick", @opts.nick)
-    
+
     oldNick = @opts.nick
     newNick = getNewNick(oldNick)
     @opts.nick = newNick
     debug_out("newNick", newNick)
-    
+
     printText( "  -> nick \"#{oldNick}\" is already used, so change \"#{oldNick}\" -> \"#{newNick}\"" )
-    
+
     post(NICK, @opts.nick)
   end
-  
+
   def getNewNick(nick)
     debug_out("getNewNick nick", nick)
-    
+
     @nickIndex ||= 1
     @nickIndex += 1
     @log.debug("@nickIndex:#{@nickIndex}")
-    
+
     nickIndexText = sprintf("%d", @nickIndex)
     @log.debug("nickIndexText:#{nickIndexText}")
-    
+
     newNick = nick + nickIndexText
     diff = newNick.length - $ircNickMaxLength
     @log.debug("newNick:#{newNick}, newNick.length#{newNick.length}")
     @log.debug("diff:#{diff}")
-    
+
     if( diff > 0 )
       nickBase = nick[0...(diff * -1)]
       @log.debug("getNewNick nickBase:#{nickBase}")
       newNick = nickBase + nickIndexText
     end
-    
+
     @log.debug("newNick:#{newNick}")
     return newNick
   end
-  
+
   def isMaster
     bcdice = newBcDice()
     bcdice.isMaster
   end
-  
+
   def quit
     debug('quitCommand')
     debug('isMaster()', isMaster())
-    
+
     return unless( isMaster() )
-    
+
     post(QUIT, encode($ircCode, $quitMessage))
   end
-  
+
   def setQuitFuction(func)
     bcdice = newBcDice()
     bcdice.setQuitFuction(func)
   end
-  
+
   def addChannel(add_ch)
     @loginChannelList << add_ch
   end
-  
+
   def deleteChannel(del_ch)
     @loginChannelList.delete_if{|i| i == del_ch}
   end
@@ -259,7 +259,7 @@ class IrcClient < Net::IRC::Client
   def sendMessageToOnlySender(nick_e, message)
     sendMessage(nick_e, message)
   end
-  
+
   def sendMessage(to, message)
     return if message.empty?
 
@@ -277,37 +277,37 @@ class IrcClient < Net::IRC::Client
       sleep(1)
     end
   end
-  
-  
+
+
   def insertEnterToTooLongMessage(message)
-    
+
     if( message.length <= $SEND_STR_MAX)
       return message
     end
-    
+
     result = ""
     index = 1
-    
+
     message.chars do |ch|
       result << ch
-      
+
       if( result.length > ($SEND_STR_MAX * index) )
         result << "\n"
         index += 1
       end
     end
-    
+
     return result
   end
-  
-  
+
+
   def notice(to, message)
     post(NOTICE, to, encode($ircCode, message))
   end
-  
+
   def privmsg(to, message)
     post(PRIVMSG, to, encode($ircCode, message))
-  end  
+  end
 end
 
 
@@ -318,28 +318,28 @@ def getInitializedIrcBot()
                :nick => $nick, :user => $userName, :real => $ircName
              })
   debug("$server, $port, $nick, $userName, $ircName", $server, $port, $nick, $userName, $ircName)
-  
+
   room = $defaultLoginChannelsText.split(',').first
   ircBot.setRoom(room)
-  
+
   ircBot.setGameByTitle( $defaultGameType )
-  
+
   unless( $extraCardFileName.empty? )
     ircBot.readExtraCard( $extraCardFileName )
   end
-  
+
   return ircBot
 end
 
 def mainIrcBot(args = [])
   argsAnalizer = ArgsAnalizer.new(args)
   argsAnalizer.analize
-  
+
   ircBot = getInitializedIrcBot()
-  
+
   if( argsAnalizer.isStartIrc )
     ircBot.start
   end
-  
+
   return ircBot
 end

--- a/src/irc/ircLib.rb
+++ b/src/irc/ircLib.rb
@@ -11,7 +11,7 @@ require 'socket.so'
 require 'encode.rb'
 
 class Net::IRC::Client
-  
+
   # Connect to server and start loop.
   def start
     @log.debug "start begin";
@@ -36,7 +36,7 @@ class Net::IRC::Client
     post NICK, @opts.nick
     @log.debug "post USER";
     post USER, @opts.user, "0", "*", @opts.real
-    
+
     @log.debug "while loop begin";
     l = nil
     while true
@@ -58,10 +58,10 @@ class Net::IRC::Client
         raise
       end
     end
-    
+
   rescue IOError
   ensure
     finish
   end
-  
+
 end

--- a/src/irc/ircLib.rb
+++ b/src/irc/ircLib.rb
@@ -58,7 +58,6 @@ class Net::IRC::Client
         raise
       end
     end
-
   rescue IOError
   ensure
     finish

--- a/src/irc/torgtaitaiIRC.rb
+++ b/src/irc/torgtaitaiIRC.rb
@@ -1,18 +1,18 @@
 # -*- coding: utf-8 -*-
 
 class TorgtaitaiIRC
-  
+
   def initialize()
     @isSecretMarkerPrinted = false
-    
+
     maker = BCDiceMaker.new
     @bcdice = maker.newBcDice
     @bcdice.setIrcClient(self)
-    
+
     @isTest = false
     @buffer = ''
   end
-  
+
   def privmsg(to, message)
     #シークレットダイスの場合はここでマーカーを出力し、どどんとふにその旨を通達。
     #マーカーは1回だけ出力すれば十分なので2回目以降は抑止
@@ -20,91 +20,91 @@ class TorgtaitaiIRC
       print("##>isSecretDice<##") unless( @isTest )
       @isSecretMarkerPrinted = true
     end
-    
+
     notice(to, message);
   end
-  
-  
-  
-  
+
+
+
+
   def notice(to, message)
     #print( "\n#{@game_type} " );
     #print( message.tosjis + "\n");
-    
+
     #output = "#{to.inspect}:#{message.tosjis}\n"
     #output = "#{message.tosjis}\n"
     output = "\n#{@gameType} #{message.tosjis}\n"
     print(output) unless( @isTest )
-    
+
     if( @isTest )
       @buffer << output
     end
   end
-  
+
   def setTest
     @isTest = true
   end
-  
+
   def getBuffer
     @buffer
   end
-  
+
   def clearBuffer
     @buffer = ''
   end
-  
+
   def setRandomValues(rands)
     @bcdice.setRandomValues(rands)
   end
-  
+
   def newconn
     self
   end
-  
+
   def add_handler(name, function)
     if( name == "public" )
       function.call(self)
     end
   end
-  
+
   def add_global_handler
   end
-  
+
   def start
   end
-  
+
   def quitCommand(arg)
   end
-  
+
   def sendMessage(to, message)
     notice(to, message)
   end
-  
+
   def sendMessageToOnlySender(nick_e, message)
     notice(nick_e, message)
   end
-  
+
   def sendMessageToChannels(message)
     notice('allChannels', message)
   end
-  
+
   def setGameByTitle(gameType)
     @gameType = gameType
     @bcdice.setGameByTitle(gameType)
   end
-  
+
   def recieveMessage
     # @bcdice.recieveMessage('nick_e', 'tnick', message)
     @bcdice.setChannel('channel')
     @bcdice.recieveMessage('', '')
   end
-  
+
   def recievePublicMessage
     # @bcdice.recievePublicMessage('nick_e', message)
     @bcdice.setChannel('channel')
     @bcdice.recievePublicMessage('')
   end
-  
+
   def setMessage(message)
     @bcdice.setMessage(message)
   end

--- a/src/test/DiceBotTest.rb
+++ b/src/test/DiceBotTest.rb
@@ -65,23 +65,23 @@ class DiceBotTest
 
     targetFiles.each do |filename|
       next if /^_/ === File.basename(filename)
-      
+
       source =
         if RUBY_VERSION < '1.9'
           File.read(filename)
         else
           File.read(filename, :encoding => 'UTF-8')
         end
-      
+
       dataSetSources = source.
         gsub("\r\n", "\n").
         tr("\r", "\n").
         split("============================\n").
         map(&:chomp)
-      
+
       # ゲームシステムをファイル名から判断する
       gameType = File.basename(filename, '.txt')
-      
+
       dataSet =
         if RUBY_VERSION < '1.9'
           dataSetSources.each_with_index.map do |dataSetSource, i|
@@ -92,18 +92,18 @@ class DiceBotTest
             DiceBotTestData.parse(dataSetSource, gameType, i)
           end
         end
-      
-      @testDataSet += 
+
+      @testDataSet +=
         if @dataIndex.nil?
           dataSet
         else
           dataSet.select { |data| data.index == @dataIndex }
         end
-      
+
     end
   end
-  
-  
+
+
   private :readTestDataSet
 
   # 各テストを実行する

--- a/src/test/DiceBotTest.rb
+++ b/src/test/DiceBotTest.rb
@@ -99,7 +99,6 @@ class DiceBotTest
         else
           dataSet.select { |data| data.index == @dataIndex }
         end
-
     end
   end
 

--- a/src/test/others/testArgs.rb
+++ b/src/test/others/testArgs.rb
@@ -8,16 +8,16 @@ require 'bcdiceCore.rb'
 require 'ArgsAnalizer.rb'
 
 class TestArgs < Test::Unit::TestCase
-  
+
   def setup
     $isDebug = false
   end
-  
+
   def trace
     $isDebug = true
   end
-  
-  
+
+
   def test_args
     argv = ['-sirc.trpg.net:6667', '-c#OnlineTRPG', '-gCthulhu', '-nfDICE_CoC']
     argsAnalizer = ArgsAnalizer.new(argv)
@@ -28,5 +28,5 @@ class TestArgs < Test::Unit::TestCase
     assert_equal($defaultGameType, 'Cthulhu')
     assert_equal($nick, 'fDICE_CoC')
   end
-  
+
 end

--- a/src/test/others/testCard.rb
+++ b/src/test/others/testCard.rb
@@ -10,66 +10,66 @@ require 'BCDice_forTest'
 $isDebug = false
 
 class TestCardTrader < Test::Unit::TestCase
-  
+
   def setup
     $isDebug = false
-    
+
     maker = BCDiceMaker_forTest.new
     @bcdice = maker.newBcDice()
     @cardTrader = @bcdice.cardTrader
-    
+
     setDefaultNick
   end
-  
+
   def setDefaultNick
     @cardTrader.setNick("test_nick")
   end
-  
+
   def _test_printCardHelp()
     @cardTrader.printCardHelp()
     assert(@bcdice.getResult().length > 100)
   end
-  
+
   def test_invalidCommand()
     @cardTrader.executeCard("aaaa", "channel")
     assert_equal("", @bcdice.getResult())
   end
-  
+
   def test_invalidCommand2()
     @cardTrader.executeCard("c-invalidCommand", "channel")
     assert_equal("", @bcdice.getResult())
   end
-  
+
   def test_shuffleCards()
     @cardTrader.executeCard("c-shuffle", "channel")
     assert_equal("sendMessage\nto:channel\nシャッフルしました\n", @bcdice.getResult())
   end
-  
+
   def test_shuffleCards_min()
     @cardTrader.executeCard("c-sh", "channel")
     assert_equal("sendMessage\nto:channel\nシャッフルしました\n", @bcdice.getResult())
   end
-  
+
   def test_draw
     @bcdice.setRandomValues([[53, 53]])
     @cardTrader.executeCard("c-draw", "channel")
     assert_equal( "sendMessageToOnlySender\nto:\nJ1\nsendMessage\nto:channel\ntest_nick: 1枚引きました\n", @bcdice.getResult())
-    
+
     @bcdice.setRandomValues([[52, 52]])
     @cardTrader.executeCard("c-draw", "channel")
     assert_equal( "sendMessageToOnlySender\nto:\nC13\nsendMessage\nto:channel\ntest_nick: 1枚引きました\n", @bcdice.getResult())
-    
+
     @bcdice.setRandomValues([[1, 51]])
     @cardTrader.executeCard("c-draw", "channel")
     assert_equal( "sendMessageToOnlySender\nto:\nS1\nsendMessage\nto:channel\ntest_nick: 1枚引きました\n", @bcdice.getResult())
   end
-  
+
   def test_draw_3
     @bcdice.setRandomValues([[1, 53], [1, 52], [51, 51]])
     @cardTrader.executeCard("c-draw[3]", "channel")
     assert_equal( "sendMessageToOnlySender\nto:\nJ1,S1,S2\nsendMessage\nto:channel\ntest_nick: 3枚引きました\n", @bcdice.getResult())
   end
-  
+
   def test_draw_full
     rands = []
     cardCount = 53
@@ -77,62 +77,62 @@ class TestCardTrader < Test::Unit::TestCase
       max = cardCount - i
       rands << [1, max]
     end
-    
+
     @bcdice.setRandomValues(rands)
     @cardTrader.executeCard("c-draw[53]", "channel")
     assert_equal( "sendMessageToOnlySender\nto:\nC1,C10,C11,C12,C13,C2,C3,C4,C5,C6,C7,C8,C9,D1,D10,D11,D12,D13,D2,D3,D4,D5,D6,D7,D8,D9,H1,H10,H11,H12,H13,H2,H3,H4,H5,H6,H7,H8,H9,J1,S1,S10,S11,S12,S13,S2,S3,S4,S5,S6,S7,S8,S9\nsendMessage\nto:channel\ntest_nick: 53枚引きました\n", @bcdice.getResult())
-    
+
     @bcdice.setRandomValues([[1, 0]])
     @cardTrader.executeCard("c-draw[1]", "channel")
     assert_equal( "sendMessage\nto:channel\nカードが残っていません\n", @bcdice.getResult())
   end
-  
+
   def test_odraw_3
     @bcdice.setRandomValues([[1, 53], [1, 52], [51, 51]])
     @cardTrader.executeCard("c-odraw[3]", "channel")
     assert_equal( "sendMessage\nto:channel\ntest_nick: J1,S1,S2を引きました\n", @bcdice.getResult())
   end
-  
+
   def test_odraw_full
     drawCards(53, 53)
-    
+
     @bcdice.setRandomValues([[1, 0]])
     @cardTrader.executeCard("c-odraw[1]", "channel")
     assert_equal( "sendMessage\nto:channel\nカードが残っていません\n", @bcdice.getResult())
   end
-  
+
   def test_hand
     @cardTrader.executeCard("c-hand", "channel")
     assert_equal( "sendMessageToOnlySender\nto:\nカードを持っていません 場札:[  ] タップした場札:[  ]\n", @bcdice.getResult())
-    
+
     @bcdice.setRandomValues([[1, 53], [1, 52], [51, 51]])
     @cardTrader.executeCard("c-odraw[3]", "channel")
     assert_equal( "sendMessage\nto:channel\ntest_nick: J1,S1,S2を引きました\n", @bcdice.getResult())
-    
+
     @cardTrader.executeCard("c-hand", "channel")
     assert_equal( "sendMessageToOnlySender\nto:\n[ J1,S1,S2 ] 場札:[  ] タップした場札:[  ]\n", @bcdice.getResult())
   end
-  
+
   def test_vhand
     @bcdice.setRandomValues([[1, 53], [1, 52], [51, 51]])
     @cardTrader.executeCard("c-odraw[3]", "channel")
     assert_equal( "sendMessage\nto:channel\ntest_nick: J1,S1,S2を引きました\n", @bcdice.getResult())
-    
+
     @cardTrader.executeCard("c-vhand test_nick", "channel")
     assert_equal( "sendMessageToOnlySender\nto:\ntest_nick の手札は[ J1,S1,S2 ] 場札:[  ] タップした場札:[  ]です\n", @bcdice.getResult())
   end
-  
+
   def test_play
     @bcdice.setRandomValues([[1, 53], [1, 52], [51, 51]])
     @cardTrader.executeCard("c-odraw[3]", "channel")
     assert_equal( "sendMessage\nto:channel\ntest_nick: J1,S1,S2を引きました\n", @bcdice.getResult())
-    
+
     @cardTrader.executeCard("c-play[S1]", "channel")
     assert_equal( "sendMessage\nto:channel\ntest_nick: 1枚出しました\nsendMessageToOnlySender\nto:\n[ J1,S2 ] 場札:[  ] タップした場札:[  ]\n", @bcdice.getResult())
-    
+
     @cardTrader.executeCard("c-play[J1,S2]", "channel")
     assert_equal( "sendMessage\nto:channel\ntest_nick: 2枚出しました\nsendMessageToOnlySender\nto:\n[  ] 場札:[  ] タップした場札:[  ]\n", @bcdice.getResult())
-    
+
     @cardTrader.executeCard("c-play[C1]", "channel")
     assert_equal( "sendMessage\nto:channel\n[C1]は持っていません\nsendMessageToOnlySender\nto:\n[  ] 場札:[  ] タップした場札:[  ]\n", @bcdice.getResult())
   end
@@ -141,26 +141,26 @@ class TestCardTrader < Test::Unit::TestCase
     @bcdice.setRandomValues([[1, 53], [1, 52], [51, 51]])
     @cardTrader.executeCard("c-draw[3]", "channel")
     assert_equal( "sendMessageToOnlySender\nto:\nJ1,S1,S2\nsendMessage\nto:channel\ntest_nick: 3枚引きました\n", @bcdice.getResult())
-    
+
     @cardTrader.executeCard("c-play1[S1]", "channel")
     assert_equal( "sendMessage\nto:channel\ntest_nick: 1枚出しました\nsendMessageToOnlySender\nto:\n[ J1,S2 ] 場札:[ S1 ] タップした場札:[  ]\n", @bcdice.getResult())
-    
+
     @cardTrader.executeCard("c-play1[J1,S2]", "channel")
     assert_equal( "sendMessage\nto:channel\ntest_nick: 2枚出しました\nsendMessageToOnlySender\nto:\n[  ] 場札:[ J1,S1,S2 ] タップした場札:[  ]\n", @bcdice.getResult())
-    
+
   end
 
   def test_rshuffle
     @bcdice.setRandomValues([[1, 53], [1, 52], [51, 51]])
     @cardTrader.executeCard("c-odraw[3]", "channel")
     assert_equal( "sendMessage\nto:channel\ntest_nick: J1,S1,S2を引きました\n", @bcdice.getResult())
-    
+
     @cardTrader.executeCard("c-play[S1,J1]", "channel")
     assert_equal( "sendMessage\nto:channel\ntest_nick: 2枚出しました\nsendMessageToOnlySender\nto:\n[ S2 ] 場札:[  ] タップした場札:[  ]\n", @bcdice.getResult())
-    
+
     @cardTrader.executeCard("c-rshuffle", "channel")
     assert_equal( "sendMessage\nto:channel\n捨て札を山に戻しました\n", @bcdice.getResult())
-    
+
     @bcdice.setRandomValues([[52, 52]])
     @cardTrader.executeCard("c-odraw[1]", "channel")
     assert_equal( "sendMessage\nto:channel\ntest_nick: J1を引きました\n", @bcdice.getResult())
@@ -172,64 +172,64 @@ class TestCardTrader < Test::Unit::TestCase
     @cardTrader.executeCard("c-play[S1]", "channel")
     @cardTrader.executeCard("c-play1[S2,S3]", "channel")
     debug( @bcdice.getResult() )
-    
+
     @cardTrader.executeCard("c-hand", "channel")
     assert_equal( "sendMessageToOnlySender\nto:\n[ J1 ] 場札:[ S2,S3 ] タップした場札:[  ]\n", @bcdice.getResult())
-    
+
     @cardTrader.executeCard("c-clean", "channel")
     assert_equal( "sendMessage\nto:channel\n場のカードを捨てました\n", @bcdice.getResult())
-    
+
     @cardTrader.executeCard("c-hand", "channel")
     assert_equal( "sendMessageToOnlySender\nto:\n[ J1 ] 場札:[  ] タップした場札:[  ]\n", @bcdice.getResult())
-    
+
     @bcdice.setRandomValues([[49, 49]])
     @cardTrader.executeCard("c-draw", "channel")
     assert_equal( "sendMessageToOnlySender\nto:\nC13\nsendMessage\nto:channel\ntest_nick: 1枚引きました\n", @bcdice.getResult())
   end
-  
-  
+
+
   def test_review
     @cardTrader.executeCard("c-review", "channel")
     assert_equal( "sendMessageToOnlySender\nto:\nS1,S2,S3,S4,S5,S6,S7,S8,S9,S10,S11,S12,S13,H1,H2,H3,H4,H5,H6,H7,H8,H9,H10,H11,H12,H13,D1,D2,D3,D4,D5,D6,D7,D8,D9,D10,D11,D12,D13,C1,C2,C3,C4,C5,C6,C7,C8,C9,C10,C11,C12,C13,J1\n", @bcdice.getResult())
-    
+
     @bcdice.setRandomValues([[1, 53], [1, 52], [1, 51], [50, 50]])
     @cardTrader.executeCard("c-odraw[4]", "channel")
     debug( @bcdice.getResult() )
-    
+
     @cardTrader.executeCard("c-review", "channel")
     assert_equal( "sendMessageToOnlySender\nto:\nS4,S5,S6,S7,S8,S9,S10,S11,S12,S13,H1,H2,H3,H4,H5,H6,H7,H8,H9,H10,H11,H12,H13,D1,D2,D3,D4,D5,D6,D7,D8,D9,D10,D11,D12,D13,C1,C2,C3,C4,C5,C6,C7,C8,C9,C10,C11,C12,C13\n", @bcdice.getResult())
   end
 
-  
+
   def test_pass
     @bcdice.setRandomValues([[1, 53], [1, 52], [1, 51], [50, 50]])
     @cardTrader.executeCard("c-odraw[4]", "channel")
     @cardTrader.executeCard("c-play1[S3]", "channel")
     debug( @bcdice.getResult() )
-    
+
     @cardTrader.setNick('john')
     @bcdice.setRandomValues([[49, 49]])
     @cardTrader.executeCard("c-odraw[1]", "channel")
     assert_equal( "sendMessage\nto:channel\njohn: C13を引きました\n", @bcdice.getResult())
     setDefaultNick
-    
+
     @cardTrader.executeCard("c-hand", "channel")
     assert_equal( "sendMessageToOnlySender\nto:\n[ J1,S1,S2 ] 場札:[ S3 ] タップした場札:[  ]\n", @bcdice.getResult())
-    
-    
+
+
     @cardTrader.executeCard("c-pass[S1]john", "channel")
     assert_equal( "sendMessage\nto:channel\ntest_nick: 1枚渡しました\nsendMessage\nto:john\n[ C13,S1 ] 場札:[  ] タップした場札:[  ]\nsendMessageToOnlySender\nto:\n[ J1,S2 ] 場札:[ S3 ] タップした場札:[  ]\n", @bcdice.getResult())
-    
+
     @cardTrader.executeCard("c-pass1[S3]john", "channel")
     assert_equal( "sendMessage\nto:channel\ntest_nick: 1枚渡しました\nsendMessage\nto:john\n[ C13,S1,S3 ] 場札:[  ] タップした場札:[  ]\nsendMessageToOnlySender\nto:\n[ J1,S2 ] 場札:[  ] タップした場札:[  ]\n", @bcdice.getResult())
 
     @cardTrader.executeCard("c-hand", "channel")
     assert_equal( "sendMessageToOnlySender\nto:\n[ J1,S2 ] 場札:[  ] タップした場札:[  ]\n", @bcdice.getResult())
-    
+
     @bcdice.setRandomValues([[2, 2]])
     @cardTrader.executeCard("c-pass john", "channel")
     assert_equal( "sendMessage\nto:channel\ntest_nick: 1枚渡しました\nsendMessage\nto:john\n[ C13,J1,S1,S3 ] 場札:[  ] タップした場札:[  ]\nsendMessageToOnlySender\nto:\n[ S2 ] 場札:[  ] タップした場札:[  ]\n", @bcdice.getResult())
-    
+
     @cardTrader.executeCard("c-hand", "channel")
     assert_equal( "sendMessageToOnlySender\nto:\n[ S2 ] 場札:[  ] タップした場札:[  ]\n", @bcdice.getResult())
   end
@@ -238,20 +238,20 @@ class TestCardTrader < Test::Unit::TestCase
   def test_pick
     @cardTrader.executeCard("c-pick[S1]", "channel")
     assert_equal( "sendMessage\nto:channel\ntest_nick: 1枚選んで引きました\nsendMessageToOnlySender\nto:\n[ S1 ] 場札:[  ] タップした場札:[  ]\n", @bcdice.getResult())
-    
+
     drawCards(49, 52)
-    
+
     @cardTrader.executeCard("c-review", "channel")
     assert_equal( "sendMessageToOnlySender\nto:\nC12,C13,J1\n", @bcdice.getResult())
-    
+
     @cardTrader.executeCard("c-pick[J1,C13,C12]", "channel")
     assert_equal( "sendMessage\nto:channel\ntest_nick: 3枚選んで引きました\nsendMessageToOnlySender\nto:\n[ C1,C10,C11,C12,C13,C2,C3,C4,C5,C6,C7,C8,C9,D1,D10,D11,D12,D13,D2,D3,D4,D5,D6,D7,D8,D9,H1,H10,H11,H12,H13,H2,H3,H4,H5,H6,H7,H8,H9,J1,S1,S10,S11,S12,S13,S2,S3,S4,S5,S6,S7,S8,S9 ] 場札:[  ] タップした場札:[  ]\n", @bcdice.getResult())
-    
+
     @cardTrader.executeCard("c-pick[J1]", "channel")
     assert_equal( "sendMessage\nto:channel\n[山札]がありません\nsendMessageToOnlySender\nto:\n[ C1,C10,C11,C12,C13,C2,C3,C4,C5,C6,C7,C8,C9,D1,D10,D11,D12,D13,D2,D3,D4,D5,D6,D7,D8,D9,H1,H10,H11,H12,H13,H2,H3,H4,H5,H6,H7,H8,H9,J1,S1,S10,S11,S12,S13,S2,S3,S4,S5,S6,S7,S8,S9 ] 場札:[  ] タップした場札:[  ]\n", @bcdice.getResult())
   end
-  
-  
+
+
   def drawCards(count, total)
     rands = []
     cardCount = count
@@ -259,74 +259,74 @@ class TestCardTrader < Test::Unit::TestCase
       max = total - i
       rands << [1, max]
     end
-    
+
     debug('drawCards srands', rands)
-    
+
     @bcdice.setRandomValues(rands)
     @cardTrader.executeCard("c-draw[#{count}]", "channel")
     @bcdice.getResult()
     #debug('drawCards, getResult@bcdice.getResult()', @bcdice.getResult())
   end
-  
-  
-  
+
+
+
   def test_back
     @bcdice.setRandomValues([[1, 53], [1, 52], [1, 51], [1, 50], [49, 49]])
     @cardTrader.executeCard("c-odraw[5]", "channel")
     @cardTrader.executeCard("c-play1[J1]", "channel")
     @cardTrader.executeCard("c-play[S1,S2,S3,S4]", "channel")
     debug( @bcdice.getResult() )
-    
+
     @cardTrader.executeCard("c-hand", "channel")
     assert_equal( "sendMessageToOnlySender\nto:\n[  ] 場札:[ J1 ] タップした場札:[  ]\n", @bcdice.getResult())
-    
+
     @cardTrader.executeCard("c-back[S1]", "channel")
     assert_equal( "sendMessage\nto:channel\ntest_nick: 1枚戻しました\nsendMessageToOnlySender\nto:\n[ S1 ] 場札:[ J1 ] タップした場札:[  ]\n", @bcdice.getResult())
-    
+
     @cardTrader.executeCard("c-back[S2,S3,S4]", "channel")
     assert_equal( "sendMessage\nto:channel\ntest_nick: 3枚戻しました\nsendMessageToOnlySender\nto:\n[ S1,S2,S3,S4 ] 場札:[ J1 ] タップした場札:[  ]\n", @bcdice.getResult())
-    
+
     @cardTrader.executeCard("c-back[J1]", "channel")
     assert_equal( "sendMessage\nto:channel\n[捨て札]がありません\n", @bcdice.getResult())
   end
 
-  
+
   def test_deal
     @bcdice.setRandomValues([[1, 53], [1, 52], [1, 51], [50, 50]])
-    
+
     @cardTrader.executeCard("c-deal[4] john", "channel")
     assert_equal( "sendMessage\nto:john\nJ1,S1,S2,S3\nsendMessage\nto:channel\ntest_nick: johnに[4]枚配りました\n", @bcdice.getResult())
-    
+
     @cardTrader.setNick('john')
     @cardTrader.executeCard("c-hand", "channel")
     assert_equal( "sendMessageToOnlySender\nto:\n[ J1,S1,S2,S3 ] 場札:[  ] タップした場札:[  ]\n", @bcdice.getResult())
   end
 
-  
-  
+
+
   def test_vdeal
     @bcdice.setRandomValues([[1, 53], [1, 52], [1, 51], [50, 50]])
     @cardTrader.executeCard("c-vdeal[4] john", "channel")
     assert_equal( "sendMessage\nto:john\nJ1,S1,S2,S3\nsendMessage\nto:test_nick\njohn に J1,S1,S2,S3 を配りました\nsendMessage\nto:channel\ntest_nick: johnに[4]枚配りました\n", @bcdice.getResult())
-    
+
     @cardTrader.setNick('john')
     @cardTrader.executeCard("c-hand", "channel")
     assert_equal( "sendMessageToOnlySender\nto:\n[ J1,S1,S2,S3 ] 場札:[  ] タップした場札:[  ]\n", @bcdice.getResult())
   end
 
-  
+
   def test_discard
     @bcdice.setRandomValues([[1, 53], [1, 52], [1, 51], [50, 50]])
     @cardTrader.executeCard("c-odraw[4]", "channel")
     @cardTrader.executeCard("c-play1[S1,S2,S3]", "channel")
     debug( @bcdice.getResult() )
-    
+
     @cardTrader.executeCard("c-hand", "channel")
     assert_equal( "sendMessageToOnlySender\nto:\n[ J1 ] 場札:[ S1,S2,S3 ] タップした場札:[  ]\n", @bcdice.getResult())
-    
+
     @cardTrader.executeCard("c-discard[J1]", "channel")
     assert_equal( "sendMessage\nto:channel\ntest_nick: 1枚捨てました\nsendMessageToOnlySender\nto:\n[  ] 場札:[ S1,S2,S3 ] タップした場札:[  ]\n", @bcdice.getResult())
-    
+
     @cardTrader.executeCard("c-discard1[S1,S2,S3]", "channel")
     assert_equal( "sendMessage\nto:channel\ntest_nick: 3枚捨てました\nsendMessageToOnlySender\nto:\n[  ] 場札:[  ] タップした場札:[  ]\n", @bcdice.getResult())
   end
@@ -337,125 +337,125 @@ class TestCardTrader < Test::Unit::TestCase
     @cardTrader.executeCard("c-odraw[1]", "channel")
     assert_equal( "sendMessage\nto:channel\njohn: S1を引きました\n", @bcdice.getResult())
     setDefaultNick
-    
+
     @bcdice.setRandomValues([[1, 52], [1, 51], [1, 50], [49, 49]])
     @cardTrader.executeCard("c-odraw[4]", "channel")
     @cardTrader.executeCard("c-play1[S2]", "channel")
     debug( @bcdice.getResult() )
-    
-    
+
+
     @cardTrader.executeCard("c-hand", "channel")
     assert_equal( "sendMessageToOnlySender\nto:\n[ J1,S3,S4 ] 場札:[ S2 ] タップした場札:[  ]\n", @bcdice.getResult())
-    
+
     @cardTrader.executeCard("c-place[S3]john", "channel")
     assert_equal( "sendMessageToOnlySender\nto:\n[ J1,S4 ] 場札:[ S2 ] タップした場札:[  ]\n", @bcdice.getResult())
-    
+
     @cardTrader.setNick('john')
     @cardTrader.executeCard("c-hand", "channel")
     assert_equal( "sendMessageToOnlySender\nto:\n[ S1 ] 場札:[ S3 ] タップした場札:[  ]\n", @bcdice.getResult())
     setDefaultNick
-    
+
     @cardTrader.executeCard("c-hand", "channel")
     assert_equal( "sendMessageToOnlySender\nto:\n[ J1,S4 ] 場札:[ S2 ] タップした場札:[  ]\n", @bcdice.getResult())
-    
+
     @cardTrader.executeCard("c-place1[S2]john", "channel")
     assert_equal( "sendMessageToOnlySender\nto:\n[ J1,S4 ] 場札:[  ] タップした場札:[  ]\n", @bcdice.getResult())
-    
+
     @cardTrader.executeCard("c-hand", "channel")
     assert_equal( "sendMessageToOnlySender\nto:\n[ J1,S4 ] 場札:[  ] タップした場札:[  ]\n", @bcdice.getResult())
-    
+
     @cardTrader.setNick('john')
     @cardTrader.executeCard("c-hand", "channel")
     assert_equal( "sendMessageToOnlySender\nto:\n[ S1 ] 場札:[ S2,S3 ] タップした場札:[  ]\n", @bcdice.getResult())
     setDefaultNick
-    
+
     @cardTrader.executeCard("c-place[J1,S4]john", "channel")
     assert_equal( "sendMessageToOnlySender\nto:\n[  ] 場札:[  ] タップした場札:[  ]\n", @bcdice.getResult())
   end
 
-  
+
   def test_tap_untap
     @bcdice.setRandomValues([[1, 53], [1, 52], [1, 51], [50, 50]])
     @cardTrader.executeCard("c-odraw[4] john", "channel")
     @cardTrader.executeCard("c-play1[J1,S1,S2,S3]", "channel")
     debug( @bcdice.getResult() )
-    
+
     @cardTrader.executeCard("c-hand", "channel")
     assert_equal( "sendMessageToOnlySender\nto:\n[  ] 場札:[ J1,S1,S2,S3 ] タップした場札:[  ]\n", @bcdice.getResult())
-    
+
     @cardTrader.executeCard("c-tap1[S1]", "channel")
     assert_equal( "sendMessage\nto:channel\ntest_nick: 1枚タップしました\nsendMessageToOnlySender\nto:\n[  ] 場札:[ J1,S2,S3 ] タップした場札:[ S1 ]\n", @bcdice.getResult())
-    
+
     @cardTrader.executeCard("c-tap1[J1,S2,S3]", "channel")
     assert_equal( "sendMessage\nto:channel\ntest_nick: 3枚タップしました\nsendMessageToOnlySender\nto:\n[  ] 場札:[  ] タップした場札:[ J1,S1,S2,S3 ]\n", @bcdice.getResult())
-    
-    
+
+
     @cardTrader.executeCard("c-untap1[S1]", "channel")
     assert_equal( "sendMessage\nto:channel\ntest_nick: 1枚アンタップしました\nsendMessageToOnlySender\nto:\n[  ] 場札:[ S1 ] タップした場札:[ J1,S2,S3 ]\n", @bcdice.getResult())
-    
+
     @cardTrader.executeCard("c-untap1[J1,S2,S3]", "channel")
     assert_equal( "sendMessage\nto:channel\ntest_nick: 3枚アンタップしました\nsendMessageToOnlySender\nto:\n[  ] 場札:[ J1,S1,S2,S3 ] タップした場札:[  ]\n", @bcdice.getResult())
   end
 
-  
+
   def test_milstone
     @bcdice.setRandomValues([[1, 53], [1, 52], [1, 51], [50, 50]])
     @cardTrader.executeCard("c-milstone", "channel")
     assert_equal( "sendMessage\nto:channel\ntest_nick: S1が出ました\n", @bcdice.getResult())
   end
-  
-  
+
+
   def test_getSpell
     cardCount = 53
     rands = getRandsForDrawFullCard(cardCount)
-    
+
     @bcdice.setRandomValues(rands)
     @cardTrader.executeCard("c-draw[52]", "channel")
     assert_equal( "sendMessageToOnlySender\nto:\nC1,C10,C11,C12,C13,C2,C3,C4,C5,C6,C7,C8,C9,D1,D10,D11,D12,D13,D2,D3,D4,D5,D6,D7,D8,D9,H1,H10,H11,H12,H13,H2,H3,H4,H5,H6,H7,H8,H9,S1,S10,S11,S12,S13,S2,S3,S4,S5,S6,S7,S8,S9\nsendMessage\nto:channel\ntest_nick: 52枚引きました\n", @bcdice.getResult())
-    
+
     @cardTrader.executeCard("c-play1[S1]", "channel")
     assert_equal( "sendMessage\nto:channel\ntest_nick: 1枚出しました\nsendMessageToOnlySender\nto:\n[ C1,C10,C11,C12,C13,C2,C3,C4,C5,C6,C7,C8,C9,D1,D10,D11,D12,D13,D2,D3,D4,D5,D6,D7,D8,D9,H1,H10,H11,H12,H13,H2,H3,H4,H5,H6,H7,H8,H9,S10,S11,S12,S13,S2,S3,S4,S5,S6,S7,S8,S9 ] 場札:[ S1 ] タップした場札:[  ]\n", @bcdice.getResult())
-    
+
     @cardTrader.executeCard("c-play[C2]", "channel")
     assert_equal( "sendMessage\nto:channel\ntest_nick: 1枚出しました\nsendMessageToOnlySender\nto:\n[ C1,C10,C11,C12,C13,C3,C4,C5,C6,C7,C8,C9,D1,D10,D11,D12,D13,D2,D3,D4,D5,D6,D7,D8,D9,H1,H10,H11,H12,H13,H2,H3,H4,H5,H6,H7,H8,H9,S10,S11,S12,S13,S2,S3,S4,S5,S6,S7,S8,S9 ] 場札:[ S1 ] タップした場札:[  ]\n", @bcdice.getResult())
-    
+
     @cardTrader.executeCard("c-hand", "channel")
     assert_equal( "sendMessageToOnlySender\nto:\n[ C1,C10,C11,C12,C13,C3,C4,C5,C6,C7,C8,C9,D1,D10,D11,D12,D13,D2,D3,D4,D5,D6,D7,D8,D9,H1,H10,H11,H12,H13,H2,H3,H4,H5,H6,H7,H8,H9,S10,S11,S12,S13,S2,S3,S4,S5,S6,S7,S8,S9 ] 場札:[ S1 ] タップした場札:[  ]\n", @bcdice.getResult())
-    
+
     @cardTrader.executeCard("c-spell", "channel")
     assert_equal( "sendMessage\nto:channel\n復活の呪文 ＞ [1TEST_NICK,TEST_NICK,card_played,BC39DC11A]\n", @bcdice.getResult() )
   end
 
   def getRandsForDrawFullCard(cardCount)
     rands = []
-    
+
     cardCount.times do |i|
       break if(i == cardCount)
       max = cardCount - i
       rands << [1, max]
     end
-    
+
     return rands
   end
-  
+
   def test_castSpell
     @cardTrader.executeCard("c-spell[1TEST_NICK,TEST_NICK,card_played,BC39DC11A]", "channel")
     assert_equal( "sendMessage\nto:channel\ntest_nick: カード配置を復活しました\n", @bcdice.getResult())
-    
+
     @cardTrader.executeCard("c-hand", "channel")
     assert_equal( "sendMessageToOnlySender\nto:\n[ C1,C10,C11,C12,C13,C3,C4,C5,C6,C7,C8,C9,D1,D10,D11,D12,D13,D2,D3,D4,D5,D6,D7,D8,D9,H1,H10,H11,H12,H13,H2,H3,H4,H5,H6,H7,H8,H9,S10,S11,S12,S13,S2,S3,S4,S5,S6,S7,S8,S9 ] 場札:[ S1 ] タップした場札:[  ]\n", @bcdice.getResult())
-    
+
   end
 
   def test_getSpellLong
-    
+
     @cardTrader.set2Deck2Jorker
-    
+
     cardCount = 108
     rands = getRandsForDrawFullCard(cardCount)
-    
+
     @bcdice.setRandomValues(rands)
-    
+
     @cardTrader.executeCard("c-draw[5]", "channel")
     assert_equal( "sendMessageToOnlySender\nto:\nS1,S2,S3,S4,S5\nsendMessage\nto:channel\ntest_nick: 5枚引きました\n", @bcdice.getResult())
     @cardTrader.executeCard("c-play[S1]", "channel")
@@ -464,8 +464,8 @@ class TestCardTrader < Test::Unit::TestCase
     assert_equal( "sendMessage\nto:channel\ntest_nick: 2枚出しました\nsendMessageToOnlySender\nto:\n[ S4,S5 ] 場札:[ S2,S3 ] タップした場札:[  ]\n", @bcdice.getResult())
     @cardTrader.executeCard("c-tap1[S3]", "channel")
     assert_equal( "sendMessage\nto:channel\ntest_nick: 1枚タップしました\nsendMessageToOnlySender\nto:\n[ S4,S5 ] 場札:[ S2 ] タップした場札:[ S3 ]\n", @bcdice.getResult())
-    
-    
+
+
     @cardTrader.setNick('john')
     @cardTrader.executeCard("c-draw[5]", "channel")
     assert_equal( "sendMessageToOnlySender\nto:\nS10,S6,S7,S8,S9\nsendMessage\nto:channel\njohn: 5枚引きました\n", @bcdice.getResult())
@@ -476,23 +476,23 @@ class TestCardTrader < Test::Unit::TestCase
     @cardTrader.executeCard("c-tap1[S8]", "channel")
     assert_equal( "sendMessage\nto:channel\njohn: 1枚タップしました\nsendMessageToOnlySender\nto:\n[ S6,S9 ] 場札:[ S7 ] タップした場札:[ S8 ]\n", @bcdice.getResult())
     setDefaultNick
-    
+
     @cardTrader.executeCard("c-spell", "channel")
     assert_equal( "sendMessage\nto:channel\n復活の呪文 ＞ [1JOHN,1TEST_NICK,2JOHN,2TEST_NICK,JOHN,TEST_NICK,card_played,HCEG2FBDFHA98]\n", @bcdice.getResult() )
   end
-  
+
   def test_castSpellLong
     @cardTrader.executeCard("c-spell[1JOHN,1TEST_NICK,2JOHN,2TEST_NICK,JOHN,TEST_NICK,card_played,HCEG2FBDFHA98]", "channel")
     assert_equal( "sendMessage\nto:channel\ntest_nick: カード配置を復活しました\n", @bcdice.getResult())
-    
+
     @cardTrader.executeCard("c-hand", "channel")
     assert_equal( "sendMessageToOnlySender\nto:\n[ S4,S5 ] 場札:[ S2 ] タップした場札:[ S3 ]\n", @bcdice.getResult())
-    
+
     @cardTrader.setNick('john')
     @cardTrader.executeCard("c-hand", "channel")
     assert_equal( "sendMessageToOnlySender\nto:\n[ S6,S9 ] 場札:[ S7 ] タップした場札:[ S8 ]\n", @bcdice.getResult())
     setDefaultNick
-    
+
   end
 
   def _test_
@@ -500,7 +500,7 @@ class TestCardTrader < Test::Unit::TestCase
     assert_equal( "", @bcdice.getResult())
   end
 
-  
+
   def trace
     $isDebug = true
   end

--- a/src/test/others/testIniFile.rb
+++ b/src/test/others/testIniFile.rb
@@ -7,48 +7,48 @@ require 'log'
 require 'IniFile.rb'
 
 class TestIniFile < Test::Unit::TestCase
-  
+
   def setup
     $isDebug = false
     @testIniFileName = 'test.ini'
-    
+
     deleteIniFile
   end
 
   def teardown
     deleteIniFile
   end
-  
+
   def deleteIniFile
     if( File.exist?(@testIniFileName) )
       File.delete(@testIniFileName)
     end
   end
-  
+
   def trace
     $isDebug = true
   end
-  
-  
+
+
   def test_readWrite
     ini = IniFile.new(@testIniFileName)
-    
+
     value = ini.read('section', 'key', 'value')
     assert_equal(value, 'value')
-    
+
     ini.write('section', 'key', 'mokeke')
-    
+
     value = ini.read('section', 'key', 'ffffff')
     assert_equal(value, 'mokeke')
   end
-  
-  
+
+
   def test_readWriteJapanease
     ini = IniFile.new(@testIniFileName)
-    
+
     value = ini.readAndWrite('サーバーもけけ村', 'server', 'irc.trpg.net')
     assert_equal('irc.trpg.net', value)
-    
+
     value = ini.read('サーバーもけけ村', 'server', 'mokeke')
     assert_equal('irc.trpg.net', value)
   end

--- a/src/test/others/testPointer.rb
+++ b/src/test/others/testPointer.rb
@@ -10,111 +10,111 @@ $isDebug = false
 
 
 class TestPointer < Test::Unit::TestCase
-  
+
   def setup
     $isDebug = false
     $isRollVoidDiceAtAnyRecive = false
-    
+
     @nick = "test_nick"
     @channel = "test_channel"
-    
+
     maker = BCDiceMaker_forTest.new
     @bcdice = maker.newBcDice()
   end
-  
+
   def trace
     $isDebug = true
   end
-  
+
   def execute(text, channel = nil, nick = nil)
     @bcdice.setMessage(text)
-    
+
     channel ||= @channel
     @bcdice.setChannel( channel )
-    
+
     nick ||= @nick
     @bcdice.recievePublicMessage( nick )
   end
-  
+
   def test_setPoinChangePoinAndOpen
     execute("#HP12")
     assert_equal( "sendMessage\nto:test_channel\ntest_nick: (HP) 12\n", @bcdice.getResult() )
-    
+
     execute("#OPEN!HP")
     assert_equal( "sendMessage\nto:test_channel\nHP: TEST_NICK(12)\n", @bcdice.getResult() )
-    
+
     execute("#HP9", nil, "nick2")
     assert_equal( "sendMessage\nto:test_channel\nnick2: (HP) 9\n", @bcdice.getResult() )
-    
+
     execute("#OPEN!HP")
     assert_equal( "sendMessage\nto:test_channel\nHP: NICK2(9) TEST_NICK(12)\n", @bcdice.getResult() )
-    
+
     execute("#OPEN!HP")
     assert_equal( "sendMessage\nto:test_channel\nHP: NICK2(9) TEST_NICK(12)\n", @bcdice.getResult() )
-    
+
     execute("#HP-5")
     assert_equal( "sendMessage\nto:test_channel\ntest_nick: (HP) 12 -> 7\n", @bcdice.getResult() )
-    
+
     execute("#OPEN!HP")
     assert_equal( "sendMessage\nto:test_channel\nHP: NICK2(9) TEST_NICK(7)\n", @bcdice.getResult() )
   end
-  
+
   def test_any
     execute("#テスト：test1 まずは最大値なし")
     assert_equal( "test_nick: テスト(TEST) 1", getResultCutHeaderSendMessageToTestChannel )
-    
+
     execute("#テスト：test1/1 続けて最大値つき")
     assert_equal( "test_nick: テスト(TEST) 1/1", getResultCutHeaderSendMessageToTestChannel )
-    
+
     execute("#OPEN!test この状態でのタグ情報")
     assert_equal( "TEST: テスト(1/1)", getResultCutHeaderSendMessageToTestChannel )
-    
+
     execute("#testx1 現在値のみを別のタグで登録した場合（最大値なし）")
     assert_equal( "test_nick: (TESTX) 1", getResultCutHeaderSendMessageToTestChannel )
-    
+
     execute("#OPEN!testx")
     assert_equal( "TESTX: TEST_NICK(1)", getResultCutHeaderSendMessageToTestChannel )
-    
+
     execute("#testx1/1 現在値のみを別のタグで登録した場合（最大値つき）")
     assert_equal( "test_nick: (TESTX) 1/1", getResultCutHeaderSendMessageToTestChannel )
-    
+
     execute("#OPEN!testx")
     assert_equal( "TESTX: TEST_NICK(1/1)", getResultCutHeaderSendMessageToTestChannel )
-    
+
     execute("#テスト：test-1 ポイントの変化")
     assert_equal( "test_nick: テスト(TEST) 1/1 -> 0/1", getResultCutHeaderSendMessageToTestChannel )
-    
+
     execute("#OPEN!test")
     assert_equal( "TEST: テスト(0/1)", getResultCutHeaderSendMessageToTestChannel )
-    
+
     execute("#テスト：test+1 ポイントの変化")
     assert_equal( "test_nick: テスト(TEST) 0/1 -> 1/1", getResultCutHeaderSendMessageToTestChannel )
-    
+
     execute("#OPEN!test")
     assert_equal( "TEST: テスト(1/1)", getResultCutHeaderSendMessageToTestChannel )
-    
+
     execute("#testx-1")
     assert_equal( "test_nick: (TESTX) 1/1 -> 0/1", getResultCutHeaderSendMessageToTestChannel )
-    
+
     execute("#OPEN!testx")
     assert_equal( "TESTX: TEST_NICK(0/1)", getResultCutHeaderSendMessageToTestChannel )
-    
+
     execute("#testx+1")
     assert_equal( "test_nick: (TESTX) 0/1 -> 1/1", getResultCutHeaderSendMessageToTestChannel )
-    
+
     # タグ全体を開くOPEN!コマンドは受け付けるけど
     # 発言者が管理しているキャラクターのタグを表示するOPEN!コマンドは受け付けない？
     execute("#OPEN!")
     assert_equal( "TEST_NICK(1/1) テスト(1/1)", getResultCutHeaderSendMessageToTestChannel )
-    
-    
+
+
     execute("#RENAME!テスト->テストb")
     assert_equal( "test_nick: テスト->テストB", getResultCutHeaderSendMessageToTestChannel )
-    
+
     execute("#OPEN!test")
     assert_equal( "TEST: テストB(1/1)", getResultCutHeaderSendMessageToTestChannel )
   end
-  
+
   def getResultCutHeaderSendMessageToTestChannel
     text = @bcdice.getResult()
     text = text.toutf8
@@ -122,10 +122,10 @@ class TestPointer < Test::Unit::TestCase
     text.sub!(/\n\Z/, '')
     return text
   end
-  
+
   def _test_XXXXXXXX
     execute(text)
     assert_equal( "", @bcdice.getResult())
   end
-  
+
 end

--- a/src/test/others/testSecretDice.rb
+++ b/src/test/others/testSecretDice.rb
@@ -10,77 +10,77 @@ $isDebug = false
 
 
 class TestSecretDice < Test::Unit::TestCase
-  
+
   def setup
     $isDebug = false
     # $isRollVoidDiceAtAnyRecive = false
-    
+
     @nick = "test_nick"
     @channel = "test_channel"
-    
+
     maker = BCDiceMaker_forTest.new
     @bcdice = maker.newBcDice()
   end
-  
+
   def execute(text, channel = nil, nick = nil)
     @bcdice.setMessage(text)
-    
+
     channel ||= @channel
     @bcdice.setChannel( channel )
-    
+
     nick ||= @nick
     @bcdice.recievePublicMessage( nick )
   end
-  
+
   def test_rollSecretAndOpen
     @bcdice.setRandomValues( [[1, 6], [1, 6], [1, 6]] )
     execute("S3d6")
     assert_equal( "sendMessage\nto:test_nick\ntest_nick: (3D6) ＞ 3[1,1,1] ＞ 3\n", @bcdice.getResult() )
-    
+
     execute("Open Dice!")
     assert_equal( "sendMessage\nto:test_channel\ntest_nick: (3D6) ＞ 3[1,1,1] ＞ 3\n", @bcdice.getResult() )
   end
-  
+
   def test_rollSecretAndOpen_at2Channel
     @bcdice.setRandomValues( [[1, 6], [1, 6], [1, 6]] )
     execute("S3d6")
     assert_equal( "sendMessage\nto:test_nick\ntest_nick: (3D6) ＞ 3[1,1,1] ＞ 3\n", @bcdice.getResult() )
-    
+
     @bcdice.setRandomValues( [[1, 6]] )
     execute("S1d6", "anotherChannel")
     assert_equal( "sendMessage\nto:test_nick\ntest_nick: (1D6) ＞ 1\n", @bcdice.getResult() )
-    
+
     execute("Open Dice!", "anotherChannel")
     assert_equal( "sendMessage\nto:anotherChannel\ntest_nick: (1D6) ＞ 1\n", @bcdice.getResult() )
-    
+
     execute("Open Dice!")
     assert_equal( "sendMessage\nto:test_channel\ntest_nick: (3D6) ＞ 3[1,1,1] ＞ 3\n", @bcdice.getResult() )
   end
-  
+
   def test_2rollSecretAnd2Open
     @bcdice.setRandomValues( [[1, 6], [1, 6], [1, 6]] )
     execute("S3d6")
     assert_equal( "sendMessage\nto:test_nick\ntest_nick: (3D6) ＞ 3[1,1,1] ＞ 3\n", @bcdice.getResult() )
-    
+
     @bcdice.setRandomValues( [[6, 6], [6, 6], [6, 6]] )
     execute("S3d6")
     assert_equal( "sendMessage\nto:test_nick\ntest_nick: (3D6) ＞ 18[6,6,6] ＞ 18\n", @bcdice.getResult() )
-    
+
     execute("Open Dice!")
     assert_equal( "sendMessage\nto:test_channel\ntest_nick: (3D6) ＞ 18[6,6,6] ＞ 18\n", @bcdice.getResult() )
-    
+
     #履歴は1件しか残らないので何も表示されない
     execute("Open Dice!")
     assert_equal( "", @bcdice.getResult() )
   end
-  
+
   def _test_XXXXXXXX
     execute(text)
     assert_equal( "", @bcdice.getResult())
   end
-  
+
   def trace
     $isDebug = true
   end
-  
+
 end

--- a/src/test/testDiceBotLoaders.rb
+++ b/src/test/testDiceBotLoaders.rb
@@ -93,7 +93,7 @@ class TestDiceBotLoaders < Test::Unit::TestCase
   def test_shouldNotLoadDiceBotNamed_InsaceScp
     assertDiceBotIgnored('_InsaneScp')
   end
-  
+
   #--
   # 3. 複数の名前で読み込めるダイスボットの読み込みを確認するテストケース
   #++


### PR DESCRIPTION
行末と、半角スペースしか含まない行から、半角スペースを削除しました。

`git diff` コマンドの出力での色設定において行末のスペース(スペースしか含まない空行を含む)が強調表示されるのが鬱陶しいのと、ファイルサイズが意味なく大きくなるのを防ぐことを目的としています。

ヒアドキュメントなど、文字列リテラルに含まれるスペースは削除していない(そもそも文字列には該当する箇所がなかった)ことを確認しています。

同時に、`.editorconfig` にて、行末のスペースを削除するよう設定を追加しています。

ローカルで PR 作成時点での master ブランチとはコンフリクトしないことは念のため確かめてあるのですが、GitHub 上では自動マージが出来ないと表示されているようです。
やったことは単純ですがファイル数が大変多くなっています。
確認が面倒かと思いますが、以上、よろしくお願い致します。