### PR TITLE
メッセージの最大文字数制限を撤廃する

### DIFF
--- a/src/cgiDiceBot.rb
+++ b/src/cgiDiceBot.rb
@@ -14,8 +14,6 @@ class CgiDiceBot
     @rands = nil # テスト以外ではnilで良い。ダイス目操作パラメータ
     @isTest = false
     @bcdice = nil
-
-    $SEND_STR_MAX = 99999 # 最大送信文字数(本来は500byte上限)
   end
 
   attr_reader :isSecret

--- a/src/configBcDice.rb
+++ b/src/configBcDice.rb
@@ -4,9 +4,6 @@ $isDebug = false
 
 $bcDiceVersion = "2.06.01"
 
-# @deprecated IRCボット機能の削除に伴い廃止予定。
-$SEND_STR_MAX = 405; # 最大送信文字数(本来は500byte上限)
-
 $DICE_MAXCNT = 200;              # ダイスが振れる最大個数
 $DICE_MAXNUM = 1000;             # ダイスの最大面数
 $isHandSort = true;              # 手札をソートする必要があるか？

--- a/src/diceBot/BattleTech.rb
+++ b/src/diceBot/BattleTech.rb
@@ -117,13 +117,9 @@ MESSAGETEXT
       resultTexts << hitResult
     end
 
+    resultTexts.push(" ＞ #{hitCount}回命中")
+
     totalResultText = resultTexts.join("\n")
-
-    if  totalResultText.length >= $SEND_STR_MAX
-      totalResultText = "..."
-    end
-
-    totalResultText += "\n ＞ #{hitCount}回命中"
     totalResultText += " 命中箇所：" + getTotalDamage(damages) if hitCount > 0
 
     return totalResultText

--- a/src/diceBot/DoubleCross.rb
+++ b/src/diceBot/DoubleCross.rb
@@ -84,7 +84,7 @@ INFO_MESSAGE_TEXT
         loop_count += 1
       end
 
-      return result_str(value_groups, loop_count)
+      return result_str(value_groups)
     end
 
     private
@@ -99,9 +99,8 @@ INFO_MESSAGE_TEXT
 
     # 判定結果の文字列を返す
     # @param [Array<ValueGroup>] value_groups 出目のグループの配列
-    # @param [Integer] loop_count 回転数
     # @return [String]
-    def result_str(value_groups, loop_count)
+    def result_str(value_groups)
       fumble = value_groups[0].values.all? { |value| value == 1 }
       # TODO: Ruby 2.4以降では Array#sum が使える
       sum = value_groups.map(&:max).reduce(0, &:+)

--- a/src/diceBot/DoubleCross.rb
+++ b/src/diceBot/DoubleCross.rb
@@ -107,41 +107,9 @@ INFO_MESSAGE_TEXT
       sum = value_groups.map(&:max).reduce(0, &:+)
       achieved_value = fumble ? 0 : (sum + @modifier)
 
-      long_str = result_str_long(value_groups, achieved_value, fumble)
-
-      if long_str.length > $SEND_STR_MAX
-        return result_str_short(loop_count, achieved_value, fumble)
-      end
-
-      return long_str
-    end
-
-    # ダイスロール結果の長い文字列表記を返す
-    # @param [Array<ValueGroup>] value_groups 出目のグループの配列
-    # @param [Integer] achieved_value 達成値
-    # @param [Boolean] fumble ファンブルしたか
-    # @return [String]
-    def result_str_long(value_groups, achieved_value, fumble)
       parts = [
         "(#{@expression})",
         "#{value_groups.join('+')}#{@modifier_str}",
-        achieved_value_with_if_fumble(achieved_value, fumble),
-        compare_result(achieved_value, fumble)
-      ]
-
-      return parts.compact.join(' ＞ ')
-    end
-
-    # ダイスロール結果の短い文字列表記を返す
-    # @param [Integer] loop_count 回転数
-    # @param [Integer] achieved_value 達成値
-    # @param [Boolean] fumble ファンブルしたか
-    # @return [String]
-    def result_str_short(loop_count, achieved_value, fumble)
-      parts = [
-        "(#{@expression})",
-        '...',
-        "回転数#{loop_count}",
         achieved_value_with_if_fumble(achieved_value, fumble),
         compare_result(achieved_value, fumble)
       ]

--- a/src/diceBot/RecordOfSteam.rb
+++ b/src/diceBot/RecordOfSteam.rb
@@ -51,10 +51,6 @@ MESSAGETEXT
 
     output = "(#{command}) ＞ #{rollResult}"
 
-    if output.length > $SEND_STR_MAX
-      output = "(#{command}) ＞ ..."
-    end
-
     roundCountText = getRoundCountText(roundCount)
     successText = getSuccessText(successCount)
     specialText = getSpecialText(specialCount)

--- a/src/diceBot/SwordWorld.rb
+++ b/src/diceBot/SwordWorld.rb
@@ -175,9 +175,8 @@ class SwordWorld < DiceBot
       break unless dice >= crit
     end
 
-    limitLength = $SEND_STR_MAX - output.length
     output += getResultText(totalValue, addValue, diceResults, diceResultTotals,
-                            rateResults, diceOnlyTotal, round, limitLength, half)
+                            rateResults, diceOnlyTotal, round, half)
 
     return output
   end
@@ -414,12 +413,10 @@ class SwordWorld < DiceBot
   # @param rateResults  [Array<String>]
   # @param dice_total [Integer]
   # @param round [Integer]
-  # @param limitLength [Integer]
   # @param half [Boolean]
   def getResultText(rating_total, modifier, diceResults, diceResultTotals,
-                    rateResults, dice_total, round, limitLength, half)
+                    rateResults, dice_total, round, half)
     sequence = []
-    short = ["..."]
 
     sequence.push("2D:[#{diceResults.join(' ')}]=#{diceResultTotals.join(',')}")
 
@@ -443,7 +440,6 @@ class SwordWorld < DiceBot
     if round > 1
       round_text = "#{round - 1}回転"
       sequence.push(round_text)
-      short.push(round_text)
     end
 
     total = rating_total + modifier
@@ -453,14 +449,8 @@ class SwordWorld < DiceBot
 
     total_text = total.to_s
     sequence.push(total_text)
-    short.push(total_text)
 
-    ret = sequence.join(" ＞ ")
-    if ret.length > limitLength
-      short.join(" ＞ ")
-    else
-      ret
-    end
+    return sequence.join(" ＞ ")
   end
 
   def setRatingTable(tnick)


### PR DESCRIPTION
Fixes #225 

IRCボット機能の削除により不要になった、メッセージの最大文字数制限の設定項目（`$SEND_STR_MAX`）を削除します。また、この設定を参照する、各ダイスボットのメッセージ短縮処理も削除します。