### PR TITLE
ヤンキー＆ヨグ＝ソトース：二つ名決定表の実装とテストを追加

### DIFF
--- a/src/diceBot/YankeeYogSothoth.rb
+++ b/src/diceBot/YankeeYogSothoth.rb
@@ -30,7 +30,7 @@ TKT	戦う理由表
 ※武勇伝フェイズ
 BUDT	武勇伝表
 GUDT	ガイヤンキー武勇伝表
-FTNT	二つ名表
+FTNT	二つ名決定表
 DAIT	第一印象表
 TKKT	ツレ関係表
 
@@ -66,6 +66,8 @@ INFO_MESSAGE_TEXT
     case string
     when 'RTT' # ランダム特技決定表
       return getRandomSkillTableResult(command)
+    when 'FTNT' # 二つ名決定表
+      return get_nickname_table(command)
     end
 
     return getTableDiceCommandResult(command)
@@ -91,6 +93,122 @@ INFO_MESSAGE_TEXT
     output = "#{name}指定特技表(#{total_n},#{total_n2}) ＞ 『#{tableName}』#{skill}"
 
     return output
+  end
+
+  # 二つ名決定表
+  def get_nickname_table(_command)
+    result1, _ = roll(1,6)
+
+    case result1
+    when 1, 2
+      nicknameTableName = "二つ名表1"
+    when 3, 4
+      nicknameTableName = "二つ名表2"
+    when 5
+      nicknameTableName = "二つ名表3"
+    when 6
+      nicknameTableName = "二つ名表4"
+    end
+
+    nicknameTableFull = {
+      '二つ名表1' => %w{
+        11:愛死天流（あいしてる）
+        12:喧嘩上等（けんかじょうとう）
+        13:正々堂々（せいせいどうどう）
+        14:天下無敵（てんかむてき）
+        15:一騎当千（いっきとうせん）
+        16:威風堂々（いふうどうどう）
+        22:焼肉定食（やきにくていしょく）
+        23:完全無欠（かんぜんむけつ）
+        24:獅子奮迅（ししふんじん）
+        25:臥薪嘗胆（がしんしょうたん）
+        26:疾風迅雷（しっぷうじんらい）
+        33:夜露死苦（よろしく）
+        34:天上天下（てんじょうてんげ）
+        35:唯我独尊（ゆいがどくそん）
+        36:電光石火（でんこうせっか）
+        44:仏恥義理（ぶっちぎり）
+        45:百戦百勝（ひゃくせんひゃくしょう）
+        46:百戦錬磨（ひゃくせんれんま）
+        55:残酷非道（ざんこくひどう）
+        56:一意専心（いちいせんしん）
+        66:時給千円（じきゅうせんえん）
+      },
+      '二つ名表2' => %w{
+        11:みんなの
+        12:スルー推奨
+        13:暴れん坊
+        14:仲間思い
+        15:サボり魔
+        16:熱血番長の
+        22:今日がダメでも明日がある
+        23:すぐカッとなる
+        24:夢を応援する
+        25:地元じゃ有名な
+        26:喧嘩慣れている
+        33:いつかビックになる
+        34:いいやつの
+        35:意外とまじめな
+        36:イイ感じの
+        44:家族想いの
+        45:とにかくモテる
+        46:学校を代表するワル
+        55:邪神ハンター
+        56:男前／イイ女
+        66:悪そうなやつはだいたい友達
+      },
+      '二つ名表3' => %w{
+        11:ファッションヤンキー
+        12:誰もが知っている
+        13:チャラい
+        14:ツヨメ
+        15:中学時代はすごかった
+        16:イカれたやつ
+        22:道徳の授業で泣いた
+        23:マジか
+        24:イケイケ
+        25:鬼語り
+        26:とりま
+        33:ちょっと眠たい
+        34:パネエ
+        35:エモい
+        36:やべーぞ！
+        44:お腹が減っている
+        45:むっつりスケベの
+        46:いじわるな
+        55:全国区に報道された
+        56:毎日が楽しい
+        66:おやじ狩り狩り
+      },
+      '二つ名表4' => %w{
+        11:国産
+        12:ブレブレ
+        13:ロボ
+        14:大銀河
+        15:超獣
+        16:ミステリー
+        22:超電磁
+        23:危険な
+        24:湯上がり
+        25:すごい
+        26:エロ
+        33:福岡
+        34:エリート
+        35:どんまい
+        36:がり勉
+        44:東京
+        45:スペース
+        46:永遠の
+        55:大阪
+        56:輝け！
+        66:名古屋
+      },
+    }
+
+    nicknameTable = getD66Table(nicknameTableFull[nicknameTableName])
+    nickName, result2 = get_table_by_d66_swap(nicknameTable)
+    
+    return "二つ名決定表(#{result1},#{result2}) ＞ 「#{nickName}」"
   end
 
   def getTableDiceCommandResult(command)
