### PR TITLE
Use json 2.2.0 due to Ruby 1.9

### DIFF
--- a/src/Gemfile
+++ b/src/Gemfile
@@ -14,6 +14,7 @@ group :development, :test do
     gem 'test-unit', '1.2.3'
   else
     gem 'codecov', :require => false
+    gem 'json', '~> 2.2.0' # For Ruby 1.9
     gem 'rake'
     gem 'test-unit'
   end


### PR DESCRIPTION
json 2.3.0 だとRuby 1.9で落ちる