### PR TITLE
Set ci dist

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: trusty
 language: ruby
 rvm:
   - 2.6


### PR DESCRIPTION
travis-ciのデフォルトOSが変わったことでRuby 1.9, 1.8のテストができなくなったのを解決する