### PR TITLE
NinjaSlayer: NJコマンドでシークレットロールできないのを修正する

### DIFF
--- a/src/diceBot/NinjaSlayer.rb
+++ b/src/diceBot/NinjaSlayer.rb
@@ -58,7 +58,7 @@ MESSAGETEXT
   DIFFICULTY_RE = /\[(#{DIFFICULTY_VALUE_RE})\]|@(#{DIFFICULTY_VALUE_RE})/io.freeze
 
   # 通常判定の正規表現
-  NJ_RE = /\ANJ(\d+)#{DIFFICULTY_RE}?\z/io.freeze
+  NJ_RE = /\A(S)?NJ(\d+)#{DIFFICULTY_RE}?\z/io.freeze
   # 回避判定の正規表現
   EV_RE = %r{\AEV(\d+)#{DIFFICULTY_RE}?(?:/(\d+))?\z}io.freeze
   # 近接攻撃の正規表現
@@ -89,7 +89,8 @@ MESSAGETEXT
     m = NJ_RE.match(str)
     return str unless m
 
-    return bRollCommand(m[1], integerValueOfDifficulty(m[2] || m[3]))
+    b_roll = bRollCommand(m[2], integerValueOfDifficulty(m[3] || m[4]))
+    return "#{m[1]}#{b_roll}"
   end
 
   def rollDiceCommand(command)

--- a/src/test/data/NinjaSlayer.txt
+++ b/src/test/data/NinjaSlayer.txt
@@ -29,6 +29,12 @@ NinjaSlayer : (4B6>=4) ＞ 2,3,6,4 ＞ 成功数2
 rand:2/6,3/6,6/6,4/6
 ============================
 input:
+SNJ4
+output:
+NinjaSlayer : (4B6>=4) ＞ 2,3,6,4 ＞ 成功数2###secret dice###
+rand:2/6,3/6,6/6,4/6
+============================
+input:
 NJ4@N
 output:
 NinjaSlayer : (4B6>=4) ＞ 2,3,6,4 ＞ 成功数2


### PR DESCRIPTION
NinjaSlayerのNJコマンドでシークレットロールできないのを修正しました。`changeText` で参照する正規表現において、シークレットロールを示す先頭の `S` を考慮していませんでした。