### PR TITLE
テストデータの文字コードと改行コードをチェックするテストを追加

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -86,8 +86,8 @@ namespace :test do
       'src/test/test_detailed_rand_results.rb',
       'src/test/range_table_test.rb',
       'src/test/add_dice_parser_test.rb',
-      'src/test/test_data_encoding.rb'
-    ]
+      ('src/test/test_data_encoding.rb' if RUBY_VERSION >= '1.9')
+    ].compact
   end
 end
 

--- a/Rakefile
+++ b/Rakefile
@@ -86,6 +86,7 @@ namespace :test do
       'src/test/test_detailed_rand_results.rb',
       'src/test/range_table_test.rb',
       'src/test/add_dice_parser_test.rb',
+      'src/test/test_data_encoding.rb'
     ]
   end
 end

--- a/src/test/test_data_encoding.rb
+++ b/src/test/test_data_encoding.rb
@@ -1,0 +1,23 @@
+# -*- coding: utf-8 -*-
+
+require 'test/unit'
+require 'nkf'
+
+class TestDataEncoding < Test::Unit::TestCase
+  data do
+    data_set = {}
+    pattern = File.join(File.dirname(__FILE__), 'data/*.txt')
+    files = Dir.glob(pattern)
+
+    files.each do |f|
+      data_set[File.basename(f)] = f
+    end
+
+    data_set
+  end
+  def test_encoding(path)
+    str = File.read(path)
+    assert_equal(NKF::UTF8, NKF.guess(str), "文字コードはUTF-8にしてください")
+    assert_false(str.include?("\r"), "改行コードはLFにしてください")
+  end
+end


### PR DESCRIPTION
ただのテキストファイルの文字コードと改行コードをチェックする仕組みがなかったので、PRで寄稿されたテストケースがSJISでCRLFなテキストだったとしてもCIをPassしてしまう。

テストデータの文字コードと改行コードをチェックするテストを作成してこの問題を回避する。