### PR TITLE
Fix action resolution for Strato Shout

### DIFF
--- a/src/diceBot/StratoShout.rb
+++ b/src/diceBot/StratoShout.rb
@@ -44,20 +44,17 @@ TENKAI: シーン展開表 奔走シーン 練習シーンで使用
 INFO_MESSAGE_TEXT
   end
 
-  def check_2D6(total_n, dice_n, signOfInequality, diff, dice_cnt, dice_max, n1, n_max)
-    check_nD6(total_n, dice_n, signOfInequality, diff, dice_cnt, dice_max, n1, n_max)
-  end
-
-  def check_nD6(total_n, dice_n, signOfInequality, diff, _dice_cnt, _dice_max, _n1, _n_max)
+  def check_2D6(total_n, dice_n, signOfInequality, diff, _, _, _, _)
     return '' unless signOfInequality == ">="
+
     if dice_n <= 2
-      return " ＞ ファンブル！ (ドラマフェイズ: 【ディスコード】+2 / ライブフェイズ: 【コンディション】-2)"
+      " ＞ ファンブル！ (ドラマフェイズ: 【ディスコード】+2 / ライブフェイズ: 【コンディション】-2)"
     elsif dice_n >= 12
-      return " ＞ スペシャル！ (【コンディション】+2)"
+      " ＞ スペシャル！ (【コンディション】+2)"
     elsif total_n >= diff
-      return " ＞ 成功"
+      " ＞ 成功"
     else
-      return " ＞ 失敗"
+      " ＞ 失敗"
     end
   end
 

--- a/src/diceBot/StratoShout.rb
+++ b/src/diceBot/StratoShout.rb
@@ -44,7 +44,7 @@ TENKAI: シーン展開表 奔走シーン 練習シーンで使用
 INFO_MESSAGE_TEXT
   end
 
-  def check_2D6(total_n, dice_n, signOfInequality, diff, _, _, _, _)
+  def check_2D6(total_n, dice_n, signOfInequality, diff, _dice_cnt, _dice_max, _n1, _n_max)
     return '' unless signOfInequality == ">="
 
     if dice_n <= 2


### PR DESCRIPTION
ストラトシャウトの判定処理に誤りがあったので、その修正です。

ストラトシャウトで2D6以外での判定は「作戦【ロジック】を使用して直前の判定を振り直す際、スキル【論理の律動】を組み合わせることで振り直しでの判定の達成値を［1D6+6］で算出する」という場合のみです。
一方で、スペシャルやファンブルは2D6の出目が特定の値の場合にのみ起こるとされています。
ですので、【ロジック】+【論理の律動】をするとスペシャルの処理もファンブルの処理も行わないのが正しい処理になるはずです。
元々の実装だと、1D6+6+n>=dをすると、1D6が1, 2の際にはファンブルと判定されていました。

1D6+6+n>=dは、単に成功か失敗かというだけならデフォルトの処理でいいので、check_nD6のオーバーライドは行わないようにしました。