### PR TITLE
一部の加算ダイスでシークレットにならない問題を修正

### DIFF
--- a/src/bcdiceCore.rb
+++ b/src/bcdiceCore.rb
@@ -448,11 +448,12 @@ class BCDice
   def checkAddRoll(arg)
     debug("check add roll")
 
-    dice = AddDice.new(self, @diceBot)
-    output = dice.rollDice(arg)
-    return nil if output == '1'
+    secret = arg[0] == 'S'
+    command = secret ? arg[1..-1] : arg
 
-    secret = (/S[-\d]+D[\d+-]+/ === arg)
+    dice = AddDice.new(self, @diceBot)
+    output = dice.rollDice(command)
+    return nil if output == '1'
 
     return output, secret
   end

--- a/src/bcdiceCore.rb
+++ b/src/bcdiceCore.rb
@@ -448,7 +448,7 @@ class BCDice
   def checkAddRoll(arg)
     debug("check add roll")
 
-    secret = arg[0] == 'S'
+    secret = arg.start_with?('S')
     command = secret ? arg[1..-1] : arg
 
     dice = AddDice.new(self, @diceBot)

--- a/src/test/data/None.txt
+++ b/src/test/data/None.txt
@@ -256,6 +256,12 @@ DiceBot : (2D6) ＞ 5[4,1] ＞ 5###secret dice###
 rand:4/6,1/6
 ============================
 input:
+S1+2D6
+output:
+DiceBot : (1+2D6) ＞ 1+5[4,1] ＞ 6###secret dice###
+rand:4/6,1/6
+============================
+input:
 2D6=7
 output:
 DiceBot : (2D6=7) ＞ 7[3,4] ＞ 7 ＞ 成功


### PR DESCRIPTION
加算ダイスの先頭がダイスロールリテラルでない時に加算ダイスと認識しない問題があった