### PR TITLE
AddDice::Node: ノードのS式を返すメソッドを追加する

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -45,6 +45,7 @@ namespace :test do
       'src/test/test_srs_help_messages.rb',
       'src/test/test_detailed_rand_results.rb',
       'src/test/range_table_test.rb',
+      'src/test/add_dice_parser_test.rb',
     ]
   end
 end

--- a/src/dice/add_dice/node.rb
+++ b/src/dice/add_dice/node.rb
@@ -15,6 +15,16 @@ class AddDice
         @lhs.to_s + cmp_op_text + @rhs.to_s
       end
 
+      # ノードのS式を返す
+      # @return [String]
+      def s_exp
+        if @cmp_op
+          "(Command (#{@cmp_op} #{@lhs.s_exp} #{@rhs}))"
+        else
+          "(Command #{@lhs.s_exp})"
+        end
+      end
+
       private
 
       def cmp_op_text
@@ -50,6 +60,12 @@ class AddDice
 
       def output
         @lhs.output + @op.to_s + @rhs.output + round_type_suffix()
+      end
+
+      # ノードのS式を返す
+      # @return [String]
+      def s_exp
+        "(#{@op}#{round_type_suffix} #{@lhs.s_exp} #{@rhs.s_exp})"
       end
 
       private
@@ -103,6 +119,12 @@ class AddDice
       def output
         "-#{@body.output}"
       end
+
+      # ノードのS式を返す
+      # @return [String]
+      def s_exp
+        "(- #{@body.s_exp})"
+      end
     end
 
     class DiceRoll
@@ -130,6 +152,14 @@ class AddDice
       def output
         @text
       end
+
+      # ノードのS式を返す
+      # @return [String]
+      def s_exp
+        parts = [@times, @sides, @critical].compact
+
+        "(DiceRoll #{parts.join(' ')})"
+      end
     end
 
     class Number
@@ -152,6 +182,7 @@ class AddDice
       end
 
       alias output to_s
+      alias s_exp to_s
     end
   end
 end

--- a/src/test/add_dice_parser_test.rb
+++ b/src/test/add_dice_parser_test.rb
@@ -1,0 +1,120 @@
+# -*- coding: utf-8 -*-
+# frozen_string_literal: true
+
+bcdice_root = File.expand_path('..', File.dirname(__FILE__))
+$:.unshift(bcdice_root) unless $:.include?(bcdice_root)
+
+require 'test/unit'
+require 'bcdiceCore'
+require 'dice/add_dice/parser'
+
+class AddDiceParserTest < Test::Unit::TestCase
+  def setup
+    @bcdice = BCDiceMaker.new.newBcDice
+  end
+
+  # ダイスロールのみ
+  def test_parse_dice_roll
+    test_parse('2D6', '(Command (DiceRoll 2 6))')
+  end
+
+  # ダイスロール + 修正値
+  def test_parse_modifier
+    test_parse('2D6+1', '(Command (+ (DiceRoll 2 6) 1))')
+  end
+
+  # 定数畳み込み
+  def test_parse_constant_folding
+    test_parse('2D6+1-1-2-3-4', '(Command (- (DiceRoll 2 6) 9))')
+  end
+
+  # 複数のダイスロール
+  def test_parse_multiple_dice_rolls
+    test_parse(
+      '2D6*3-1D6+1',
+      '(Command (+ (- (* (DiceRoll 2 6) 3) (DiceRoll 1 6)) 1))'
+    )
+  end
+
+  # 除法
+  def test_parse_division
+    test_parse('5D6/10', '(Command (/ (DiceRoll 5 6) 10))')
+  end
+
+  # 除法（切り上げ）
+  def test_parse_division_with_rounding_up
+    test_parse('3D6/2U', '(Command (/U (DiceRoll 3 6) 2))')
+  end
+
+  # 除法（四捨五入）
+  def test_parse_division_with_rounding_off
+    test_parse('1D100/10R', '(Command (/R (DiceRoll 1 100) 10))')
+  end
+
+  # 符号反転（負の整数で割る）
+  def test_parse_negation_1
+    test_parse('1D6/-3', '(Command (/ (DiceRoll 1 6) -3))')
+  end
+
+  # 符号反転（ダイスロールの符号反転）
+  def test_parse_negation_2
+    test_parse('-1D6+1', '(Command (+ (- (DiceRoll 1 6)) 1))')
+  end
+
+  # 二重符号反転（--1）
+  def test_parse_double_negation_1
+    test_parse('2D6--1', '(Command (+ (DiceRoll 2 6) 1))')
+  end
+
+  # 二重符号反転（---1）
+  def test_parse_double_negation_2
+    test_parse('2D6---1', '(Command (- (DiceRoll 2 6) 1))')
+  end
+
+  # 目標値あり（=）
+  def test_parse_target_value_eq_1
+    test_parse('2D6=7', '(Command (== (DiceRoll 2 6) 7))')
+  end
+
+  # 目標値あり（===）
+  def test_parse_target_value_eq_2
+    test_parse('2D6===7', '(Command (== (DiceRoll 2 6) 7))')
+  end
+
+  # 目標値あり（<>）
+  def test_parse_target_value_not_eq
+    test_parse('2D6<>7', '(Command (!= (DiceRoll 2 6) 7))')
+  end
+
+  # 目標値あり（>=）
+  def test_parse_target_value_geq_1
+    test_parse('2D6>=7', '(Command (>= (DiceRoll 2 6) 7))')
+  end
+
+  # 目標値あり（=>）
+  def test_parse_target_value_geq_2
+    test_parse('2D6=>7', '(Command (>= (DiceRoll 2 6) 7))')
+  end
+
+  # 目標値あり、目標値の定数畳み込み
+  def test_parse_target_value_constant_fonding
+    test_parse(
+      '1D6+1-2>=1+2',
+      '(Command (>= (- (DiceRoll 1 6) 1) 3))'
+    )
+  end
+
+  private
+
+  # 構文解析をテストする
+  # @param [String] command テストするコマンド
+  # @param [String] expected_s_exp 期待されるS式
+  # @return [void]
+  def test_parse(command, expected_s_exp)
+    parser = AddDice::Parser.new(command)
+    node = parser.parse
+
+    assert(!parser.error?, '構文解析に成功する')
+    assert_equal(expected_s_exp, node.s_exp, '結果の抽象構文木が正しい')
+  end
+end


### PR DESCRIPTION
構文解析のデバッグを行いやすくするために、AddDiceの抽象構文木のノードにS式を返すメソッドを追加しました。また、このメソッドを使用して、構文解析結果の抽象構文木が正しいことを確認するテストを追加しました。