### PR TITLE
汎用コマンドパーサー

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -81,6 +81,7 @@ namespace :test do
       'src/test/test_dicebot_info_is_defined.rb',
       'src/test/testDiceBotLoaders.rb',
       'src/test/testDiceBotPrefixesCompatibility.rb',
+      'src/test/test_command_parser.rb',
       'src/test/test_d66_table.rb',
       'src/test/test_srs_help_messages.rb',
       'src/test/test_detailed_rand_results.rb',

--- a/src/test/data/SamsaraBallad.txt
+++ b/src/test/data/SamsaraBallad.txt
@@ -7,43 +7,43 @@ rand:99/100
 input:
 SB roll
 output:
-SamsaraBallad : D100 ＞ 75
+SamsaraBallad : (D100) ＞ 75
 rand:75/100
 ============================
 input:
 SB#2@8 roll
 output:
-SamsaraBallad : D100 ＞ 80 ＞ ファンブル
+SamsaraBallad : (D100) ＞ 80 ＞ ファンブル
 rand:80/100
 ============================
 input:
 SB#2@8 roll
 output:
-SamsaraBallad : D100 ＞ 83
+SamsaraBallad : (D100) ＞ 83
 rand:83/100
 ============================
 input:
 SB#2@8 roll
 output:
-SamsaraBallad : D100 ＞ 89 ＞ クリティカル
+SamsaraBallad : (D100) ＞ 89 ＞ クリティカル
 rand:89/100
 ============================
 input:
 SBS roll
 output:
-SamsaraBallad : D100 ＞ 7,5 ＞ 57
+SamsaraBallad : (D100) ＞ 7,5 ＞ 57
 rand:7/10,5/10
 ============================
 input:
 SBS roll
 output:
-SamsaraBallad : D100 ＞ 7,10 ＞ 7
+SamsaraBallad : (D100) ＞ 7,10 ＞ 7
 rand:7/10,10/10
 ============================
 input:
 SBS roll
 output:
-SamsaraBallad : D100 ＞ 10,10 ＞ 100
+SamsaraBallad : (D100) ＞ 10,10 ＞ 100
 rand:10/10,10/10
 ============================
 input:

--- a/src/test/test_command_parser.rb
+++ b/src/test/test_command_parser.rb
@@ -90,9 +90,14 @@ class TestCommandParser < Test::Unit::TestCase
     assert_equal(23, parsed.fumble)
   end
 
-  data("LL@2@5", "LL#2#5")
-  def test_duplicate_suffix(data)
-    parsed = @parser.parse(data)
+  def test_duplicate_critical
+    parsed = @parser.parse("LL@2@5")
+
+    assert_equal(nil, parsed)
+  end
+
+  def test_duplicate_fumble
+    parsed = @parser.parse("LL#2#5")
 
     assert_equal(nil, parsed)
   end

