### PR TITLE
CgiDiceBotも乱数詳細を返すように

### DIFF
--- a/src/cgiDiceBot.rb
+++ b/src/cgiDiceBot.rb
@@ -155,6 +155,14 @@ class CgiDiceBot
   def sendMessageToChannels(message)
     @rollResult += message
   end
+
+  def rand_results
+    @bcdice.rand_results
+  end
+
+  def detailed_rand_results
+    @bcdice.detailed_rand_results
+  end
 end
 
 if $0 === __FILE__


### PR DESCRIPTION
#134 でダイスロールの詳細を保持するようになったが、CgiDiceBotからもそれを見れるようにする。これはbcdice-jsなどの外部ツールがCgiDiceBot経由でダイスロールしているためである。

`BCDice#rand_results`と`BCDice#detailed_rand_results`へのエイリアスをそれぞれ作成した。