### PR TITLE
ArsMagicaで成功失敗判定ができない問題を修正

### DIFF
--- a/src/test/data/ArsMagica.txt
+++ b/src/test/data/ArsMagica.txt
@@ -369,3 +369,39 @@ Ars10
 output:
 ArsMagica : (1R10[10]) ＞ 8
 rand:9/10
+============================
+input:
+Ars-3
+output:
+ArsMagica : (1R10-3) ＞ 8-3 ＞ 5
+rand:9/10
+============================
+input:
+Ars+3
+output:
+ArsMagica : (1R10+3) ＞ 8+3 ＞ 11
+rand:9/10
+============================
+input:
+Ars10>=7
+output:
+ArsMagica : (1R10[10]>=7) ＞ 2 ＞ 失敗
+rand:3/10
+============================
+input:
+Ars10>=7
+output:
+ArsMagica : (1R10[10]>=7) ＞ 9 ＞ 成功
+rand:10/10
+============================
+input:
+Ars10>=7
+output:
+ArsMagica : (1R10[10]>=7) ＞ 7 ＞ 成功
+rand:8/10
+============================
+input:
+Ars2>=7 Botchの時には目標値を使った判定はされない
+output:
+ArsMagica : (1R10[2]>=7) ＞ 0[0,0,0] ＞ 2Botch!
+rand:1/10,1/10,1/10

--- a/src/test/data/ArsMagica.txt
+++ b/src/test/data/ArsMagica.txt
@@ -37,12 +37,6 @@ rand:8/10
 input:
 Ars1
 output:
-ArsMagica : (1R10[1]) ＞ 9
-rand:10/10
-============================
-input:
-Ars1
-output:
 ArsMagica : (1R10[1]) ＞ 5
 rand:6/10
 ============================
@@ -55,20 +49,8 @@ rand:4/10
 input:
 Ars1
 output:
-ArsMagica : (1R10[1]) ＞ 3
-rand:4/10
-============================
-input:
-Ars1
-output:
 ArsMagica : (1R10[1]) ＞ 0[0,7] ＞ 0
 rand:1/10,8/10
-============================
-input:
-Ars1
-output:
-ArsMagica : (1R10[1]) ＞ 7
-rand:8/10
 ============================
 input:
 Ars3
@@ -85,12 +67,6 @@ rand:4/10
 input:
 Ars3
 output:
-ArsMagica : (1R10[3]) ＞ 7
-rand:8/10
-============================
-input:
-Ars3
-output:
 ArsMagica : (1R10[3]) ＞ 9
 rand:10/10
 ============================
@@ -99,30 +75,6 @@ Ars3
 output:
 ArsMagica : (1R10[3]) ＞ 7
 rand:8/10
-============================
-input:
-Ars3
-output:
-ArsMagica : (1R10[3]) ＞ 9
-rand:10/10
-============================
-input:
-Ars3
-output:
-ArsMagica : (1R10[3]) ＞ 7
-rand:8/10
-============================
-input:
-Ars3
-output:
-ArsMagica : (1R10[3]) ＞ 7
-rand:8/10
-============================
-input:
-Ars3
-output:
-ArsMagica : (1R10[3]) ＞ 4
-rand:5/10
 ============================
 input:
 Ars3
@@ -145,20 +97,8 @@ rand:9/10
 input:
 Ars5
 output:
-ArsMagica : (1R10[5]) ＞ 4
-rand:5/10
-============================
-input:
-Ars5
-output:
 ArsMagica : (1R10[5]) ＞ 6
 rand:7/10
-============================
-input:
-Ars5
-output:
-ArsMagica : (1R10[5]) ＞ 3
-rand:4/10
 ============================
 input:
 Ars5
@@ -171,12 +111,6 @@ Ars5
 output:
 ArsMagica : (1R10[5]) ＞ 3
 rand:4/10
-============================
-input:
-Ars5
-output:
-ArsMagica : (1R10[5]) ＞ 4
-rand:5/10
 ============================
 input:
 Ars5
@@ -217,26 +151,8 @@ rand:1/10,10/10,6/10,10/10,6/10,8/10,2/10,6/10
 input:
 Ars7
 output:
-ArsMagica : (1R10[7]) ＞ 9
-rand:10/10
-============================
-input:
-Ars7
-output:
-ArsMagica : (1R10[7]) ＞ 4
-rand:5/10
-============================
-input:
-Ars7
-output:
 ArsMagica : (1R10[7]) ＞ 10[1,5]
 rand:2/10,5/10
-============================
-input:
-Ars7
-output:
-ArsMagica : (1R10[7]) ＞ 3
-rand:4/10
 ============================
 input:
 Ars7
@@ -253,62 +169,14 @@ rand:8/10
 input:
 Ars9
 output:
-ArsMagica : (1R10[9]) ＞ 3
-rand:4/10
-============================
-input:
-Ars9
-output:
-ArsMagica : (1R10[9]) ＞ 9
-rand:10/10
-============================
-input:
-Ars9
-output:
-ArsMagica : (1R10[9]) ＞ 8
-rand:9/10
-============================
-input:
-Ars9
-output:
-ArsMagica : (1R10[9]) ＞ 2
-rand:3/10
-============================
-input:
-Ars9
-output:
-ArsMagica : (1R10[9]) ＞ 4
-rand:5/10
-============================
-input:
-Ars9
-output:
 ArsMagica : (1R10[9]) ＞ 20[1,1,5]
 rand:2/10,1/10,5/10
 ============================
 input:
 Ars9
 output:
-ArsMagica : (1R10[9]) ＞ 4
-rand:5/10
-============================
-input:
-Ars9
-output:
 ArsMagica : (1R10[9]) ＞ 8[1,4]
 rand:2/10,4/10
-============================
-input:
-Ars9
-output:
-ArsMagica : (1R10[9]) ＞ 7
-rand:8/10
-============================
-input:
-Ars9
-output:
-ArsMagica : (1R10[9]) ＞ 5
-rand:6/10
 ============================
 input:
 Ars10
@@ -319,56 +187,8 @@ rand:2/10,7/10
 input:
 Ars10
 output:
-ArsMagica : (1R10[10]) ＞ 6
-rand:7/10
-============================
-input:
-Ars10
-output:
-ArsMagica : (1R10[10]) ＞ 5
-rand:6/10
-============================
-input:
-Ars10
-output:
-ArsMagica : (1R10[10]) ＞ 7
-rand:8/10
-============================
-input:
-Ars10
-output:
-ArsMagica : (1R10[10]) ＞ 5
-rand:6/10
-============================
-input:
-Ars10
-output:
-ArsMagica : (1R10[10]) ＞ 2
-rand:3/10
-============================
-input:
-Ars10
-output:
-ArsMagica : (1R10[10]) ＞ 9
-rand:10/10
-============================
-input:
-Ars10
-output:
-ArsMagica : (1R10[10]) ＞ 7
-rand:8/10
-============================
-input:
-Ars10
-output:
 ArsMagica : (1R10[10]) ＞ 0[0,2,4,7,9,4,5,5,7,4,2] ＞ 0
 rand:1/10,3/10,5/10,8/10,10/10,5/10,6/10,6/10,8/10,5/10,3/10
-============================
-input:
-Ars10
-output:
-ArsMagica : (1R10[10]) ＞ 8
-rand:9/10
 ============================
 input:
 Ars-3


### PR DESCRIPTION
ArsMagicaのテストで成功失敗判定のテストケースがなかったため、 `DiceBot#check_result` のリファクタリング(#145)で修正漏れしていた。 

問題を修正し、該当するテストケースを追加。
また、重複するテストケースを排除。