@@ -391,5 +509,5 @@ INFO_MESSAGE_TEXT
       },
     }
 
-  setPrefixes(['RTT'] + @@tables.keys)
+  setPrefixes(['RTT', 'FTNT'] + @@tables.keys)
 end

--- a/src/diceBot/YankeeYogSothoth.rb
+++ b/src/diceBot/YankeeYogSothoth.rb
@@ -97,7 +97,7 @@ INFO_MESSAGE_TEXT
 
   # 二つ名決定表
   def get_nickname_table(_command)
-    result1, _ = roll(1,6)
+    result1, = roll(1, 6)
 
     case result1
     when 1, 2
@@ -207,7 +207,7 @@ INFO_MESSAGE_TEXT
 
     nicknameTable = getD66Table(nicknameTableFull[nicknameTableName])
     nickName, result2 = get_table_by_d66_swap(nicknameTable)
-    
+
     return "二つ名決定表(#{result1},#{result2}) ＞ 「#{nickName}」"
   end
 

--- a/src/test/data/YankeeYogSothoth.txt
+++ b/src/test/data/YankeeYogSothoth.txt
@@ -214,3 +214,75 @@ output:
 YankeeYogSothoth : 病院生活表(6) ＞ 16:看護師と仲良くなった
 rand:6/6,
 ============================
+input:
+FTNT
+output:
+YankeeYogSothoth : 二つ名決定表(1,11) ＞ 「愛死天流（あいしてる）」
+rand:1/6,1/6,1/6
+============================
+input:
+FTNT
+output:
+YankeeYogSothoth : 二つ名決定表(2,16) ＞ 「威風堂々（いふうどうどう）」
+rand:2/6,6/6,1/6
+============================
+input:
+FTNT
+output:
+YankeeYogSothoth : 二つ名決定表(2,66) ＞ 「時給千円（じきゅうせんえん）」
+rand:2/6,6/6,6/6
+============================
+input:
+FTNT
+output:
+YankeeYogSothoth : 二つ名決定表(3,11) ＞ 「みんなの」
+rand:3/6,1/6,1/6
+============================
+input:
+FTNT
+output:
+YankeeYogSothoth : 二つ名決定表(3,16) ＞ 「熱血番長の」
+rand:3/6,1/6,6/6
+============================
+input:
+FTNT
+output:
+YankeeYogSothoth : 二つ名決定表(4,66) ＞ 「悪そうなやつはだいたい友達」
+rand:4/6,6/6,6/6
+============================
+input:
+FTNT
+output:
+YankeeYogSothoth : 二つ名決定表(5,11) ＞ 「ファッションヤンキー」
+rand:5/6,1/6,1/6
+============================
+input:
+FTNT
+output:
+YankeeYogSothoth : 二つ名決定表(5,16) ＞ 「イカれたやつ」
+rand:5/6,6/6,1/6
+============================
+input:
+FTNT
+output:
+YankeeYogSothoth : 二つ名決定表(5,66) ＞ 「おやじ狩り狩り」
+rand:5/6,6/6,6/6
+============================
+input:
+FTNT
+output:
+YankeeYogSothoth : 二つ名決定表(6,11) ＞ 「国産」
+rand:6/6,1/6,1/6
+============================
+input:
+FTNT
+output:
+YankeeYogSothoth : 二つ名決定表(6,16) ＞ 「ミステリー」
+rand:6/6,1/6,6/6
+============================
+input:
+FTNT
+output:
+YankeeYogSothoth : 二つ名決定表(6,66) ＞ 「名古屋」
+rand:6/6,6/6,6/6
+============================


### PR DESCRIPTION
ヤンキー＆ヨグ＝ソトースのダイスボットにおいて、一覧に記載があるものの実装されておらず、コマンドが反応していなかった「二つ名決定表 (コマンド: `FTNT`)」が実行可能になるよう修正しました。
また、元々「二つ名表」と記載がありましたが、ルールブック内での正式名称は「二つ名決定表」でしたので名称を修正しています。

二つ名の決定は、ルールブック記載の通り

1. まず1d6を振り、4つある `二つ名表` の中からどの表を使用するか決定
2. d66を振り、`1.` で決めた表の中から二つ名を決定

の順に処理を行って結果を表示しています。

不備・改善点がありましたらご指摘お願います。