### PR TITLE
AddDice::Node: 二項演算子をリファクタリングする

### DIFF
--- a/src/dice/add_dice/node.rb
+++ b/src/dice/add_dice/node.rb
@@ -1,16 +1,36 @@
 # -*- coding: utf-8 -*-
+# frozen_string_literal: true
 
 class AddDice
+  # 加算ロールの構文解析木のノードを格納するモジュール
   module Node
+    # 加算ロールコマンドのノード。
+    #
+    # 目標値が設定されていない場合は +lhs+ のみを使用する。
+    # 目標値が設定されている場合は、+lhs+、+cmp_op+、+rhs+ を使用する。
     class Command
-      attr_reader :lhs, :cmp_op, :rhs
+      # 左辺のノード
+      # @return [Object]
+      attr_reader :lhs
+      # 比較演算子
+      # @return [Symbol]
+      attr_reader :cmp_op
+      # 右辺のノード
+      # @return [Integer, String]
+      attr_reader :rhs
 
+      # ノードを初期化する
+      # @param [Object] lhs 左辺のノード
+      # @param [Symbol] cmp_op 比較演算子
+      # @param [Integer, String] rhs 右辺のノード
       def initialize(lhs, cmp_op, rhs)
         @lhs = lhs
         @cmp_op = cmp_op
         @rhs = rhs
       end
 
+      # 文字列に変換する
+      # @return [String]
       def to_s
         @lhs.to_s + cmp_op_text + @rhs.to_s
       end
@@ -27,6 +47,8 @@ class AddDice
 
       private
 
+      # メッセージ中で比較演算子をどのように表示するかを返す
+      # @return [String]
       def cmp_op_text
         case @cmp_op
         when :'!='
@@ -39,7 +61,17 @@ class AddDice
       end
     end
 
+    # 二項演算子のノード
     class BinaryOp
+      # ノードを初期化する
+      #
+      # +round_type+ には、+:roundUp+（切り上げ）、+:roundOff+（四捨五入）、
+      # または +nil+ を指定する。
+      #
+      # @param [Object] lhs 左辺のノード
+      # @param [Symbol] op 演算子
+      # @param [Object] rhs 右辺のノード
+      # @param [Symbol, nil] round_type 除算における小数の丸め方
       def initialize(lhs, op, rhs, round_type = nil)
         @lhs = lhs
         @op = op
@@ -47,6 +79,12 @@ class AddDice
         @round_type = round_type
       end
 
+      # ノードを評価する
+      #
+      # 左右のオペランドをそれぞれ再帰的に評価した後で、演算を行う。
+      #
+      # @param [Randomizer] randomizer ランダマイザ
+      # @return [Integer] 評価結果
       def eval(randomizer)
         lhs = @lhs.eval(randomizer)
         rhs = @rhs.eval(randomizer)
@@ -54,10 +92,14 @@ class AddDice
         calc(lhs, rhs)
       end
 
+      # 文字列に変換する
+      # @return [String]
       def to_s
         @lhs.to_s + @op.to_s + @rhs.to_s + round_type_suffix()
       end
 
+      # メッセージへの出力を返す
+      # @return [String]
       def output
         @lhs.output + @op.to_s + @rhs.output + round_type_suffix()
       end
@@ -70,6 +112,10 @@ class AddDice
 
       private
 
+      # 演算を行う
+      # @param [Integer] lhs 左のオペランド
+      # @param [Integer] rhs 右のオペランド
+      # @return [Integer] 演算の結果
       def calc(lhs, rhs)
         if @op != :/
           return lhs.send(@op, rhs)
@@ -101,21 +147,36 @@ class AddDice
       end
     end
 
+    # 符号反転のノード
     class Negate
+      # 符号反転の対象
+      # @return [Object]
       attr_reader :body
 
+      # ノードを初期化する
+      # @param [Object] body 符号反転の対象
       def initialize(body)
         @body = body
       end
 
+      # ノードを評価する
+      #
+      # 対象オペランドを再帰的に評価した後、評価結果の符号を反転する。
+      #
+      # @param [Randomizer] randomizer ランダマイザ
+      # @return [Integer] 評価結果
       def eval(randomizer)
         -@body.eval(randomizer)
       end
 
+      # 文字列に変換する
+      # @return [String]
       def to_s
         "-#{@body}"
       end
 
+      # メッセージへの出力を返す
+      # @return [String]
       def output
         "-#{@body.output}"
       end
@@ -127,20 +188,36 @@ class AddDice
       end
     end
 
+    # ダイスロールのノード
     class DiceRoll
+      # ノードを初期化する
+      # @param [Number] times ダイスを振る回数のノード
+      # @param [Number] sides ダイスの面数のノード
+      # @param [Number, nil] critical クリティカル値のノード
       def initialize(times, sides, critical)
         @times = times.literal
         @sides = sides.literal
         @critical = critical.nil? ? nil : critical.literal
+
+        # ダイスを振った結果の出力
         @text = nil
       end
 
