### PR TITLE
マスターコマンド：レーティング表設定コマンドを削除する

### DIFF
--- a/src/bcdiceCore.rb
+++ b/src/bcdiceCore.rb
@@ -266,10 +266,6 @@ class BCDice
       # 個数振り足しロール回数制限設定 0=無限
       setRerollLimit()
 
-    when /\Ar(?:ating\s*)?t(?:able)?\z/
-      # レーティング表設定
-      setRatingTable()
-
     when 'sort'
       # ソートモード設定
       setSortMode()
@@ -373,15 +369,6 @@ class BCDice
     else
       sendMessageToChannels("個数振り足しロールの回数を無限に設定しました")
     end
-  end
-
-  def setRatingTable()
-    return unless isMaster()
-
-    output = @diceBot.setRatingTable(@tnick)
-    return if output == '1'
-
-    sendMessageToChannels(output)
   end
 
   def setSortMode()

--- a/src/diceBot/DiceBot.rb
+++ b/src/diceBot/DiceBot.rb
@@ -434,11 +434,6 @@ class DiceBot
     return '', 0
   end
 
-  # SW専用
-  def setRatingTable(_nick_e, _tnick, _channel_to_list)
-    '1'
-  end
-
   # ガンドッグのnD9専用
   def isD9
     false


### PR DESCRIPTION
Fixes #178

※IRCボット機能は後にまとめて削除する予定ですが、このPR内のコミットはDiceBotにも影響するため、変更範囲が小さいうちに投稿します。

IRCボット用のマスターコマンドから、ソード・ワールドのレーティング表設定コマンドを削除します。
引数の数の不一致により、以前からこのコマンドを実行するとArgumentErrorが発生するようになっていました。

また、同時に不要になった `DiceBot#setRatingTable` も削除します。
そのため、この名前のメソッドはソード・ワールドのダイスボットに固有のメソッドに変わります。