### PR TITLE
GURPSのクラス名を修正する

### DIFF
--- a/lib/bcdice/game_system/GURPS.rb
+++ b/lib/bcdice/game_system/GURPS.rb
@@ -2,7 +2,7 @@
 
 module BCDice
   module GameSystem
-    class GURLS < Base
+    class GURPS < Base
       # ゲームシステムの識別子
       ID = 'GURPS'
 


### PR DESCRIPTION
https://github.com/bcdice/BCDice/commit/a105181596be99799c254a122225c8400b78290a#diff-edecff1d1db5953fb49c6a7247df7aabecbf6edfb9faff9799cdd1ca487d3fc3R5 で、GURPSのクラス名が `GURLS` に変わっていたので、修正しました。