+      # ノードを評価する（ダイスを振る）
+      #
+      # 評価結果は出目の合計値になる。
+      # 出目はランダマイザに記録される。
+      #
+      # @param [Randomizer] randomizer ランダマイザ
+      # @return [Integer] 評価結果（出目の合計値）
       def eval(randomizer)
         total, @text = randomizer.roll(@times, @sides, @critical)
 
         total
       end
 
+      # 文字列に変換する
+      # @return [String]
       def to_s
         if @critical
           "#{@times}D#{@sides}@#{@critical}"
@@ -149,6 +226,8 @@ class AddDice
         end
       end
 
+      # メッセージへの出力を返す
+      # @return [String]
       def output
         @text
       end
@@ -162,21 +241,32 @@ class AddDice
       end
     end
 
+    # 数値のノード
     class Number
+      # 値
+      # @return [Integer]
       attr_reader :literal
 
+      # ノードを初期化する
+      # @param [Integer] literal 値
       def initialize(literal)
         @literal = literal
       end
 
+      # 符号を反転した結果の数値ノードを返す
+      # @return [Number]
       def negate
         Number.new(-@literal)
       end
 
+      # ノードを評価する
+      # @return [Integer] 格納している値
       def eval(_randomizer)
         @literal
       end
 
+      # 文字列に変換する
+      # @return [String]
       def to_s
         @literal.to_s
       end

--- a/src/dice/add_dice/node.rb
+++ b/src/dice/add_dice/node.rb
@@ -123,7 +123,7 @@ class AddDice
 
     # 除算ノードの基底クラス
     #
-    # 定数 +ROUNDING_METHOD_SYMBOL+ で端数処理方法を示す記号
+    # 定数 +ROUNDING_METHOD+ で端数処理方法を示す記号
     # ( +'U'+, +'R'+, +''+ ) を定義すること。
     # また、除算および端数処理を行う +divide_and_round+ メソッドを実装すること。
     class DivideBase < BinaryOp
@@ -140,7 +140,7 @@ class AddDice
       #
       # @return [String]
       def to_s
-        "#{super}#{rounding_method_symbol}"
+        "#{super}#{rounding_method}"
       end
 
       # メッセージへの出力を返す
@@ -149,21 +149,21 @@ class AddDice
       #
       # @return [String]
       def output
-        "#{super}#{rounding_method_symbol}"
+        "#{super}#{rounding_method}"
       end
 
       private
 
       # 端数処理方法を示す記号を返す
       # @return [String]
-      def rounding_method_symbol
-        self.class::ROUNDING_METHOD_SYMBOL
+      def rounding_method
+        self.class::ROUNDING_METHOD
       end
 
       # S式で使う演算子の表現を返す
       # @return [String]
       def op_for_s_exp
-        "#{@op}#{rounding_method_symbol}"
+        "#{@op}#{rounding_method}"
       end
 
       # 演算を行う
@@ -190,7 +190,7 @@ class AddDice
     # 除算（切り上げ）のノード
     class DivideWithRoundingUp < DivideBase
       # 端数処理方法を示す記号
-      ROUNDING_METHOD_SYMBOL = 'U'
+      ROUNDING_METHOD = 'U'
 
       private
 
@@ -206,7 +206,7 @@ class AddDice
     # 除算（四捨五入）のノード
     class DivideWithRoundingOff < DivideBase
       # 端数処理方法を示す記号
-      ROUNDING_METHOD_SYMBOL = 'R'
+      ROUNDING_METHOD = 'R'
 
       private
 
@@ -222,7 +222,7 @@ class AddDice
     # 除算（切り捨て）のノード
     class DivideWithRoundingDown < DivideBase
       # 端数処理方法を示す記号
-      ROUNDING_METHOD_SYMBOL = ''
+      ROUNDING_METHOD = ''
 
       private
 

--- a/src/dice/add_dice/parser.rb
+++ b/src/dice/add_dice/parser.rb
@@ -1,17 +1,26 @@
 # -*- coding: utf-8 -*-
+# frozen_string_literal: true
 
 require "utils/ArithmeticEvaluator"
 require "utils/normalize"
 require "dice/add_dice/node"
 
 class AddDice
+  # 加算ロールの構文解析器のクラス
   class Parser
+    # 構文解析器を初期化する
+    # @param [String] expr 構文解析対象の文字列
     def initialize(expr)
+      # 構文解析対象の文字列
       @expr = expr
+      # 読み込んだトークンのインデックス
       @idx = 0
+      # 構文解析エラーが発生したかどうか
       @error = false
     end
 
+    # 構文解析を実行する
+    # @return [Node::Command] 加算ロールコマンド
     def parse()
       lhs, cmp_op, rhs = @expr.partition(/[<>=]+/)
 
@@ -30,22 +39,28 @@ class AddDice
       return AddDice::Node::Command.new(lhs, cmp_op, rhs)
     end
 