--- a/src/test/test_command_parser.rb
+++ b/src/test/test_command_parser.rb
@@ -1,0 +1,110 @@
+# -*- coding: utf-8 -*-
+
+require 'test/unit'
+require 'bcdiceCore'
+require 'utils/command_parser'
+
+class TestCommandParser < Test::Unit::TestCase
+  def setup
+    @parser = CommandParser.new("LL", "SA")
+  end
+
+  def test_parse_full
+    parsed = @parser.parse("LL@1#2+4<=5")
+
+    assert_not_nil(parsed)
+    assert_equal("LL", parsed.command)
+    assert_equal(1, parsed.critical)
+    assert_equal(2, parsed.fumble)
+    assert_equal(4, parsed.modify_number)
+    assert_equal(:<=, parsed.cmp_op)
+    assert_equal(5, parsed.target_number)
+  end
+
+  def test_command_only
+    parsed = @parser.parse("LL")
+
+    assert_not_nil(parsed)
+    assert_equal("LL", parsed.command)
+    assert_equal(nil, parsed.critical)
+    assert_equal(nil, parsed.fumble)
+    assert_equal(0, parsed.modify_number)
+    assert_equal(nil, parsed.cmp_op)
+    assert_equal(nil, parsed.target_number)
+  end
+
+  def test_not_match
+    parsed = @parser.parse("RR@1#2+4<=5")
+
+    assert_equal(nil, parsed)
+  end
+
+  def test_negative_suffix
+    parsed = @parser.parse("LL@-1#-2")
+
+    assert_not_nil(parsed)
+    assert_equal("LL", parsed.command)
+    assert_equal(-1, parsed.critical)
+    assert_equal(-2, parsed.fumble)
+  end
+
+  def test_expr
+    parsed = @parser.parse("LL@1#2-4*3+6/2<=-10/5+2*6")
+
+    assert_not_nil(parsed)
+    assert_equal("LL", parsed.command)
+    assert_equal(1, parsed.critical)
+    assert_equal(2, parsed.fumble)
+    assert_equal(-9, parsed.modify_number)
+    assert_equal(:<=, parsed.cmp_op)
+    assert_equal(10, parsed.target_number)
+  end
+
+  def test_reverse_critical
+    parsed = @parser.parse("LL#1@2+4<=5")
+
+    assert_not_nil(parsed)
+    assert_equal("LL", parsed.command)
+    assert_equal(2, parsed.critical)
+    assert_equal(1, parsed.fumble)
+    assert_equal(4, parsed.modify_number)
+    assert_equal(:<=, parsed.cmp_op)
+    assert_equal(5, parsed.target_number)
+  end
+
+  def test_critical_only
+    parsed = @parser.parse("LL@23")
+
+    assert_not_nil(parsed)
+    assert_equal("LL", parsed.command)
+    assert_equal(23, parsed.critical)
+    assert_equal(nil, parsed.fumble)
+  end
+
+  def test_fumble_only
+    parsed = @parser.parse("LL#23")
+
+    assert_not_nil(parsed)
+    assert_equal("LL", parsed.command)
+    assert_equal(nil, parsed.critical)
+    assert_equal(23, parsed.fumble)
+  end
+
+  data("LL@2@5", "LL#2#5")
+  def test_duplicate_suffix(data)
+    parsed = @parser.parse(data)
+
+    assert_equal(nil, parsed)
+  end
+
+  def test_no_suffix
+    parsed = @parser.parse("LL+10>30")
+
+    assert_equal("LL", parsed.command)
+    assert_equal(nil, parsed.critical)
+    assert_equal(nil, parsed.fumble)
+    assert_equal(10, parsed.modify_number)
+    assert_equal(:>, parsed.cmp_op)
+    assert_equal(30, parsed.target_number)
+  end
+end

--- a/src/utils/command_parser.rb
+++ b/src/utils/command_parser.rb
@@ -1,0 +1,93 @@
+require "utils/ArithmeticEvaluator"
+require "utils/normalize"
+
+class CommandParser < ArithmeticEvaluator
+  def initialize(*literals)
+    @literals = literals
+    @round_type = :omit
+  end
+
+  def parse(expr, round_type = :omit)
+    @tokens = tokenize(expr)
+    @idx = 0
+    @error = false
+    @round_type = round_type
+
+    @parsed = Parsed.new()
+
+    lhs()
+    if @error
+      return nil
+    end
+
+    @parsed.cmp_op = take_cmp_op()
+    @parsed.target_number = @parsed.cmp_op ? expr() : nil
+
+    if @idx < @tokens.size || @error
+      return nil
+    end
+
+    return @parsed
+  end
+
+  Parsed = Struct.new(:command, :critical, :fumble, :modify_number, :cmp_op, :target_number)
+
+  private
+
+  def tokenize(expr)
+    expr.gsub(%r{[\(\)\+\-*/@#]|[<>!=]+}) { |e| " #{e} " }.split(' ')
+  end
+
+  def lhs
+    command = take()
+    unless @literals.include?(command)
+      @error = true
+      return
+    end
+
+    command_suffix()
+
+    ret = 0
+    loop do
+      if consume("+")
+        ret += mul()
+      elsif consume("-")
+        ret -= mul()
+      else
+        break
+      end
+    end
+
+    @parsed.command = command
+    @parsed.modify_number = ret
+  end
+
+  def command_suffix
+    loop do
+      if consume("@")
+        if @parsed.critical
+          @error = true
+        end
+        @parsed.critical = unary()
+      elsif consume("#")
+        if @parsed.fumble
+          @error = true
+        end
+        @parsed.fumble = unary()
+      else
+        break
+      end
+    end
+  end
+
+  def take
+    ret = @tokens[@idx]
+    @idx += 1
+
+    return ret
+  end
+
+  def take_cmp_op
+    Normalize.comparison_operator(take())
+  end
+end


### PR DESCRIPTION
コマンドからクリティカル、ファンブル、修正値、比較演算子、目標値をパースする汎用パーサーを追加する。使い方は下記の通り。

```ruby
parser = CommandParser.new("LL", "LR") # 使うコマンドを列挙
cmd = parser.parse("LL@1#2+4<=5")

cmd.command #=> "LL"
cmd.critical #=> 1
cmd.fumble #=> 2
cmd.modify_number #=> 4
cmd.cmp_op #=> :<=
cmd.target_number #=> 5
```

良い名前が思い浮かばなかったので、`CommandParser` `CommandParser#command` にしたが、代替案があれば変更したい。