### PR TITLE
BeastBindTrinityのリファクタリング

### DIFF
--- a/src/diceBot/BeastBindTrinity.rb
+++ b/src/diceBot/BeastBindTrinity.rb
@@ -1,6 +1,9 @@
 # -*- coding: utf-8 -*-
 # frozen_string_literal: true
 
+require 'utils/ArithmeticEvaluator'
+require 'utils/format'
+require 'utils/normalize'
 require 'utils/table'
 require 'utils/d66_grid_table'
 
@@ -63,225 +66,181 @@ INFO_MESSAGE_TEXT
     @d66Type = 2
   end
 
-  def changeText(string)
-    string = string.gsub(/(\d+)BB6/i) { "#{Regexp.last_match(1)}R6" }
-    string = string.gsub(/(\d+)BB/i)  { "#{Regexp.last_match(1)}R6" }
-    string = string.gsub(/\%([\-\d]+)/i) { "[H:#{Regexp.last_match(1)}]" }
-    string = string.gsub(/\@([\+\-\d]+)/i) { "[C#{Regexp.last_match(1)}]" }
-    string = string.gsub(/\#([A]?[\+\-\d]+)/i) { "[F#{Regexp.last_match(1)}]" }
-    string = string.gsub(/\$([1-6]+)/i) { "[S#{Regexp.last_match(1)}]" }
-    string = string.gsub(/\&(\d)/i) { "[U#{Regexp.last_match(1)}]" }
-    return string
-  end
-
-  def dice_command_xRn(string, nick_e)
-    @nick_e = nick_e
-    return bbt_check(string)
-  end
-
-  ####################           ビーストバインド トリニティ         ########################
-
-  def bbt_check(string)
-    output = "1"
-
-    debug("bbt string", string)
-    unless (m = /(^|\s)S?((\d+)R6([\+\-\d]*)(\[H:([\-\d]+)\])?(\[C([\+\-\d]+)\])?(\[F(A)?([\+\-\d]+)\])?(\[S([1-6]+)\])?(\[U([1-6])\])?(([>=]+)(\d+))?)(\s|$)/i.match(string))
-      debug("not mutch")
-      return output
+  class BBCommand
+    def initialize(command)
+      @command = command
+      parse()
     end
 
-    # 各種値の初期設定
-    humanity = 99          # 人間性（ゲームプレイ中の上限は60）
-    critical = 12          # クリティカル値（基本値=12）
-    fumble   =  2          # ファンブル値（基本値=2）
-    dicesubs = []          # 出目を固定して振る場合の出目予約
-    nofumble = false        # ファンブルしても達成値が0にならないモードかどうかの判別
-    dicepull = false        # 「出目●未満のダイス」を出目●として扱うモードが有効かどうかの判別
-    pul_flg  = false        # 出目引き上げ機能が適用されたかどうかの確認
+    def roll(bot)
+      if @parse_error
+        return nil
+      end
 
-    # 各種文字列の取得
-    string    = m[2] # ダイスボットで読み込んだ判定文全体
-    dice_c    = m[3].to_i # 振るダイス数の取得
-    bonus     = 0 # 修正値の取得
-    signOfInequality = ""	# 判定結果のための不等号
-    diff      = 0 # 難易度
-    bonusText = m[4] # 修正値の取得
-    bonus     = parren_killer("(0" + bonusText + ")").to_i unless bonusText.nil?
+      @bot = bot
 
-    if m[5]
-      humanity = m[6].to_i if m[6] # 人間性からクリティカル値を取得
-      debug("▼現在人間性 取得 #{humanity}")
+      dice_list_org = roll_with_dice_pool()
+      if dice_list_org.empty?
+        return "ERROR:振るダイスの数が0個です"
+      end
+
+      dice_list_filtered = dice_list_org.map { |dice| [dice, @dice_value_lower_limit].max }.sort
+      @dice_total = dice_list_filtered.inject(0, :+)
+
+      total = calc_total()
+
+      dice_list_org_str = "[#{dice_list_org.join(',')}]" if dice_list_filtered != dice_list_org
+
+      sequence = [
+        command_expr(),
+        dice_list_org_str,
+        interim_expr(dice_list_filtered),
+        dice_status(),
+        total.to_s,
+        result_compare(total)
+      ].compact
+
+      return sequence.join(" ＞ ")
+    end
+
+    private
+
+    def parse()
+      m = /^(\d+)(?:R6|BB6?)((?:[\+\-]\d+)+)?(?:%(\-?\d+))?(?:@([\+\-\d]+))?(?:#(A)?([\+\-\d]+))?(?:\$([1-6]+))?(?:&([1-6]))?(?:([>=]+)(\d+))?$/.match(@command)
+      unless m
+        @parse_error = true
+        return
+      end
+
+      @dice_num = m[1].to_i
+      @modify_number = m[2] ? ArithmeticEvaluator.new.eval(m[2]) : 0
+
+      @critical = parse_critical(m[3], m[4])
+
+      @keep_value_on_fumble = !m[5].nil?
+
+      @fumble = parse_fumble(m[6])
+
+      @dice_pool = m[7] ? m[7].split("").map(&:to_i) : []
+      @dice_pool.pop(@dice_pool.size - @dice_num) if @dice_pool.size > @dice_num
+
+      @dice_value_lower_limit = m[8].to_i
+
+      @cmp_op = Normalize.comparison_operator(m[9])
+      @target_number = m[10] && m[10].to_i
+
+      @parse_error = false
+    end
+
+    # @param humanity [String, nil]
+    # @param atmark [String, nil]
+    # @return [Integer]
+    def parse_critical(humanity, atmark)
+      humanity = humanity ? humanity.to_i : 99
+      atmark_value = atmark ? ArithmeticEvaluator.new.eval(atmark) : 0
+
+      critical =
+        if /^[+-]/.match(atmark)
+          [critical_from_humanity(humanity) + atmark_value, 12].min
+        elsif atmark
+          atmark_value
+        else
+          critical_from_humanity(humanity)
+        end
+
+      return critical
+    end
+
+    def critical_from_humanity(humanity)
       if humanity <= 0
-        critical = 9
-        debug("▼現在人間性からC値取得 #{critical}")
+        9
       elsif humanity <= 20
-        critical = 10
-        debug("▼現在人間性からC値取得 #{critical}")
+        10
       elsif humanity <= 40
-        critical = 11
-        debug("▼現在人間性からC値取得 #{critical}")
-      end
-    end
-
-    if m[7]
-      str_critical = m[8] if m[8] # クリティカル値の文字列を取得
-      debug("▼C値文字列 取得 #{str_critical}")
-    end
-
-    if m[9]
-      nofumble = true if m[10] # ファンブル耐性指定
-      debug("▼F値耐性 #{nofumble}")
-      str_fumble = m[11] if m[11]    # ファンブル値の文字列を取得
-      debug("▼F値文字列 取得 #{str_fumble}")
-    end
-
-    if m[12]
-      str_dicesubs = m[13] if m[13]  # ダイス差し替え用の文字列を取得
-      debug("▼出目予約用の文字列 取得 #{str_dicesubs}")
-    end
-
-    if m[14]
-      dicepull = m[15].to_i if m[15] # ダイス引き上げ用の文字列を取得
-      debug("▼出目引き上げモード 取得 #{dicepull}")
-    end
-
-    signOfInequality = m[17] if m[17]
-    diff = m[18].to_i if m[18]
-
-    # 数値・数式からクリティカル値を決定
-    if str_critical
-      n_cri = 0
-      str_critical.scan(/[\+\-]?\d+/).each do |num|
-        n_cri += num.to_i
-      end
-      debug("▼C値指定符 算出 #{n_cri}")
-      critical = str_critical.match(/^[\+\-][\+\-\d]+/) ? [critical + n_cri, 12].min : n_cri
-      debug("▼クリティカル値 #{critical}")
-    end
-
-    # 数値・数式からファンブル値を決定
-    if str_fumble
-      n_fum = 0
-      str_fumble.scan(/[\+\-]?\d+/).each do |num|
-        n_fum += num.to_i
-      end
-      debug("▼F値指定符 算出 #{n_fum}")
-      fumble = str_fumble.match(/^[\+\-][\+\-\d]+/) ? fumble + n_fum : n_fum
-      debug("▼ファンブル値 #{fumble}")
-    end
-
-    # 出目予約の有無を確認
-    if str_dicesubs
-      str_dicesubs.split(//).each { |i| dicesubs.push(i.to_i) if dicesubs.size < dice_c }
-      debug("▼ダイス出目予約 #{dicesubs}")
-    end
-
-    dice_now = 0
-    dice_str = ""
-    total_n = 0
-
-    cri_flg   = false
-    cri_bonus = 0
-    fum_flg   = false
-
-    dice_tc = dice_c - dicesubs.size
-
-    if dice_tc > 0
-      _, dice_str, = roll(dice_tc, 6, (sortType & 1)) # ダイス数修正、並べ替えせずに出力
-      dice_num = (dice_str.split(/,/) + dicesubs).collect { |n| n.to_i }	# 差し換え指定のダイスを挿入
-    elsif dicesubs.empty?
-      return "ERROR:振るダイスの数が0個です"
-    else
-      dice_num = dicesubs # 差し換えのみの場合は差し換え指定のみ（ダイスを振らない）
-    end
-
-    dice_num.sort! # 並べ替え
-
-    if dicepull # 出目引き上げ機能
-      debug("▼出目引き上げ #{dicepull}")
-      dice_num_old = dice_num.dup
-      (0...dice_num.size).each { |i| dice_num[i] = [dice_num[i], dicepull].max }
-      pul_flg = dice_num != dice_num_old
-      debug("▼出目引き上げの有無について #{pul_flg}")
-
-      dice_num.sort! # 置換後、再度並べ替え
-      dold_str = dice_num_old.join(",")	# 置換前のダイス一覧を作成
-    end
-
-    dice_str = dice_num.join(",")	# dice_strの取得
-    if dice_c == 1
-      dice_now = dice_num[dice_c - 1] # ダイス数が1の場合、通常の処理だと配列の引数が「0」と「-1」となって二重に計算されるので処理を変更
-    else
-      dice_now = dice_num[dice_c - 2] + dice_num[dice_c - 1] # 判定の出目を確定
-    end
-
-    if dice_now >= critical # クリティカル成立の判定
-      cri_flg = true
-      cri_bonus = 20
-    end
-
-    total_n = [dice_now + bonus + cri_bonus, 0].max # 達成値の最小値は0
-
-    if fumble >= dice_now # ファンブル成立の判定
-      fum_flg = true
-      total_n = 0 unless nofumble
-    end
-
-    dice_str = "[#{dice_str}]"
-
-    # 表示文章の作成
-    output = ""
-
-    if pul_flg
-      output += "[#{dold_str}] ＞ "
-    end
-
-    output += "#{dice_now}#{dice_str}"
-
-    if fum_flg == true && nofumble == false
-      output += "【ファンブル】"
-    else
-      output += "【ファンブル】" if fum_flg
-      if bonus > 0
-        output += "+#{bonus}"
-      elsif bonus < 0
-        output += bonus.to_s
-      end
-      output += "+#{cri_bonus}【クリティカル】" if cri_flg
-    end
-
-    showstring = "#{dice_c}R6"	# 結果出力文におけるダイスロール式の作成
-    if bonus > 0 # （結果出力の時に必ずC値・F値を表示するようにする）
-      showstring += "+#{bonus}"
-    elsif bonus < 0
-      showstring += bonus.to_s
-    end
-    showstring += "[C#{critical},F#{fumble}]"
-    if signOfInequality != ""
-      showstring += "#{signOfInequality}#{diff}"
-    end
-
-    if sendMode > 0 # 出力文の完成
-      if /[^\d\[\]]+/ =~ output
-        output = "#{@nick_e}: (#{showstring}) ＞ #{output} ＞ #{total_n}"
+        11
       else
-        output = "#{@nick_e}: (#{showstring}) ＞ #{total_n}"
+        12
       end
-    else
-      output = "#{@nick_e}: (#{showstring}) ＞ #{total_n}"
     end
 
-    if signOfInequality != "" # 成功度判定処理
-      cmp_op = Normalize.comparison_operator(signOfInequality)
-      dice_list = dice_num
-      output += check_result(total_n, dice_now, dice_list, 6, cmp_op, diff)
+    # @param sharp [String, nil]
+    # @return [Integer]
+    def parse_fumble(sharp)
+      sharp_value = sharp ? ArithmeticEvaluator.new.eval(sharp) : 0
+
+      if /^[+-]/.match(sharp)
+        2 + sharp_value
+      elsif sharp
+        sharp_value
+      else
+        2
+      end
     end
 
-    return output
+    def roll_with_dice_pool
+      dice_times = @dice_num - @dice_pool.size
+      dice_list = Array.new(dice_times) { @bot.roll(1, 6)[0] } + @dice_pool
+
+      return dice_list.sort
+    end
+
+    def command_expr
+      modifier = Format.modifier(@modify_number)
+      "(#{@dice_num}BB#{modifier}@#{@critical}\##{@fumble}#{@cmp_op}#{@target_number})"
+    end
+
+    def interim_expr(dice_list)
+      expr = "#{@dice_total}[#{dice_list.join(',')}]#{Format.modifier(@modify_number)}"
+      expr += "+20" if critical?
+
+      return expr
+    end
+
+    def dice_status
+      if fumble?
+        "ファンブル"
+      elsif critical?
+        "クリティカル"
+      end
+    end
+
+    def fumble?
+      @dice_total <= @fumble
+    end
+
+    def critical?
+      @dice_total >= @critical
+    end
+
+    def calc_total
+      total = @dice_total + @modify_number
+      if fumble?
+        total = 0 unless @keep_value_on_fumble
+      elsif critical?
+        total += 20
+      end
+
+      if total < 0
+        total = 0
+      end
+
+      return total
+    end
+
+    def result_compare(total)
+      if @cmp_op
+        total.send(@cmp_op, @target_number) ? "成功" : "失敗"
+      end
+    end
   end
 
   def rollDiceCommand(command)
-    roll_tables(command, TABLES)
+    if (ret = roll_tables(command, TABLES))
+      return ret
+    end
+
+    bb = BBCommand.new(command)
+    return bb.roll(self)
   end
 
   TABLES = {
@@ -382,5 +341,5 @@ INFO_MESSAGE_TEXT
     ),
   }.freeze
 
-  setPrefixes(['\d+BB'] + TABLES.keys)
+  setPrefixes(['\d+BB.*', '\d+R6.*'] + TABLES.keys)
 end

--- a/src/test/data/BeastBindTrinity.txt
+++ b/src/test/data/BeastBindTrinity.txt
@@ -1,133 +1,133 @@
 input:
 2BB+5
 output:
-BeastBindTrinity : (2R6+5[C12,F2]) ＞ 11[5,6]+5 ＞ 16
+BeastBindTrinity : (2BB+5@12#2) ＞ 11[5,6]+5 ＞ 16
 rand:6/6,5/6
 ============================
 input:
 2BB+5>=16
 output:
-BeastBindTrinity : (2R6+5[C12,F2]>=16) ＞ 11[5,6]+5 ＞ 16 ＞ 成功
+BeastBindTrinity : (2BB+5@12#2>=16) ＞ 11[5,6]+5 ＞ 16 ＞ 成功
 rand:5/6,6/6
 ============================
 input:
 2BB+5>=17
 output:
-BeastBindTrinity : (2R6+5[C12,F2]>=17) ＞ 11[5,6]+5 ＞ 16 ＞ 失敗
+BeastBindTrinity : (2BB+5@12#2>=17) ＞ 11[5,6]+5 ＞ 16 ＞ 失敗
 rand:5/6,6/6
 ============================
 input:
 2BB+5@11#5
 output:
-BeastBindTrinity : (2R6+5[C11,F5]) ＞ 11[5,6]+5+20【クリティカル】 ＞ 36
+BeastBindTrinity : (2BB+5@11#5) ＞ 11[5,6]+5+20 ＞ クリティカル ＞ 36
 rand:5/6,6/6
 ============================
 input:
 2BB+5@11#5>=36
 output:
-BeastBindTrinity : (2R6+5[C11,F5]>=36) ＞ 11[5,6]+5+20【クリティカル】 ＞ 36 ＞ 成功
+BeastBindTrinity : (2BB+5@11#5>=36) ＞ 11[5,6]+5+20 ＞ クリティカル ＞ 36 ＞ 成功
 rand:5/6,6/6
 ============================
 input:
 2BB+5@11#5>=37
 output:
-BeastBindTrinity : (2R6+5[C11,F5]>=37) ＞ 11[5,6]+5+20【クリティカル】 ＞ 36 ＞ 失敗
+BeastBindTrinity : (2BB+5@11#5>=37) ＞ 11[5,6]+5+20 ＞ クリティカル ＞ 36 ＞ 失敗
 rand:5/6,6/6
 ============================
 input:
 2BB+5@11#6
 output:
-BeastBindTrinity : (2R6+5[C11,F6]) ＞ 6[1,5]【ファンブル】 ＞ 0
+BeastBindTrinity : (2BB+5@11#6) ＞ 6[1,5]+5 ＞ ファンブル ＞ 0
 rand:5/6,1/6
 ============================
 input:
 2BB+5@11#6>=1
 output:
-BeastBindTrinity : (2R6+5[C11,F6]>=1) ＞ 6[1,5]【ファンブル】 ＞ 0 ＞ 失敗
+BeastBindTrinity : (2BB+5@11#6>=1) ＞ 6[1,5]+5 ＞ ファンブル ＞ 0 ＞ 失敗
 rand:5/6,1/6
 ============================
 input:
 2BB+5%41
 output:
-BeastBindTrinity : (2R6+5[C12,F2]) ＞ 6[1,5]+5 ＞ 11
+BeastBindTrinity : (2BB+5@12#2) ＞ 6[1,5]+5 ＞ 11
 rand:5/6,1/6
 ============================
 input:
 2BB+5%41>=30
 output:
-BeastBindTrinity : (2R6+5[C12,F2]>=30) ＞ 11[5,6]+5 ＞ 16 ＞ 失敗
+BeastBindTrinity : (2BB+5@12#2>=30) ＞ 11[5,6]+5 ＞ 16 ＞ 失敗
 rand:5/6,6/6
 ============================
 input:
 2BB+5%41>=30
 output:
-BeastBindTrinity : (2R6+5[C12,F2]>=30) ＞ 12[6,6]+5+20【クリティカル】 ＞ 37 ＞ 成功
+BeastBindTrinity : (2BB+5@12#2>=30) ＞ 12[6,6]+5+20 ＞ クリティカル ＞ 37 ＞ 成功
 rand:6/6,6/6
 ============================
 input:
 2BB+5%21>=30
 output:
-BeastBindTrinity : (2R6+5[C11,F2]>=30) ＞ 12[6,6]+5+20【クリティカル】 ＞ 37 ＞ 成功
+BeastBindTrinity : (2BB+5@11#2>=30) ＞ 12[6,6]+5+20 ＞ クリティカル ＞ 37 ＞ 成功
 rand:6/6,6/6
 ============================
 input:
 2BB+5%21>=30
 output:
-BeastBindTrinity : (2R6+5[C11,F2]>=30) ＞ 11[5,6]+5+20【クリティカル】 ＞ 36 ＞ 成功
+BeastBindTrinity : (2BB+5@11#2>=30) ＞ 11[5,6]+5+20 ＞ クリティカル ＞ 36 ＞ 成功
 rand:5/6,6/6
 ============================
 input:
 2BB+5%21>=30
 output:
-BeastBindTrinity : (2R6+5[C11,F2]>=30) ＞ 10[4,6]+5 ＞ 15 ＞ 失敗
+BeastBindTrinity : (2BB+5@11#2>=30) ＞ 10[4,6]+5 ＞ 15 ＞ 失敗
 rand:4/6,6/6
 ============================
 input:
 2BB+5%1>=30
 output:
-BeastBindTrinity : (2R6+5[C10,F2]>=30) ＞ 11[5,6]+5+20【クリティカル】 ＞ 36 ＞ 成功
+BeastBindTrinity : (2BB+5@10#2>=30) ＞ 11[5,6]+5+20 ＞ クリティカル ＞ 36 ＞ 成功
 rand:5/6,6/6
 ============================
 input:
 2BB+5%1>=30
 output:
-BeastBindTrinity : (2R6+5[C10,F2]>=30) ＞ 10[4,6]+5+20【クリティカル】 ＞ 35 ＞ 成功
+BeastBindTrinity : (2BB+5@10#2>=30) ＞ 10[4,6]+5+20 ＞ クリティカル ＞ 35 ＞ 成功
 rand:4/6,6/6
 ============================
 input:
 2BB+5%1>=30
 output:
-BeastBindTrinity : (2R6+5[C10,F2]>=30) ＞ 9[4,5]+5 ＞ 14 ＞ 失敗
+BeastBindTrinity : (2BB+5@10#2>=30) ＞ 9[4,5]+5 ＞ 14 ＞ 失敗
 rand:4/6,5/6
 ============================
 input:
 2BB+5%-1>=30
 output:
-BeastBindTrinity : (2R6+5[C9,F2]>=30) ＞ 10[4,6]+5+20【クリティカル】 ＞ 35 ＞ 成功
+BeastBindTrinity : (2BB+5@9#2>=30) ＞ 10[4,6]+5+20 ＞ クリティカル ＞ 35 ＞ 成功
 rand:4/6,6/6
 ============================
 input:
 2BB+5%-1>=30
 output:
-BeastBindTrinity : (2R6+5[C9,F2]>=30) ＞ 9[4,5]+5+20【クリティカル】 ＞ 34 ＞ 成功
+BeastBindTrinity : (2BB+5@9#2>=30) ＞ 9[4,5]+5+20 ＞ クリティカル ＞ 34 ＞ 成功
 rand:4/6,5/6
 ============================
 input:
 2BB+5%1@9>=30
 output:
-BeastBindTrinity : (2R6+5[C9,F2]>=30) ＞ 9[4,5]+5+20【クリティカル】 ＞ 34 ＞ 成功
+BeastBindTrinity : (2BB+5@9#2>=30) ＞ 9[4,5]+5+20 ＞ クリティカル ＞ 34 ＞ 成功
 rand:4/6,5/6
 ============================
 input:
 2BB+5%12$56
 output:
-BeastBindTrinity : (2R6+5[C10,F2]) ＞ 11[5,6]+5+20【クリティカル】 ＞ 36
+BeastBindTrinity : (2BB+5@10#2) ＞ 11[5,6]+5+20 ＞ クリティカル ＞ 36
 rand:
 ============================
 input:
 2BB+5$2
 output:
-BeastBindTrinity : (2R6+5[C12,F2]) ＞ 7[2,5]+5 ＞ 12
+BeastBindTrinity : (2BB+5@12#2) ＞ 7[2,5]+5 ＞ 12
 rand:5/6
 ============================
 input:
@@ -139,80 +139,92 @@ rand:1/6,1/6
 input:
 2BB+5@-1
 output:
-BeastBindTrinity : (2R6+5[C11,F2]) ＞ 10[4,6]+5 ＞ 15
+BeastBindTrinity : (2BB+5@11#2) ＞ 10[4,6]+5 ＞ 15
 rand:4/6,6/6
 ============================
 input:
 2BB+5%20@-1
 output:
-BeastBindTrinity : (2R6+5[C9,F2]) ＞ 10[4,6]+5+20【クリティカル】 ＞ 35
+BeastBindTrinity : (2BB+5@9#2) ＞ 10[4,6]+5+20 ＞ クリティカル ＞ 35
 rand:4/6,6/6
 ============================
 input:
 2BB+5%20@-1>=30
 output:
-BeastBindTrinity : (2R6+5[C9,F2]>=30) ＞ 10[4,6]+5+20【クリティカル】 ＞ 35 ＞ 成功
+BeastBindTrinity : (2BB+5@9#2>=30) ＞ 10[4,6]+5+20 ＞ クリティカル ＞ 35 ＞ 成功
 rand:4/6,6/6
 ============================
 input:
 2BB+5@-1-2
 output:
-BeastBindTrinity : (2R6+5[C9,F2]) ＞ 10[4,6]+5+20【クリティカル】 ＞ 35
+BeastBindTrinity : (2BB+5@9#2) ＞ 10[4,6]+5+20 ＞ クリティカル ＞ 35
 rand:4/6,6/6
 ============================
 input:
 2BB+5%-5@+2#+2
 output:
-BeastBindTrinity : (2R6+5[C11,F4]) ＞ 10[4,6]+5 ＞ 15
+BeastBindTrinity : (2BB+5@11#4) ＞ 10[4,6]+5 ＞ 15
 rand:4/6,6/6
 ============================
 input:
 2BB+5#A6
 output:
-BeastBindTrinity : (2R6+5[C12,F6]) ＞ 6[1,5]【ファンブル】+5 ＞ 11
+BeastBindTrinity : (2BB+5@12#6) ＞ 6[1,5]+5 ＞ ファンブル ＞ 11
 rand:5/6,1/6
 ============================
 input:
 2BB+5#A+6
 output:
-BeastBindTrinity : (2R6+5[C12,F8]) ＞ 6[1,5]【ファンブル】+5 ＞ 11
+BeastBindTrinity : (2BB+5@12#8) ＞ 6[1,5]+5 ＞ ファンブル ＞ 11
 rand:5/6,1/6
 ============================
 input:
 2BB+5&3
 output:
-BeastBindTrinity : (2R6+5[C12,F2]) ＞ [1,1] ＞ 6[3,3]+5 ＞ 11
+BeastBindTrinity : (2BB+5@12#2) ＞ [1,1] ＞ 6[3,3]+5 ＞ 11
 rand:1/6,1/6
 ============================
 input:
 1BB
 output:
-BeastBindTrinity : (1R6[C12,F2]) ＞ 3
+BeastBindTrinity : (1BB@12#2) ＞ 3[3] ＞ 3
 rand:3/6
 ============================
 input:
 1BB+3
 output:
-BeastBindTrinity : (1R6+3[C12,F2]) ＞ 3[3]+3 ＞ 6
+BeastBindTrinity : (1BB+3@12#2) ＞ 3[3]+3 ＞ 6
 rand:3/6
 ============================
 input:
 1BB&3
 output:
-BeastBindTrinity : (1R6[C12,F2]) ＞ [1] ＞ 3[3] ＞ 3
+BeastBindTrinity : (1BB@12#2) ＞ [1] ＞ 3[3] ＞ 3
 rand:1/6
 ============================
 input:
 2BB+5%20@+3
 output:
-BeastBindTrinity : (2R6+5[C12,F2]) ＞ 11[5,6]+5 ＞ 16
+BeastBindTrinity : (2BB+5@12#2) ＞ 11[5,6]+5 ＞ 16
 rand:5/6,6/6
 ============================
 input:
 2BB+5%20@13
 output:
-BeastBindTrinity : (2R6+5[C13,F2]) ＞ 12[6,6]+5 ＞ 17
+BeastBindTrinity : (2BB+5@13#2) ＞ 12[6,6]+5 ＞ 17
 rand:6/6,6/6
+============================
+input:
+2BB6+5@11#5
+output:
+BeastBindTrinity : (2BB+5@11#5) ＞ 11[5,6]+5+20 ＞ クリティカル ＞ 36
+rand:5/6,6/6
+============================
+input:
+2R6+5@11#5
+output:
+BeastBindTrinity : (2BB+5@11#5) ＞ 11[5,6]+5+20 ＞ クリティカル ＞ 36
+rand:5/6,6/6
 ============================
 input:
 EXPO_A


### PR DESCRIPTION
- 表類のクラスを使う
- 判定コマンドの処理をクラスに切り出す

## 判定コマンドの仕様

![image](https://user-images.githubusercontent.com/4254002/91433364-23b89e80-e89e-11ea-8b8f-688165bf8e81.png)
[Regexperによる可視化](https://regexper.com/#%2F%5E%28%5Cd%2B%29%28%3F%3AR6%7CBB6%3F%29%28%28%3F%3A%5B%5C%2B%5C-%5D%5Cd%2B%29%2B%29%3F%28%3F%3A%25%28%5C-%3F%5Cd%2B%29%29%3F%28%3F%3A%40%28%5B%5C%2B%5C-%5Cd%5D%2B%29%29%3F%28%3F%3A%23%28A%29%3F%28%5B%5C%2B%5C-%5Cd%5D%2B%29%29%3F%28%3F%3A%5C%24%28%5B1-6%5D%2B%29%29%3F%28%3F%3A%26%28%5B1-6%5D%29%29%3F%28%3F%3A%28%5B%3E%3D%5D%2B%29%28%5Cd%2B%29%29%3F%24%2F)

### 各prefixの意味
- `%<number>`: humanityの指定。この値によってクリティカル値のベースが変更される
- `@<number>`: 
  - 符号ありの場合: クリティカル値のベース + `<number>` をクリティカル値とする
  - 符号なしの場合: `<number>` をクリティカル値とする
- `#A<number>`:
  - ファンブル値を `<number> `にする
    - 符号の有無による挙動はファンブルと同様
  - `A` がつく場合:  ファンブルした場に達成値を維持する
  - `A` がない場合: ファンブルした時に達成値を0にする
- `$<number 1><number 2>...`: 事前にダイス目を指定する
- `&<number>`: `<number>` 未満のダイス目を `<number>` にする

### 大まかな挙動
- nD6を振り、クリティカル値以上ならクリティカル、ファンブル値以下ならファンブル
  - クリティカルの場合には達成値に+20
  - ファンブルの場合には達成値は0
    - ただし `#A` と指定している場合にはファンブル時の達成値は変動しない

### 変更された挙動
- コマンドの出力で示される式が `nR6` 形式から `nBB` 形式に変更
- `2BB@12`は`2R6[C12]` といった変換されていたが直接パースするように
  - `2R6[C12]` の形式は受け付けないようにした
  - `2R6@12` は受け付ける

### 廃止された挙動
- `nBF` を `nQ6` に変換していたが、`nQ6`のコマンドが存在しないため廃止