### PR TITLE
Remove Object#untaint

### DIFF
--- a/src/TableFileData.rb
+++ b/src/TableFileData.rb
@@ -57,8 +57,6 @@ class TableFileData
     fileNames = Dir.glob("#{dir}/#{prefix}*.txt")
 
     fileNames.each do |fileName|
-      fileName = fileName.untaint
-
       info = readGameCommandInfo(fileName, prefix)
       gameType = info["gameType"]
       gameType ||= ""
@@ -284,7 +282,6 @@ class TableFileCreator
     end
 
     fileName = "#{@dir}/#{@prefix}#{prefix2}#{command}.txt"
-    fileName.untaint
 
     return fileName
   end
@@ -294,7 +291,6 @@ class TableFileCreator
     @command ||= ''
 
     @command.gsub!(/\./, '_')
-    @command.untaint
   end
 
   def checkCommand(command)

--- a/src/diceBot/DiceBotLoader.rb
+++ b/src/diceBot/DiceBotLoader.rb
@@ -86,7 +86,7 @@ class DiceBotLoader
 
     botFiles = Dir.glob("#{diceBotDir}/*.rb")
     botNames =
-      botFiles.map { |botFile| File.basename(botFile, '.rb').untaint }
+      botFiles.map { |botFile| File.basename(botFile, '.rb') }
     validBotNames =
       # 特別な名前のものを除外する
       (botNames - BOT_NAMES_TO_IGNORE).


### PR DESCRIPTION
Object#untaint is deprecated. It will be removed Ruby 3.2.