+    # 構文解析エラーが発生したかどうかを返す
+    # @return [Boolean]
     def error?
       @error
     end
 
     private
 
+    # 構文解析対象の文字列をトークンの配列に変換する
+    # @return [Array<String>]
     def tokenize(expr)
       expr.gsub(%r{[\+\-\*/DURS@]}) { |e| " #{e} " }.split(' ')
     end
 
+    # 式
     def expr
       consume("S")
 
       return add()
     end
 
+    # 加算、減算
     def add
       node = mul()
 
@@ -64,6 +79,7 @@ class AddDice
       return node
     end
 
+    # TODO: 処理の説明を書く
     def sub_negative_number(op, rhs)
       if rhs.is_a?(Node::Number) && rhs.literal < 0
         if op == :+
@@ -76,6 +92,7 @@ class AddDice
       [op, rhs]
     end
 
+    # 乗算、除算
     def mul
       node = unary()
 
@@ -92,6 +109,7 @@ class AddDice
       return node
     end
 
+    # 単項演算
     def unary
       if consume("+")
         unary()
@@ -111,6 +129,7 @@ class AddDice
       end
     end
 
+    # 項：ダイスロール、数値
     def term
       ret = expect_number()
       if consume("D")
@@ -124,6 +143,14 @@ class AddDice
       ret
     end
 
+    # トークンを消費する
+    #
+    # トークンと期待した文字列が合致していた場合、次のトークンに進む。
+    # 合致していなかった場合は、進まない。
+    #
+    # @param [String] str 期待する文字列
+    # @return [true] トークンと期待した文字列が合致していた場合
+    # @return [false] トークンと期待した文字列が合致していなかった場合
     def consume(str)
       if @tokens[@idx] != str
         return false
@@ -141,6 +168,13 @@ class AddDice
       end
     end
 
+    # 指定された文字列のトークンを要求する
+    #
+    # トークンと期待した文字列が合致していなかった場合、エラーとする。
+    # エラーの有無にかかわらず、次のトークンに進む。
+    #
+    # @param [String] str 期待する文字列
+    # @return [void]
     def expect(str)
       if @tokens[@idx] != str
         @error = true
@@ -149,6 +183,14 @@ class AddDice
       @idx += 1
     end
 
+    # 整数のトークンを要求する
+    #
+    # 整数のトークンならば、対応する整数のノードを返す。
+    # そうでなければエラーとし、整数0のノードを返す。
+    #
+    # エラーの有無にかかわらず、次のトークンに進む。
+    #
+    # @return [Node::Number] 整数のノード
     def expect_number()
       unless integer?(@tokens[@idx])
         @error = true
@@ -161,6 +203,9 @@ class AddDice
       return AddDice::Node::Number.new(ret)
     end
 
+    # 文字列が整数かどうかを返す
+    # @param [String] str 対象文字列
+    # @return [Boolean]
     def integer?(str)
       # Ruby 1.9 以降では Kernel.#Integer を使うべき
       # Ruby 1.8 にもあるが、基数を指定できない問題がある

--- a/src/dice/add_dice/parser.rb
+++ b/src/dice/add_dice/parser.rb
@@ -100,13 +100,30 @@ class AddDice
         if consume("*")
           node = AddDice::Node::BinaryOp.new(node, :*, unary())
         elsif consume("/")
-          node = AddDice::Node::BinaryOp.new(node, :/, unary(), consume_round_type())
+          rhs = unary()
+          klass = divide_node_class()
+          node = klass.new(node, rhs)
         else
           break
         end
       end
 
       return node
+    end
+
+    # 端数処理方法を示す記号を読み込み、対応する除算ノードのクラスを返す
+    # @return [Class] 除算ノードのクラス
+    def divide_node_class
+      if consume('U')
+        # 切り上げ
+        Node::DivideWithRoundingUp
+      elsif consume('R')
+        # 四捨五入
+        Node::DivideWithRoundingOff
+      else
+        # 切り捨て
+        Node::DivideWithRoundingDown
+      end
     end
 
     # 単項演算
@@ -158,14 +175,6 @@ class AddDice
 
       @idx += 1
       return true
-    end
-
-    def consume_round_type()
-      if consume("U")
-        :roundUp
-      elsif consume("R")
-        :roundOff
-      end
     end
 
     # 指定された文字列のトークンを要求する


### PR DESCRIPTION
除算ノードのクラスを新しく作り、BinaryOpを単純化しました。

除算の処理だけが特別なので、汎用的なBinaryOpにそれを書くのではなく、端数処理方法別に除算ノードのクラスを3つ作り、それらに処理を分担させました。

クラスの継承関係：

    BinaryOp（二項演算子）
    |
    +-- DivideBase（除算の基底クラス）
        |
        |-- DivideWithRoundingUp  （除算 -> 切り上げ）
        |-- DivideWithRoundingOff （除算 -> 四捨五入）
        +-- DivideWithRoundingDown（除算 -> 切り捨て）