### PR TITLE
メタリックガーディアンで比較演算子がない時にもクリティカルのチェックをする

### DIFF
--- a/src/diceBot/MetallicGuadian.rb
+++ b/src/diceBot/MetallicGuadian.rb
@@ -27,17 +27,24 @@ class MetallicGuadian < SRS
 　　クリティカル値、ファンブル値は省略可能です。([]ごと省略できます)
 　　自動成功、自動失敗、成功、失敗を自動表示します。
 
-　　例) 2d6+2>=10       修整+2、目標値10で判定
+　　例) 2d6+2>=10       修正+2、目標値10で判定
 　　例) 2d6+2>=10[11]   ↑をクリティカル値11で判定
 　　例) 2d6+2>=10[12,4] ↑をクリティカル値12、ファンブル値4で判定
 　　例) MG+2>=10        2d6+2>=10と同じ（MGが2D6のショートカットコマンド）
+　　例) MG+2            2d6+2を実行し、クリティカル値12、ファンブル値2として、自動成功と自動失敗のみ判定
 
 ・D66ダイス(入れ替え無し)あり
 INFO_MESSAGE_TEXT
   end
 
   def changeText(string)
-    string = string.gsub(/^(S)?MG/i) { "#{Regexp.last_match(1)}2D6" }
-    return string
+    @need_check_critical_2d6 = false
+    m = /^S?MG/i.match(string)
+    if m.nil?
+      return string
+    else
+      @need_check_critical_2d6 = true
+      return string.sub("MG", "2D6")
+    end
   end
 end

--- a/src/test/data/MetallicGuadian.txt
+++ b/src/test/data/MetallicGuadian.txt
@@ -57,3 +57,39 @@ D66
 output:
 MetallicGuadian : (D66) ＞ 65
 rand:6/6,5/6
+============================
+input:
+MG
+output:
+MetallicGuadian : (2D6) ＞ 12[6,6]＋0 ＞ 12 ＞ 自動成功
+rand:6/6,6/6
+============================
+input:
+MG
+output:
+MetallicGuadian : (2D6) ＞ 2[1,1]＋0 ＞ 2 ＞ 自動失敗
+rand:1/6,1/6
+============================
+input:
+MG+1
+output:
+MetallicGuadian : (2D6+1) ＞ 11[5,6]＋1 ＞ 12
+rand:5/6,6/6
+============================
+input:
+MG-1
+output:
+MetallicGuadian : (2D6-1) ＞ 3[1,2]－1 ＞ 2
+rand:2/6,1/6
+============================
+input:
+2D6
+output:
+MetallicGuadian : (2D6) ＞ 12[6,6] ＞ 12
+rand:6/6,6/6
+============================
+input:
+2D6
+output:
+MetallicGuadian : (2D6) ＞ 2[1,1] ＞ 2
+rand:1/6,1/6


### PR DESCRIPTION
メタリックガーディアンで `MG` を実行した時に、比較演算子がなくてもクリティカルとファンブルのチェックをする。クリティカル/ファンブルの基準は従来のデフォルト値と同じ。

他のSRS系システムでも適用した方がいいかはわからないので、今回はメタリックガーディアンのみに適用

Ref. #114