### PR TITLE
レーティング表でピンゾロ時に、補正があっても**に

### DIFF
--- a/src/diceBot/SwordWorld.rb
+++ b/src/diceBot/SwordWorld.rb
@@ -122,14 +122,25 @@ class SwordWorld < DiceBot
     round = 0
 
     loop do
-      dice, diceText = rollDice(values)
+      dice_raw, diceText = rollDice(values)
+      dice = dice_raw
 
       if  firstDiceChanteTo != 0
-        dice = firstDiceChanteTo
+        dice = dice_raw = firstDiceChanteTo
         firstDiceChanteTo = 0
       elsif  firstDiceChangeModify != 0
         dice += firstDiceChangeModify.to_i
         firstDiceChangeModify = 0
+      end
+
+      # 出目がピンゾロの時にはそこで終了
+      if dice_raw <= 2
+        diceResultTotals << dice_raw.to_s
+        diceResults << diceText.to_s
+        rateResults << "**"
+
+        round += 1
+        break
       end
 
       dice += getAdditionalDiceValue(dice, values)

--- a/src/test/data/SwordWorld.txt
+++ b/src/test/data/SwordWorld.txt
@@ -899,6 +899,12 @@ SwordWorld : KeyNo.20c[10]m[+1] ＞ 2D:[5,1]=7 ＞ 5
 rand:5/6,1/6
 ============================
 input:
+K10$+1
+output:
+SwordWorld : KeyNo.10c[10]m[+1] ＞ 2D:[1,1]=2 ＞ ** ＞ 自動的失敗
+rand:1/6,1/6
+============================
+input:
 K10+5$9
 output:
 SwordWorld : KeyNo.10c[10]m[9]+5 ＞ 2D:[6,2]=9 ＞ 5+5 ＞ 10
@@ -979,7 +985,7 @@ rand:1/6,6/6,2/6,2/6
 input:
 k10-5@9$+2
 output:
-SwordWorld : KeyNo.10c[9]m[+2]-5 ＞ 2D:[1,1]=4 ＞ 1-5 ＞ -4
+SwordWorld : KeyNo.10c[9]m[+2]-5 ＞ 2D:[1,1]=2 ＞ ** ＞ 自動的失敗
 rand:1/6,1/6
 ============================
 input:


### PR DESCRIPTION
レーティング表でピンゾロが出た時には補正があっても**を結果とする。
運命変転でダイスの出目そのものを変更する場合には、変更後の値を参照する。

Ref. #106 