### PR TITLE
事前処理によるダイスロールを廃止

### DIFF
--- a/lib/bcdice/base.rb
+++ b/lib/bcdice/base.rb
@@ -164,7 +164,7 @@ module BCDice
     # コマンドを評価する
     # @return [Result, nil] コマンド実行結果。コマンドが実行できなかった場合はnilを返す
     def eval
-      command = BCDice::Preprocessor.process(@raw_input, @randomizer, self)
+      command = BCDice::Preprocessor.process(@raw_input, self)
       upcased_command = command.upcase
 
       result = dice_command(command) || eval_common_command(upcased_command)

--- a/lib/bcdice/preprocessor.rb
+++ b/lib/bcdice/preprocessor.rb
@@ -3,31 +3,26 @@ module BCDice
   #
   # @example
   #   Preprocessor.process(
-  #     "1d6+[2D6]+[40..50]+4D+(3*4) 切り取られる部分",
-  #     randomizer,
+  #     "1d6+4D+(3*4) 切り取られる部分",
   #     game_system
-  #   ) #=> "1d6+3+46+4D6+7"
+  #   ) #=> "1d6+4D6+7"
   class Preprocessor
     # @param (see #initialize)
     # @return [String]
-    def self.process(text, randomizer, game_system)
-      Preprocessor.new(text, randomizer, game_system).process()
+    def self.process(text, game_system)
+      Preprocessor.new(text, game_system).process()
     end
 
     # @param text [String]
-    # @param randomizer [Randomizer]
     # @param game_system [Base]
-    def initialize(text, randomizer, game_system)
+    def initialize(text, game_system)
       @text = text
-      @randomizer = randomizer
       @game_system = game_system
     end
 
     # @return [String]
     def process
       trim_after_whitespace()
-      replace_preroll()
-      replace_range()
       replace_parentheses()
 
       @text = @game_system.change_text(@text)
@@ -42,34 +37,6 @@ module BCDice
     # 空白より前だけを取る
     def trim_after_whitespace()
       @text = @text.strip.split(/\s/, 2).first
-    end
-
-    # [1D6]のような部分を事前ダイスロールする
-    def replace_preroll()
-      @text = @text.gsub(/\[\d+D\d+\]/i) do |matched|
-        # Remove '[' and ']'
-        command = matched[1..-2].upcase
-        times, sides = command.split("D").map(&:to_i)
-
-        @randomizer.roll_sum(times, sides)
-      end
-    end
-
-    # [1...6]のような部分を事前ダイスロールする
-    def replace_range
-      @text = @text.gsub(/\[(\d+)\.\.\.(\d+)\]/) do |matched|
-        first = Regexp.last_match(1).to_i
-        last = Regexp.last_match(2).to_i
-
-        if first > last
-          matched
-        else
-          steps = last - first + 1
-          dice = @randomizer.roll_once(steps)
-
-          first + dice - 1
-        end
-      end
     end
 
     # カッコ書きの数式を事前計算する

--- a/test/data/BarnaKronika.toml
+++ b/test/data/BarnaKronika.toml
@@ -200,10 +200,9 @@ rands = [
 
 [[ test ]]
 game_system = "BarnaKronika"
-input = "[1...10]BK"
+input = "3BK"
 output = "(3R6[0,0]) ＞ [4,5,6] ＞ 失敗"
 rands = [
-  { sides = 10, value = 3 },
   { sides = 6, value = 5 },
   { sides = 6, value = 4 },
   { sides = 6, value = 6 },
@@ -211,10 +210,9 @@ rands = [
 
 [[ test ]]
 game_system = "BarnaKronika"
-input = "[1...10]BK"
+input = "7BK"
 output = "(7R6[0,0]) ＞ [1,1,1,2,3,4,5] ＞ 成功数3,セット1"
 rands = [
-  { sides = 10, value = 7 },
   { sides = 6, value = 3 },
   { sides = 6, value = 1 },
   { sides = 6, value = 4 },
@@ -226,19 +224,17 @@ rands = [
 
 [[ test ]]
 game_system = "BarnaKronika"
-input = "[1...10]BK"
+input = "1BK"
 output = "(1R6[0,0]) ＞ [3] ＞ 失敗"
 rands = [
-  { sides = 10, value = 1 },
   { sides = 6, value = 3 },
 ]
 
 [[ test ]]
 game_system = "BarnaKronika"
-input = "[1...10]BK"
+input = "6BK"
 output = "(6R6[0,0]) ＞ [1,2,5,5,5,6] ＞ 成功数3,セット1"
 rands = [
-  { sides = 10, value = 6 },
   { sides = 6, value = 5 },
   { sides = 6, value = 5 },
   { sides = 6, value = 2 },
@@ -249,10 +245,9 @@ rands = [
 
 [[ test ]]
 game_system = "BarnaKronika"
-input = "[1...10]BK"
+input = "8BK"
 output = "(8R6[0,0]) ＞ [1,1,1,2,4,5,5,6] ＞ 成功数3,セット2"
 rands = [
-  { sides = 10, value = 8 },
   { sides = 6, value = 5 },
   { sides = 6, value = 1 },
   { sides = 6, value = 1 },
@@ -265,10 +260,9 @@ rands = [
 
 [[ test ]]
 game_system = "BarnaKronika"
-input = "[1...10]BK"
+input = "5BK"
 output = "(5R6[0,0]) ＞ [1,1,3,3,6] ＞ 成功数2,セット2"
 rands = [
-  { sides = 10, value = 5 },
   { sides = 6, value = 1 },
   { sides = 6, value = 3 },
   { sides = 6, value = 3 },
@@ -278,10 +272,9 @@ rands = [
 
 [[ test ]]
 game_system = "BarnaKronika"
-input = "[1...10]BK"
+input = "6BK"
 output = "(6R6[0,0]) ＞ [2,3,3,4,4,6] ＞ 成功数2,セット2"
 rands = [
-  { sides = 10, value = 6 },
   { sides = 6, value = 6 },
   { sides = 6, value = 4 },
   { sides = 6, value = 3 },
@@ -292,30 +285,27 @@ rands = [
 
 [[ test ]]
 game_system = "BarnaKronika"
-input = "[1...10]BK"
+input = "2BK"
 output = "(2R6[0,0]) ＞ [3,6] ＞ 失敗"
 rands = [
-  { sides = 10, value = 2 },
   { sides = 6, value = 3 },
   { sides = 6, value = 6 },
 ]
 
 [[ test ]]
 game_system = "BarnaKronika"
-input = "[1...10]BK"
+input = "2BK"
 output = "(2R6[0,0]) ＞ [5,6] ＞ 失敗"
 rands = [
-  { sides = 10, value = 2 },
   { sides = 6, value = 6 },
   { sides = 6, value = 5 },
 ]
 
 [[ test ]]
 game_system = "BarnaKronika"
-input = "[1...10]BK"
+input = "7BK"
 output = "(7R6[0,0]) ＞ [1,1,2,2,4,6,6] ＞ 成功数2,セット3"
 rands = [
-  { sides = 10, value = 7 },
   { sides = 6, value = 6 },
   { sides = 6, value = 6 },
   { sides = 6, value = 2 },
@@ -527,10 +517,9 @@ rands = [
 
 [[ test ]]
 game_system = "BarnaKronika"
-input = "[1...10]BA"
+input = "4BA"
 output = "(4R6[1,0]) ＞ [2,4,5,6] ＞ 失敗"
 rands = [
-  { sides = 10, value = 4 },
   { sides = 6, value = 6 },
   { sides = 6, value = 5 },
   { sides = 6, value = 4 },
@@ -539,10 +528,9 @@ rands = [
 
 [[ test ]]
 game_system = "BarnaKronika"
-input = "[1...10]BA"
+input = "5BA"
 output = "(5R6[1,0]) ＞ [2,2,6,6,6] ＞ 右腕:攻撃値2,胴体:攻撃値3"
 rands = [
-  { sides = 10, value = 5 },
   { sides = 6, value = 2 },
   { sides = 6, value = 6 },
   { sides = 6, value = 6 },
@@ -552,10 +540,9 @@ rands = [
 
 [[ test ]]
 game_system = "BarnaKronika"
-input = "[1...10]BA"
+input = "7BA"
 output = "(7R6[1,0]) ＞ [1,2,3,4,6,6,6] ＞ 胴体:攻撃値3"
 rands = [
-  { sides = 10, value = 7 },
   { sides = 6, value = 2 },
   { sides = 6, value = 6 },
   { sides = 6, value = 3 },
@@ -567,10 +554,9 @@ rands = [
 
 [[ test ]]
 game_system = "BarnaKronika"
-input = "[1...10]BA"
+input = "7BA"
 output = "(7R6[1,0]) ＞ [2,3,3,4,5,6,6] ＞ 左腕:攻撃値2,胴体:攻撃値2"
 rands = [
-  { sides = 10, value = 7 },
   { sides = 6, value = 6 },
   { sides = 6, value = 4 },
   { sides = 6, value = 5 },
@@ -582,19 +568,17 @@ rands = [
 
 [[ test ]]
 game_system = "BarnaKronika"
-input = "[1...10]BA"
+input = "1BA"
 output = "(1R6[1,0]) ＞ [4] ＞ 失敗"
 rands = [
-  { sides = 10, value = 1 },
   { sides = 6, value = 4 },
 ]
 
 [[ test ]]
 game_system = "BarnaKronika"
-input = "[1...10]BA"
+input = "9BA"
 output = "(9R6[1,0]) ＞ [2,2,2,3,3,3,4,4,5] ＞ 右腕:攻撃値3,左腕:攻撃値3,右脚:攻撃値2"
 rands = [
-  { sides = 10, value = 9 },
   { sides = 6, value = 2 },
   { sides = 6, value = 2 },
   { sides = 6, value = 2 },
@@ -608,10 +592,9 @@ rands = [
 
 [[ test ]]
 game_system = "BarnaKronika"
-input = "[1...10]BA"
+input = "3BA"
 output = "(3R6[1,0]) ＞ [1,5,6] ＞ 失敗"
 rands = [
-  { sides = 10, value = 3 },
   { sides = 6, value = 1 },
   { sides = 6, value = 5 },
   { sides = 6, value = 6 },
@@ -619,20 +602,18 @@ rands = [
 
 [[ test ]]
 game_system = "BarnaKronika"
-input = "[1...10]BA"
+input = "2BA"
 output = "(2R6[1,0]) ＞ [2,3] ＞ 失敗"
 rands = [
-  { sides = 10, value = 2 },
   { sides = 6, value = 2 },
   { sides = 6, value = 3 },
 ]
 
 [[ test ]]
 game_system = "BarnaKronika"
-input = "[1...10]BA"
+input = "7BA"
 output = "(7R6[1,0]) ＞ [1,2,4,4,5,5,6] ＞ 右脚:攻撃値2,左脚:攻撃値2"
 rands = [
-  { sides = 10, value = 7 },
   { sides = 6, value = 6 },
   { sides = 6, value = 4 },
   { sides = 6, value = 2 },
@@ -644,10 +625,9 @@ rands = [
 
 [[ test ]]
 game_system = "BarnaKronika"
-input = "[1...10]BA"
+input = "5BA"
 output = "(5R6[1,0]) ＞ [1,1,2,5,5] ＞ 頭部:攻撃値2,左脚:攻撃値2"
 rands = [
-  { sides = 10, value = 5 },
   { sides = 6, value = 1 },
   { sides = 6, value = 5 },
   { sides = 6, value = 2 },
@@ -857,11 +837,9 @@ rands = [
 
 [[ test ]]
 game_system = "BarnaKronika"
-input = "[1...10]BKC[1...5]"
+input = "9BKC4"
 output = "(9R6[0,4]) ＞ [2,4,4,4,4,5,5,6,6] ＞ 成功数8,セット1"
 rands = [
-  { sides = 10, value = 9 },
-  { sides = 5, value = 4 },
   { sides = 6, value = 5 },
   { sides = 6, value = 6 },
   { sides = 6, value = 4 },
@@ -875,11 +853,9 @@ rands = [
 
 [[ test ]]
 game_system = "BarnaKronika"
-input = "[1...10]BKC[1...5]"
+input = "9BKC1"
 output = "(9R6[0,1]) ＞ [1,1,2,2,2,3,3,4,6] ＞ 成功数4,セット1"
 rands = [
-  { sides = 10, value = 9 },
-  { sides = 5, value = 1 },
   { sides = 6, value = 2 },
   { sides = 6, value = 2 },
   { sides = 6, value = 2 },
@@ -893,11 +869,9 @@ rands = [
 
 [[ test ]]
 game_system = "BarnaKronika"
-input = "[1...10]BKC[1...5]"
+input = "8BKC4"
 output = "(8R6[0,4]) ＞ [1,2,3,3,4,5,5,6] ＞ 成功数2,セット1"
 rands = [
-  { sides = 10, value = 8 },
-  { sides = 5, value = 4 },
   { sides = 6, value = 3 },
   { sides = 6, value = 5 },
   { sides = 6, value = 6 },
@@ -910,11 +884,9 @@ rands = [
 
 [[ test ]]
 game_system = "BarnaKronika"
-input = "[1...10]BKC[1...5]"
+input = "4BKC2"
 output = "(4R6[0,2]) ＞ [2,3,5,6] ＞ 成功数2,セット1"
 rands = [
-  { sides = 10, value = 4 },
-  { sides = 5, value = 2 },
   { sides = 6, value = 6 },
   { sides = 6, value = 3 },
   { sides = 6, value = 2 },
@@ -923,11 +895,9 @@ rands = [
 
 [[ test ]]
 game_system = "BarnaKronika"
-input = "[1...10]BKC[1...5]"
+input = "4BKC4"
 output = "(4R6[0,4]) ＞ [1,4,4,6] ＞ 成功数4,セット1"
 rands = [
-  { sides = 10, value = 4 },
-  { sides = 5, value = 4 },
   { sides = 6, value = 4 },
   { sides = 6, value = 6 },
   { sides = 6, value = 4 },
@@ -936,11 +906,9 @@ rands = [
 
 [[ test ]]
 game_system = "BarnaKronika"
-input = "[1...10]BKC[1...5]"
+input = "3BKC2"
 output = "(3R6[0,2]) ＞ [3,5,6] ＞ 失敗"
 rands = [
-  { sides = 10, value = 3 },
-  { sides = 5, value = 2 },
   { sides = 6, value = 6 },
   { sides = 6, value = 3 },
   { sides = 6, value = 5 },
@@ -948,11 +916,9 @@ rands = [
 
 [[ test ]]
 game_system = "BarnaKronika"
-input = "[1...10]BKC[1...5]"
+input = "10BKC2"
 output = "(10R6[0,2]) ＞ [1,2,3,3,4,4,5,5,6,6] ＞ 成功数2,セット1"
 rands = [
-  { sides = 10, value = 10 },
-  { sides = 5, value = 2 },
   { sides = 6, value = 1 },
   { sides = 6, value = 3 },
   { sides = 6, value = 6 },
@@ -967,22 +933,18 @@ rands = [
 
 [[ test ]]
 game_system = "BarnaKronika"
-input = "[1...10]BKC[1...5]"
+input = "2BKC2"
 output = "(2R6[0,2]) ＞ [1,5] ＞ 失敗"
 rands = [
-  { sides = 10, value = 2 },
-  { sides = 5, value = 2 },
   { sides = 6, value = 1 },
   { sides = 6, value = 5 },
 ]
 
 [[ test ]]
 game_system = "BarnaKronika"
-input = "[1...10]BKC[1...5]"
+input = "10BKC1"
 output = "(10R6[0,1]) ＞ [1,2,3,3,4,4,4,5,6,6] ＞ 成功数2,セット1"
 rands = [
-  { sides = 10, value = 10 },
-  { sides = 5, value = 1 },
   { sides = 6, value = 6 },
   { sides = 6, value = 5 },
   { sides = 6, value = 3 },
@@ -997,11 +959,9 @@ rands = [
 
 [[ test ]]
 game_system = "BarnaKronika"
-input = "[1...10]BKC[1...5]"
+input = "10BKC5"
 output = "(10R6[0,5]) ＞ [1,1,2,2,3,3,4,5,6,6] ＞ 成功数2,セット1"
 rands = [
-  { sides = 10, value = 10 },
-  { sides = 5, value = 5 },
   { sides = 6, value = 3 },
   { sides = 6, value = 6 },
   { sides = 6, value = 1 },
@@ -1216,32 +1176,26 @@ rands = [
 
 [[ test ]]
 game_system = "BarnaKronika"
-input = "[1...10]BAC[1...5]"
+input = "2BAC2"
 output = "(2R6[1,2]) ＞ [1,4] ＞ 失敗"
 rands = [
-  { sides = 10, value = 2 },
-  { sides = 5, value = 2 },
   { sides = 6, value = 4 },
   { sides = 6, value = 1 },
 ]
 
 [[ test ]]
 game_system = "BarnaKronika"
-input = "[1...10]BAC[1...5]"
+input = "1BAC2"
 output = "(1R6[1,2]) ＞ [1] ＞ 失敗"
 rands = [
-  { sides = 10, value = 1 },
-  { sides = 5, value = 2 },
   { sides = 6, value = 1 },
 ]
 
 [[ test ]]
 game_system = "BarnaKronika"
-input = "[1...10]BAC[1...5]"
+input = "10BAC3"
 output = "(10R6[1,3]) ＞ [1,2,3,3,4,4,5,5,6,6] ＞ 左腕:攻撃値4"
 rands = [
-  { sides = 10, value = 10 },
-  { sides = 5, value = 3 },
   { sides = 6, value = 5 },
   { sides = 6, value = 3 },
   { sides = 6, value = 2 },
@@ -1256,11 +1210,9 @@ rands = [
 
 [[ test ]]
 game_system = "BarnaKronika"
-input = "[1...10]BAC[1...5]"
+input = "4BAC2"
 output = "(4R6[1,2]) ＞ [2,2,6,6] ＞ 右腕:攻撃値4"
 rands = [
-  { sides = 10, value = 4 },
-  { sides = 5, value = 2 },
   { sides = 6, value = 6 },
   { sides = 6, value = 2 },
   { sides = 6, value = 2 },
@@ -1269,11 +1221,9 @@ rands = [
 
 [[ test ]]
 game_system = "BarnaKronika"
-input = "[1...10]BAC[1...5]"
+input = "5BAC2"
 output = "(5R6[1,2]) ＞ [1,1,1,2,4] ＞ 右腕:攻撃値2"
 rands = [
-  { sides = 10, value = 5 },
-  { sides = 5, value = 2 },
   { sides = 6, value = 1 },
   { sides = 6, value = 2 },
   { sides = 6, value = 1 },
@@ -1283,22 +1233,18 @@ rands = [
 
 [[ test ]]
 game_system = "BarnaKronika"
-input = "[1...10]BAC[1...5]"
+input = "2BAC2"
 output = "(2R6[1,2]) ＞ [4,6] ＞ 失敗"
 rands = [
-  { sides = 10, value = 2 },
-  { sides = 5, value = 2 },
   { sides = 6, value = 4 },
   { sides = 6, value = 6 },
 ]
 
 [[ test ]]
 game_system = "BarnaKronika"
-input = "[1...10]BAC[1...5]"
+input = "4BAC5"
 output = "(4R6[1,5]) ＞ [3,3,4,6] ＞ 失敗"
 rands = [
-  { sides = 10, value = 4 },
-  { sides = 5, value = 5 },
   { sides = 6, value = 4 },
   { sides = 6, value = 3 },
   { sides = 6, value = 6 },
@@ -1307,11 +1253,9 @@ rands = [
 
 [[ test ]]
 game_system = "BarnaKronika"
-input = "[1...10]BAC[1...5]"
+input = "8BAC5"
 output = "(8R6[1,5]) ＞ [1,3,3,3,3,4,5,6] ＞ 左脚:攻撃値2"
 rands = [
-  { sides = 10, value = 8 },
-  { sides = 5, value = 5 },
   { sides = 6, value = 3 },
   { sides = 6, value = 5 },
   { sides = 6, value = 3 },
@@ -1324,11 +1268,9 @@ rands = [
 
 [[ test ]]
 game_system = "BarnaKronika"
-input = "[1...10]BAC[1...5]"
+input = "7BAC2"
 output = "(7R6[1,2]) ＞ [1,3,4,5,5,5,6] ＞ 失敗"
 rands = [
-  { sides = 10, value = 7 },
-  { sides = 5, value = 2 },
   { sides = 6, value = 5 },
   { sides = 6, value = 4 },
   { sides = 6, value = 5 },
@@ -1340,10 +1282,8 @@ rands = [
 
 [[ test ]]
 game_system = "BarnaKronika"
-input = "[1...10]BAC[1...5]"
+input = "1BAC5"
 output = "(1R6[1,5]) ＞ [4] ＞ 失敗"
 rands = [
-  { sides = 10, value = 1 },
-  { sides = 5, value = 5 },
   { sides = 6, value = 4 },
 ]

--- a/test/data/DarkBlaze.toml
+++ b/test/data/DarkBlaze.toml
@@ -973,10 +973,9 @@ rands = [
 
 [[ test ]]
 game_system = "DarkBlaze"
-input = "BT[1...3]"
+input = "BT3"
 output = "掘り出し袋表[4,4] ＞ 《雷撃石》を3個獲得"
 rands = [
-  { sides = 3, value = 3 },
   { sides = 6, value = 3 },
   { sides = 6, value = 1 },
   { sides = 6, value = 2 },
@@ -987,10 +986,9 @@ rands = [
 
 [[ test ]]
 game_system = "DarkBlaze"
-input = "BT[1...3]"
+input = "BT2"
 output = "掘り出し袋表[7,5] ＞ 《金貨》を5枚獲得"
 rands = [
-  { sides = 3, value = 2 },
   { sides = 6, value = 3 },
   { sides = 6, value = 4 },
   { sides = 6, value = 1 },
@@ -999,10 +997,9 @@ rands = [
 
 [[ test ]]
 game_system = "DarkBlaze"
-input = "BT[1...3]"
+input = "BT1"
 output = "掘り出し袋表[9,1] ＞ 《獣皮 I》を1個獲得"
 rands = [
-  { sides = 3, value = 1 },
   { sides = 6, value = 3 },
   { sides = 6, value = 6 },
   { sides = 6, value = 1 },
@@ -1010,10 +1007,9 @@ rands = [
 
 [[ test ]]
 game_system = "DarkBlaze"
-input = "BT[1...3]"
+input = "BT1"
 output = "掘り出し袋表[10,6] ＞ 《竜鱗 I》を3個獲得"
 rands = [
-  { sides = 3, value = 1 },
   { sides = 6, value = 5 },
   { sides = 6, value = 5 },
   { sides = 6, value = 6 },
@@ -1021,10 +1017,9 @@ rands = [
 
 [[ test ]]
 game_system = "DarkBlaze"
-input = "BT[1...3]"
+input = "BT2"
 output = "掘り出し袋表[12,8] ＞ 《レアモノ II》を1個獲得"
 rands = [
-  { sides = 3, value = 2 },
   { sides = 6, value = 6 },
   { sides = 6, value = 6 },
   { sides = 6, value = 6 },
@@ -1033,10 +1028,9 @@ rands = [
 
 [[ test ]]
 game_system = "DarkBlaze"
-input = "BT[1...3]"
+input = "BT2"
 output = "掘り出し袋表[6,7] ＞ 《金属 I》を3個獲得"
 rands = [
-  { sides = 3, value = 2 },
   { sides = 6, value = 2 },
   { sides = 6, value = 4 },
   { sides = 6, value = 5 },
@@ -1045,10 +1039,9 @@ rands = [
 
 [[ test ]]
 game_system = "DarkBlaze"
-input = "BT[1...3]"
+input = "BT1"
 output = "掘り出し袋表[9,5] ＞ 《獣皮 I》を2個獲得"
 rands = [
-  { sides = 3, value = 1 },
   { sides = 6, value = 6 },
   { sides = 6, value = 3 },
   { sides = 6, value = 5 },
@@ -1056,10 +1049,9 @@ rands = [
 
 [[ test ]]
 game_system = "DarkBlaze"
-input = "BT[1...3]"
+input = "BT3"
 output = "掘り出し袋表[2,6] ＞ 《氷結石》を3個獲得"
 rands = [
-  { sides = 3, value = 3 },
   { sides = 6, value = 1 },
   { sides = 6, value = 1 },
   { sides = 6, value = 2 },
@@ -1070,10 +1062,9 @@ rands = [
 
 [[ test ]]
 game_system = "DarkBlaze"
-input = "BT[1...3]"
+input = "BT2"
 output = "掘り出し袋表[7,7] ＞ 《金貨》を7枚獲得"
 rands = [
-  { sides = 3, value = 2 },
   { sides = 6, value = 3 },
   { sides = 6, value = 4 },
   { sides = 6, value = 1 },
@@ -1082,10 +1073,9 @@ rands = [
 
 [[ test ]]
 game_system = "DarkBlaze"
-input = "BT[1...3]"
+input = "BT1"
 output = "掘り出し袋表[10,2] ＞ 《竜鱗 I》を1個獲得"
 rands = [
-  { sides = 3, value = 1 },
   { sides = 6, value = 5 },
   { sides = 6, value = 5 },
   { sides = 6, value = 2 },

--- a/test/data/EarthDawn.toml
+++ b/test/data/EarthDawn.toml
@@ -1,9 +1,8 @@
 [[ test ]]
 game_system = "EarthDawn"
-input = "[1...40]E20"
+input = "38E20"
 output = "ステップ38>=20 ＞ 2d20[75,10]+2d10[7,3]+1d8[2] ＞ 97 ＞ 最良成功"
 rands = [
-  { sides = 40, value = 38 },
   { sides = 20, value = 20 },
   { sides = 20, value = 20 },
   { sides = 20, value = 20 },
@@ -16,10 +15,9 @@ rands = [
 
 [[ test ]]
 game_system = "EarthDawn"
-input = "[1...40]E20"
+input = "34E20"
 output = "ステップ34>=20 ＞ 1d20[9]+1d12[21]+2d10[9,8]+1d8[4] ＞ 51 ＞ 最良成功"
 rands = [
-  { sides = 40, value = 34 },
   { sides = 20, value = 9 },
   { sides = 12, value = 12 },
   { sides = 12, value = 9 },
@@ -30,20 +28,18 @@ rands = [
 
 [[ test ]]
 game_system = "EarthDawn"
-input = "[1...40]E20"
+input = "18E20"
 output = "ステップ18>=20 ＞ 1d20[17]+1d12[3] ＞ 20 ＞ 成功"
 rands = [
-  { sides = 40, value = 18 },
   { sides = 20, value = 17 },
   { sides = 12, value = 3 },
 ]
 
 [[ test ]]
 game_system = "EarthDawn"
-input = "[1...40]E20"
+input = "24E20"
 output = "ステップ24>=20 ＞ 1d20[4]+1d12[8]+1d10[2] ＞ 14 ＞ 失敗"
 rands = [
-  { sides = 40, value = 24 },
   { sides = 20, value = 4 },
   { sides = 12, value = 8 },
   { sides = 10, value = 2 },
@@ -51,10 +47,9 @@ rands = [
 
 [[ test ]]
 game_system = "EarthDawn"
-input = "[1...40]E20"
+input = "23E20"
 output = "ステップ23>=20 ＞ 1d20[3]+2d10[4,7] ＞ 14 ＞ 失敗"
 rands = [
-  { sides = 40, value = 23 },
   { sides = 20, value = 3 },
   { sides = 10, value = 4 },
   { sides = 10, value = 7 },
@@ -62,10 +57,9 @@ rands = [
 
 [[ test ]]
 game_system = "EarthDawn"
-input = "[1...40]E20"
+input = "37E20"
 output = "ステップ37>=20 ＞ 2d20[25,19]+1d10[1]+2d8[4,7] ＞ 56 ＞ 最良成功"
 rands = [
-  { sides = 40, value = 37 },
   { sides = 20, value = 20 },
   { sides = 20, value = 5 },
   { sides = 20, value = 19 },
@@ -76,10 +70,9 @@ rands = [
 
 [[ test ]]
 game_system = "EarthDawn"
-input = "[1...40]E20"
+input = "9E20"
 output = "ステップ9>=20 ＞ 1d8[3]+1d6[8] ＞ 11 ＞ 大失敗"
 rands = [
-  { sides = 40, value = 9 },
   { sides = 8, value = 3 },
   { sides = 6, value = 6 },
   { sides = 6, value = 2 },
@@ -87,10 +80,9 @@ rands = [
 
 [[ test ]]
 game_system = "EarthDawn"
-input = "[1...40]E20"
+input = "32E20"
 output = "ステップ32>=20 ＞ 1d20[9]+2d10[5,2]+2d8[6,9] ＞ 31 ＞ 良成功"
 rands = [
-  { sides = 40, value = 32 },
   { sides = 20, value = 9 },
   { sides = 10, value = 5 },
   { sides = 10, value = 2 },
@@ -101,10 +93,9 @@ rands = [
 
 [[ test ]]
 game_system = "EarthDawn"
-input = "[1...40]E20"
+input = "19E20"
 output = "ステップ19>=20 ＞ 1d20[2]+2d6[1,17] ＞ 20 ＞ 成功"
 rands = [
-  { sides = 40, value = 19 },
   { sides = 20, value = 2 },
   { sides = 6, value = 1 },
   { sides = 6, value = 6 },
@@ -114,10 +105,9 @@ rands = [
 
 [[ test ]]
 game_system = "EarthDawn"
-input = "[1...40]E20"
+input = "14E20"
 output = "ステップ14>=20 ＞ 1d20[17]+1d4[19] ＞ 36 ＞ 優成功"
 rands = [
-  { sides = 40, value = 14 },
   { sides = 20, value = 17 },
   { sides = 4, value = 4 },
   { sides = 4, value = 4 },
@@ -128,10 +118,9 @@ rands = [
 
 [[ test ]]
 game_system = "EarthDawn"
-input = "[1...40]E20+4"
+input = "40E20+4"
 output = "ステップ40>=20 ＞ 2d20[7,9]+1d10[7]+1d8[4]+2d6[2,19]+4 ＞ 52 ＞ 最良成功"
 rands = [
-  { sides = 40, value = 40 },
   { sides = 20, value = 7 },
   { sides = 20, value = 9 },
   { sides = 10, value = 7 },
@@ -145,10 +134,9 @@ rands = [
 
 [[ test ]]
 game_system = "EarthDawn"
-input = "[1...40]E20+4"
+input = "30E20+4"
 output = "ステップ30>=20 ＞ 1d20[14]+1d10[16]+1d8[2]+2d6[3,3]+4 ＞ 42 ＞ 最良成功"
 rands = [
-  { sides = 40, value = 30 },
   { sides = 20, value = 14 },
   { sides = 10, value = 10 },
   { sides = 10, value = 6 },
@@ -159,10 +147,9 @@ rands = [
 
 [[ test ]]
 game_system = "EarthDawn"
-input = "[1...40]E20+4"
+input = "37E20+4"
 output = "ステップ37>=20 ＞ 2d20[18,2]+1d10[5]+2d8[6,7]+4 ＞ 42 ＞ 最良成功"
 rands = [
-  { sides = 40, value = 37 },
   { sides = 20, value = 18 },
   { sides = 20, value = 2 },
   { sides = 10, value = 5 },
@@ -172,20 +159,18 @@ rands = [
 
 [[ test ]]
 game_system = "EarthDawn"
-input = "[1...40]E20+4"
+input = "17E20+4"
 output = "ステップ17>=20 ＞ 1d20[14]+1d10[7]+4 ＞ 25 ＞ 成功"
 rands = [
-  { sides = 40, value = 17 },
   { sides = 20, value = 14 },
   { sides = 10, value = 7 },
 ]
 
 [[ test ]]
 game_system = "EarthDawn"
-input = "[1...40]E20+4"
+input = "26E20+4"
 output = "ステップ26>=20 ＞ 1d20[9]+1d10[4]+1d8[1]+1d6[2]+4 ＞ 20 ＞ 成功"
 rands = [
-  { sides = 40, value = 26 },
   { sides = 20, value = 9 },
   { sides = 10, value = 4 },
   { sides = 8, value = 1 },
@@ -194,10 +179,9 @@ rands = [
 
 [[ test ]]
 game_system = "EarthDawn"
-input = "[1...40]E20+4"
+input = "34E20+4"
 output = "ステップ34>=20 ＞ 1d20[7]+1d12[1]+2d10[6,7]+1d8[15]+4 ＞ 40 ＞ 優成功"
 rands = [
-  { sides = 40, value = 34 },
   { sides = 20, value = 7 },
   { sides = 12, value = 1 },
   { sides = 10, value = 6 },
@@ -208,10 +192,9 @@ rands = [
 
 [[ test ]]
 game_system = "EarthDawn"
-input = "[1...40]E20+4"
+input = "40E20+4"
 output = "ステップ40>=20 ＞ 2d20[19,12]+1d10[9]+1d8[5]+2d6[1,5]+4 ＞ 55 ＞ 最良成功"
 rands = [
-  { sides = 40, value = 40 },
   { sides = 20, value = 19 },
   { sides = 20, value = 12 },
   { sides = 10, value = 9 },
@@ -222,10 +205,9 @@ rands = [
 
 [[ test ]]
 game_system = "EarthDawn"
-input = "[1...40]E20+4"
+input = "37E20+4"
 output = "ステップ37>=20 ＞ 2d20[13,14]+1d10[8]+2d8[7,4]+4 ＞ 50 ＞ 最良成功"
 rands = [
-  { sides = 40, value = 37 },
   { sides = 20, value = 13 },
   { sides = 20, value = 14 },
   { sides = 10, value = 8 },
@@ -235,10 +217,9 @@ rands = [
 
 [[ test ]]
 game_system = "EarthDawn"
-input = "[1...40]E20+4"
+input = "29E20+4"
 output = "ステップ29>=20 ＞ 1d20[12]+1d12[10]+1d10[3]+1d8[2]+4 ＞ 31 ＞ 良成功"
 rands = [
-  { sides = 40, value = 29 },
   { sides = 20, value = 12 },
   { sides = 12, value = 10 },
   { sides = 10, value = 3 },
@@ -247,10 +228,9 @@ rands = [
 
 [[ test ]]
 game_system = "EarthDawn"
-input = "[1...40]E20+4"
+input = "30E20+4"
 output = "ステップ30>=20 ＞ 1d20[3]+1d10[3]+1d8[12]+2d6[4,2]+4 ＞ 28 ＞ 良成功"
 rands = [
-  { sides = 40, value = 30 },
   { sides = 20, value = 3 },
   { sides = 10, value = 3 },
   { sides = 8, value = 8 },
@@ -261,29 +241,26 @@ rands = [
 
 [[ test ]]
 game_system = "EarthDawn"
-input = "[1...40]E20+6"
+input = "6E20+6"
 output = "ステップ6>=20 ＞ 1d10[7]+6 ＞ 13 ＞ 失敗"
 rands = [
-  { sides = 40, value = 6 },
   { sides = 10, value = 7 },
 ]
 
 [[ test ]]
 game_system = "EarthDawn"
-input = "[1...40]E20+6"
+input = "9E20+6"
 output = "ステップ9>=20 ＞ 1d8[6]+1d6[3]+6 ＞ 15 ＞ 失敗"
 rands = [
-  { sides = 40, value = 9 },
   { sides = 8, value = 6 },
   { sides = 6, value = 3 },
 ]
 
 [[ test ]]
 game_system = "EarthDawn"
-input = "[1...40]E20+6"
+input = "19E20+6"
 output = "ステップ19>=20 ＞ 1d20[2]+2d6[2,10]+6 ＞ 20 ＞ 成功"
 rands = [
-  { sides = 40, value = 19 },
   { sides = 20, value = 2 },
   { sides = 6, value = 2 },
   { sides = 6, value = 6 },
@@ -292,10 +269,9 @@ rands = [
 
 [[ test ]]
 game_system = "EarthDawn"
-input = "[1...40]E20+6"
+input = "38E20+6"
 output = "ステップ38>=20 ＞ 2d20[14,4]+2d10[2,19]+1d8[4]+6 ＞ 49 ＞ 最良成功"
 rands = [
-  { sides = 40, value = 38 },
   { sides = 20, value = 14 },
   { sides = 20, value = 4 },
   { sides = 10, value = 2 },
@@ -306,10 +282,9 @@ rands = [
 
 [[ test ]]
 game_system = "EarthDawn"
-input = "[1...40]E20+6"
+input = "24E20+6"
 output = "ステップ24>=20 ＞ 1d20[5]+1d12[1]+1d10[5]+6 ＞ 17 ＞ 失敗"
 rands = [
-  { sides = 40, value = 24 },
   { sides = 20, value = 5 },
   { sides = 12, value = 1 },
   { sides = 10, value = 5 },
@@ -317,10 +292,9 @@ rands = [
 
 [[ test ]]
 game_system = "EarthDawn"
-input = "[1...40]E20+6"
+input = "26E20+6"
 output = "ステップ26>=20 ＞ 1d20[6]+1d10[9]+1d8[2]+1d6[4]+6 ＞ 27 ＞ 成功"
 rands = [
-  { sides = 40, value = 26 },
   { sides = 20, value = 6 },
   { sides = 10, value = 9 },
   { sides = 8, value = 2 },
@@ -329,10 +303,9 @@ rands = [
 
 [[ test ]]
 game_system = "EarthDawn"
-input = "[1...40]E20+6"
+input = "32E20+6"
 output = "ステップ32>=20 ＞ 1d20[12]+2d10[5,1]+2d8[1,7]+6 ＞ 32 ＞ 良成功"
 rands = [
-  { sides = 40, value = 32 },
   { sides = 20, value = 12 },
   { sides = 10, value = 5 },
   { sides = 10, value = 1 },
@@ -342,10 +315,9 @@ rands = [
 
 [[ test ]]
 game_system = "EarthDawn"
-input = "[1...40]E20+6"
+input = "23E20+6"
 output = "ステップ23>=20 ＞ 1d20[13]+2d10[15,9]+6 ＞ 43 ＞ 最良成功"
 rands = [
-  { sides = 40, value = 23 },
   { sides = 20, value = 13 },
   { sides = 10, value = 10 },
   { sides = 10, value = 5 },
@@ -354,20 +326,18 @@ rands = [
 
 [[ test ]]
 game_system = "EarthDawn"
-input = "[1...40]E20+6"
+input = "9E20+6"
 output = "ステップ9>=20 ＞ 1d8[4]+1d6[5]+6 ＞ 15 ＞ 失敗"
 rands = [
-  { sides = 40, value = 9 },
   { sides = 8, value = 4 },
   { sides = 6, value = 5 },
 ]
 
 [[ test ]]
 game_system = "EarthDawn"
-input = "[1...40]E20+6"
+input = "40E20+6"
 output = "ステップ40>=20 ＞ 2d20[27,6]+1d10[1]+1d8[3]+2d6[2,2]+6 ＞ 47 ＞ 最良成功"
 rands = [
-  { sides = 40, value = 40 },
   { sides = 20, value = 20 },
   { sides = 20, value = 7 },
   { sides = 20, value = 6 },
@@ -379,10 +349,9 @@ rands = [
 
 [[ test ]]
 game_system = "EarthDawn"
-input = "[1...40]E20+8"
+input = "23E20+8"
 output = "ステップ23>=20 ＞ 1d20[13]+2d10[6,4]+8 ＞ 31 ＞ 良成功"
 rands = [
-  { sides = 40, value = 23 },
   { sides = 20, value = 13 },
   { sides = 10, value = 6 },
   { sides = 10, value = 4 },
@@ -390,20 +359,18 @@ rands = [
 
 [[ test ]]
 game_system = "EarthDawn"
-input = "[1...40]E20+8"
+input = "12E20+8"
 output = "ステップ12>=20 ＞ 2d10[2,2]+8 ＞ 12 ＞ 失敗"
 rands = [
-  { sides = 40, value = 12 },
   { sides = 10, value = 2 },
   { sides = 10, value = 2 },
 ]
 
 [[ test ]]
 game_system = "EarthDawn"
-input = "[1...40]E20+8"
+input = "35E20+8"
 output = "ステップ35>=20 ＞ 2d20[7,19]+1d10[6]+1d8[3]+1d4[3]+8 ＞ 46 ＞ 最良成功"
 rands = [
-  { sides = 40, value = 35 },
   { sides = 20, value = 7 },
   { sides = 20, value = 19 },
   { sides = 10, value = 6 },
@@ -413,10 +380,9 @@ rands = [
 
 [[ test ]]
 game_system = "EarthDawn"
-input = "[1...40]E20+8"
+input = "35E20+8"
 output = "ステップ35>=20 ＞ 2d20[19,17]+1d10[7]+1d8[14]+1d4[1]+8 ＞ 66 ＞ 最良成功"
 rands = [
-  { sides = 40, value = 35 },
   { sides = 20, value = 19 },
   { sides = 20, value = 17 },
   { sides = 10, value = 7 },
@@ -427,10 +393,9 @@ rands = [
 
 [[ test ]]
 game_system = "EarthDawn"
-input = "[1...40]E20+8"
+input = "36E20+8"
 output = "ステップ36>=20 ＞ 2d20[15,12]+1d10[7]+1d8[2]+1d6[4]+8 ＞ 48 ＞ 最良成功"
 rands = [
-  { sides = 40, value = 36 },
   { sides = 20, value = 15 },
   { sides = 20, value = 12 },
   { sides = 10, value = 7 },
@@ -440,10 +405,9 @@ rands = [
 
 [[ test ]]
 game_system = "EarthDawn"
-input = "[1...40]E20+8"
+input = "28E20+8"
 output = "ステップ28>=20 ＞ 1d20[17]+2d10[1,8]+1d8[6]+8 ＞ 40 ＞ 優成功"
 rands = [
-  { sides = 40, value = 28 },
   { sides = 20, value = 17 },
   { sides = 10, value = 1 },
   { sides = 10, value = 8 },
@@ -452,10 +416,9 @@ rands = [
 
 [[ test ]]
 game_system = "EarthDawn"
-input = "[1...40]E20+8"
+input = "34E20+8"
 output = "ステップ34>=20 ＞ 1d20[7]+1d12[3]+2d10[6,7]+1d8[13]+8 ＞ 44 ＞ 最良成功"
 rands = [
-  { sides = 40, value = 34 },
   { sides = 20, value = 7 },
   { sides = 12, value = 3 },
   { sides = 10, value = 6 },
@@ -466,10 +429,9 @@ rands = [
 
 [[ test ]]
 game_system = "EarthDawn"
-input = "[1...40]E20+8"
+input = "24E20+8"
 output = "ステップ24>=20 ＞ 1d20[2]+1d12[5]+1d10[9]+8 ＞ 24 ＞ 成功"
 rands = [
-  { sides = 40, value = 24 },
   { sides = 20, value = 2 },
   { sides = 12, value = 5 },
   { sides = 10, value = 9 },
@@ -477,10 +439,9 @@ rands = [
 
 [[ test ]]
 game_system = "EarthDawn"
-input = "[1...40]E20+8"
+input = "31E20+8"
 output = "ステップ31>=20 ＞ 1d20[8]+1d10[6]+2d8[1,2]+1d6[2]+8 ＞ 27 ＞ 成功"
 rands = [
-  { sides = 40, value = 31 },
   { sides = 20, value = 8 },
   { sides = 10, value = 6 },
   { sides = 8, value = 1 },
@@ -490,29 +451,26 @@ rands = [
 
 [[ test ]]
 game_system = "EarthDawn"
-input = "[1...40]E20+8"
+input = "18E20+8"
 output = "ステップ18>=20 ＞ 1d20[18]+1d12[10]+8 ＞ 36 ＞ 優成功"
 rands = [
-  { sides = 40, value = 18 },
   { sides = 20, value = 18 },
   { sides = 12, value = 10 },
 ]
 
 [[ test ]]
 game_system = "EarthDawn"
-input = "[1...40]E20+10"
+input = "6E20+10"
 output = "ステップ6>=20 ＞ 1d10[4]+10 ＞ 14 ＞ 失敗"
 rands = [
-  { sides = 40, value = 6 },
   { sides = 10, value = 4 },
 ]
 
 [[ test ]]
 game_system = "EarthDawn"
-input = "[1...40]E20+10"
+input = "37E20+10"
 output = "ステップ37>=20 ＞ 2d20[2,7]+1d10[7]+2d8[2,3]+10 ＞ 31 ＞ 良成功"
 rands = [
-  { sides = 40, value = 37 },
   { sides = 20, value = 2 },
   { sides = 20, value = 7 },
   { sides = 10, value = 7 },
@@ -522,10 +480,9 @@ rands = [
 
 [[ test ]]
 game_system = "EarthDawn"
-input = "[1...40]E20+10"
+input = "22E20+10"
 output = "ステップ22>=20 ＞ 1d20[9]+1d10[3]+1d8[10]+10 ＞ 32 ＞ 良成功"
 rands = [
-  { sides = 40, value = 22 },
   { sides = 20, value = 9 },
   { sides = 10, value = 3 },
   { sides = 8, value = 8 },
@@ -534,20 +491,18 @@ rands = [
 
 [[ test ]]
 game_system = "EarthDawn"
-input = "[1...40]E20+10"
+input = "16E20+10"
 output = "ステップ16>=20 ＞ 1d20[15]+1d8[7]+10 ＞ 32 ＞ 良成功"
 rands = [
-  { sides = 40, value = 16 },
   { sides = 20, value = 15 },
   { sides = 8, value = 7 },
 ]
 
 [[ test ]]
 game_system = "EarthDawn"
-input = "[1...40]E20+10"
+input = "21E20+10"
 output = "ステップ21>=20 ＞ 1d20[8]+1d10[2]+1d6[11]+10 ＞ 31 ＞ 良成功"
 rands = [
-  { sides = 40, value = 21 },
   { sides = 20, value = 8 },
   { sides = 10, value = 2 },
   { sides = 6, value = 6 },
@@ -556,10 +511,9 @@ rands = [
 
 [[ test ]]
 game_system = "EarthDawn"
-input = "[1...40]E20+10"
+input = "34E20+10"
 output = "ステップ34>=20 ＞ 1d20[8]+1d12[8]+2d10[6,4]+1d8[2]+10 ＞ 38 ＞ 優成功"
 rands = [
-  { sides = 40, value = 34 },
   { sides = 20, value = 8 },
   { sides = 12, value = 8 },
   { sides = 10, value = 6 },
@@ -569,10 +523,9 @@ rands = [
 
 [[ test ]]
 game_system = "EarthDawn"
-input = "[1...40]E20+10"
+input = "29E20+10"
 output = "ステップ29>=20 ＞ 1d20[8]+1d12[3]+1d10[6]+1d8[1]+10 ＞ 28 ＞ 良成功"
 rands = [
-  { sides = 40, value = 29 },
   { sides = 20, value = 8 },
   { sides = 12, value = 3 },
   { sides = 10, value = 6 },
@@ -581,20 +534,18 @@ rands = [
 
 [[ test ]]
 game_system = "EarthDawn"
-input = "[1...40]E20+10"
+input = "7E20+10"
 output = "ステップ7>=20 ＞ 1d12[22]+10 ＞ 32 ＞ 良成功"
 rands = [
-  { sides = 40, value = 7 },
   { sides = 12, value = 12 },
   { sides = 12, value = 10 },
 ]
 
 [[ test ]]
 game_system = "EarthDawn"
-input = "[1...40]E20+10"
+input = "39E20+10"
 output = "ステップ39>=20 ＞ 2d20[3,23]+1d12[2]+1d10[11]+1d8[11]+10 ＞ 60 ＞ 最良成功"
 rands = [
-  { sides = 40, value = 39 },
   { sides = 20, value = 3 },
   { sides = 20, value = 20 },
   { sides = 20, value = 3 },
@@ -607,10 +558,9 @@ rands = [
 
 [[ test ]]
 game_system = "EarthDawn"
-input = "[1...40]E20+10"
+input = "8E20+10"
 output = "ステップ8>=20 ＞ 2d6[17,3]+10 ＞ 30 ＞ 良成功"
 rands = [
-  { sides = 40, value = 8 },
   { sides = 6, value = 6 },
   { sides = 6, value = 6 },
   { sides = 6, value = 5 },
@@ -619,20 +569,18 @@ rands = [
 
 [[ test ]]
 game_system = "EarthDawn"
-input = "[1...40]E20+12"
+input = "3E20+12"
 output = "ステップ3>=20 ＞ 1d4[7]+12 ＞ 19 ＞ 失敗"
 rands = [
-  { sides = 40, value = 3 },
   { sides = 4, value = 4 },
   { sides = 4, value = 3 },
 ]
 
 [[ test ]]
 game_system = "EarthDawn"
-input = "[1...40]E20+12"
+input = "25E20+12"
 output = "ステップ25>=20 ＞ 1d20[9]+1d10[5]+1d8[23]+1d4[3]+12 ＞ 52 ＞ 最良成功"
 rands = [
-  { sides = 40, value = 25 },
   { sides = 20, value = 9 },
   { sides = 10, value = 5 },
   { sides = 8, value = 8 },
@@ -643,10 +591,9 @@ rands = [
 
 [[ test ]]
 game_system = "EarthDawn"
-input = "[1...40]E20+12"
+input = "31E20+12"
 output = "ステップ31>=20 ＞ 1d20[19]+1d10[9]+2d8[7,3]+1d6[4]+12 ＞ 54 ＞ 最良成功"
 rands = [
-  { sides = 40, value = 31 },
   { sides = 20, value = 19 },
   { sides = 10, value = 9 },
   { sides = 8, value = 7 },
@@ -656,29 +603,26 @@ rands = [
 
 [[ test ]]
 game_system = "EarthDawn"
-input = "[1...40]E20+12"
+input = "14E20+12"
 output = "ステップ14>=20 ＞ 1d20[18]+1d4[2]+12 ＞ 32 ＞ 良成功"
 rands = [
-  { sides = 40, value = 14 },
   { sides = 20, value = 18 },
   { sides = 4, value = 2 },
 ]
 
 [[ test ]]
 game_system = "EarthDawn"
-input = "[1...40]E20+12"
+input = "7E20+12"
 output = "ステップ7>=20 ＞ 1d12[2]+12 ＞ 14 ＞ 失敗"
 rands = [
-  { sides = 40, value = 7 },
   { sides = 12, value = 2 },
 ]
 
 [[ test ]]
 game_system = "EarthDawn"
-input = "[1...40]E20+12"
+input = "26E20+12"
 output = "ステップ26>=20 ＞ 1d20[15]+1d10[4]+1d8[1]+1d6[1]+12 ＞ 33 ＞ 良成功"
 rands = [
-  { sides = 40, value = 26 },
   { sides = 20, value = 15 },
   { sides = 10, value = 4 },
   { sides = 8, value = 1 },
@@ -687,10 +631,9 @@ rands = [
 
 [[ test ]]
 game_system = "EarthDawn"
-input = "[1...40]E20+12"
+input = "32E20+12"
 output = "ステップ32>=20 ＞ 1d20[12]+2d10[2,9]+2d8[2,1]+12 ＞ 38 ＞ 優成功"
 rands = [
-  { sides = 40, value = 32 },
   { sides = 20, value = 12 },
   { sides = 10, value = 2 },
   { sides = 10, value = 9 },
@@ -700,10 +643,9 @@ rands = [
 
 [[ test ]]
 game_system = "EarthDawn"
-input = "[1...40]E20+12"
+input = "27E20+12"
 output = "ステップ27>=20 ＞ 1d20[13]+1d10[2]+2d8[2,4]+12 ＞ 33 ＞ 良成功"
 rands = [
-  { sides = 40, value = 27 },
   { sides = 20, value = 13 },
   { sides = 10, value = 2 },
   { sides = 8, value = 2 },
@@ -712,10 +654,9 @@ rands = [
 
 [[ test ]]
 game_system = "EarthDawn"
-input = "[1...40]E20+12"
+input = "22E20+12"
 output = "ステップ22>=20 ＞ 1d20[3]+1d10[3]+1d8[3]+12 ＞ 21 ＞ 成功"
 rands = [
-  { sides = 40, value = 22 },
   { sides = 20, value = 3 },
   { sides = 10, value = 3 },
   { sides = 8, value = 3 },
@@ -723,10 +664,9 @@ rands = [
 
 [[ test ]]
 game_system = "EarthDawn"
-input = "[1...40]E20+12"
+input = "30E20+12"
 output = "ステップ30>=20 ＞ 1d20[12]+1d10[4]+1d8[5]+2d6[3,3]+12 ＞ 39 ＞ 優成功"
 rands = [
-  { sides = 40, value = 30 },
   { sides = 20, value = 12 },
   { sides = 10, value = 4 },
   { sides = 8, value = 5 },
@@ -736,10 +676,9 @@ rands = [
 
 [[ test ]]
 game_system = "EarthDawn"
-input = "[1...40]E20+20"
+input = "9E20+20"
 output = "ステップ9>=20 ＞ 1d8[15]+1d6[1]+20 ＞ 36 ＞ 優成功"
 rands = [
-  { sides = 40, value = 9 },
   { sides = 8, value = 8 },
   { sides = 8, value = 7 },
   { sides = 6, value = 1 },
@@ -747,19 +686,17 @@ rands = [
 
 [[ test ]]
 game_system = "EarthDawn"
-input = "[1...40]E20+20"
+input = "3E20+20"
 output = "ステップ3>=20 ＞ 1d4[3]+20 ＞ 23 ＞ 成功"
 rands = [
-  { sides = 40, value = 3 },
   { sides = 4, value = 3 },
 ]
 
 [[ test ]]
 game_system = "EarthDawn"
-input = "[1...40]E20+20"
+input = "28E20+20"
 output = "ステップ28>=20 ＞ 1d20[9]+2d10[4,4]+1d8[3]+20 ＞ 40 ＞ 優成功"
 rands = [
-  { sides = 40, value = 28 },
   { sides = 20, value = 9 },
   { sides = 10, value = 4 },
   { sides = 10, value = 4 },
@@ -768,10 +705,9 @@ rands = [
 
 [[ test ]]
 game_system = "EarthDawn"
-input = "[1...40]E20+20"
+input = "38E20+20"
 output = "ステップ38>=20 ＞ 2d20[10,5]+2d10[16,17]+1d8[14]+20 ＞ 82 ＞ 最良成功"
 rands = [
-  { sides = 40, value = 38 },
   { sides = 20, value = 10 },
   { sides = 20, value = 5 },
   { sides = 10, value = 10 },
@@ -784,28 +720,25 @@ rands = [
 
 [[ test ]]
 game_system = "EarthDawn"
-input = "[1...40]E20+20"
+input = "6E20+20"
 output = "ステップ6>=20 ＞ 1d10[6]+20 ＞ 26 ＞ 成功"
 rands = [
-  { sides = 40, value = 6 },
   { sides = 10, value = 6 },
 ]
 
 [[ test ]]
 game_system = "EarthDawn"
-input = "[1...40]E20+20"
+input = "6E20+20"
 output = "ステップ6>=20 ＞ 1d10[3]+20 ＞ 23 ＞ 成功"
 rands = [
-  { sides = 40, value = 6 },
   { sides = 10, value = 3 },
 ]
 
 [[ test ]]
 game_system = "EarthDawn"
-input = "[1...40]E20+20"
+input = "27E20+20"
 output = "ステップ27>=20 ＞ 1d20[2]+1d10[6]+2d8[5,5]+20 ＞ 38 ＞ 優成功"
 rands = [
-  { sides = 40, value = 27 },
   { sides = 20, value = 2 },
   { sides = 10, value = 6 },
   { sides = 8, value = 5 },
@@ -814,10 +747,9 @@ rands = [
 
 [[ test ]]
 game_system = "EarthDawn"
-input = "[1...40]E20+20"
+input = "33E20+20"
 output = "ステップ33>=20 ＞ 1d20[16]+3d10[6,5,4]+1d8[4]+20 ＞ 55 ＞ 最良成功"
 rands = [
-  { sides = 40, value = 33 },
   { sides = 20, value = 16 },
   { sides = 10, value = 6 },
   { sides = 10, value = 5 },
@@ -827,20 +759,18 @@ rands = [
 
 [[ test ]]
 game_system = "EarthDawn"
-input = "[1...40]E20+20"
+input = "2E20+20"
 output = "ステップ2>=20 ＞ 1d4[5]+19 ＞ 24 ＞ 成功"
 rands = [
-  { sides = 40, value = 2 },
   { sides = 4, value = 4 },
   { sides = 4, value = 1 },
 ]
 
 [[ test ]]
 game_system = "EarthDawn"
-input = "[1...40]E20+20"
+input = "4E20+20"
 output = "ステップ4>=20 ＞ 1d6[1]+20 ＞ 21 ＞ 自動失敗"
 rands = [
-  { sides = 40, value = 4 },
   { sides = 6, value = 1 },
 ]
 

--- a/test/data/EmbryoMachine.toml
+++ b/test/data/EmbryoMachine.toml
@@ -1110,10 +1110,9 @@ rands = [
 
 [[ test ]]
 game_system = "EmbryoMachine"
-input = "EM[1...10]"
+input = "EM2"
 output = "(2R10>=2[20,2]) ＞ 10[4,6] ＞ 10 ＞ 成功 ＞ 命中レベルC ＞ [5]左脚"
 rands = [
-  { sides = 10, value = 2 },
   { sides = 10, value = 4 },
   { sides = 10, value = 6 },
   { sides = 10, value = 4 },
@@ -1122,10 +1121,9 @@ rands = [
 
 [[ test ]]
 game_system = "EmbryoMachine"
-input = "EM[1...10]"
+input = "EM5"
 output = "(2R10>=5[20,2]) ＞ 9[3,6] ＞ 9 ＞ 成功 ＞ 命中レベルC ＞ [3]頭"
 rands = [
-  { sides = 10, value = 5 },
   { sides = 10, value = 6 },
   { sides = 10, value = 3 },
   { sides = 10, value = 1 },
@@ -1134,11 +1132,10 @@ rands = [
 
 [[ test ]]
 game_system = "EmbryoMachine"
-input = "EM[1...10]"
+input = "EM5"
 output = "(2R10>=5[20,2]) ＞ 14[5,9] ＞ 14 ＞ 成功 ＞ 命中レベルB ＞ [15]右脚"
 rands = [
   { sides = 10, value = 5 },
-  { sides = 10, value = 5 },
   { sides = 10, value = 9 },
   { sides = 10, value = 9 },
   { sides = 10, value = 6 },
@@ -1146,10 +1143,9 @@ rands = [
 
 [[ test ]]
 game_system = "EmbryoMachine"
-input = "EM[1...10]"
+input = "EM5"
 output = "(2R10>=5[20,2]) ＞ 11[5,6] ＞ 11 ＞ 成功 ＞ 命中レベルC ＞ [17]右脚"
 rands = [
-  { sides = 10, value = 5 },
   { sides = 10, value = 6 },
   { sides = 10, value = 5 },
   { sides = 10, value = 9 },
@@ -1158,10 +1154,9 @@ rands = [
 
 [[ test ]]
 game_system = "EmbryoMachine"
-input = "EM[1...10]"
+input = "EM7"
 output = "(2R10>=7[20,2]) ＞ 11[4,7] ＞ 11 ＞ 成功 ＞ 命中レベルB ＞ [7]左脚"
 rands = [
-  { sides = 10, value = 7 },
   { sides = 10, value = 4 },
   { sides = 10, value = 7 },
   { sides = 10, value = 4 },
@@ -1170,10 +1165,9 @@ rands = [
 
 [[ test ]]
 game_system = "EmbryoMachine"
-input = "EM[1...10]"
+input = "EM2"
 output = "(2R10>=2[20,2]) ＞ 16[7,9] ＞ 16 ＞ 成功 ＞ 命中レベルB ＞ [11]胴"
 rands = [
-  { sides = 10, value = 2 },
   { sides = 10, value = 9 },
   { sides = 10, value = 7 },
   { sides = 10, value = 4 },
@@ -1182,11 +1176,10 @@ rands = [
 
 [[ test ]]
 game_system = "EmbryoMachine"
-input = "EM[1...10]"
+input = "EM8"
 output = "(2R10>=8[20,2]) ＞ 12[4,8] ＞ 12 ＞ 成功 ＞ 命中レベルB ＞ [16]右脚"
 rands = [
   { sides = 10, value = 8 },
-  { sides = 10, value = 8 },
   { sides = 10, value = 4 },
   { sides = 10, value = 10 },
   { sides = 10, value = 6 },
@@ -1194,11 +1187,10 @@ rands = [
 
 [[ test ]]
 game_system = "EmbryoMachine"
-input = "EM[1...10]"
+input = "EM9"
 output = "(2R10>=9[20,2]) ＞ 11[2,9] ＞ 11 ＞ 成功 ＞ 命中レベルB ＞ [9]左腕"
 rands = [
   { sides = 10, value = 9 },
-  { sides = 10, value = 9 },
   { sides = 10, value = 2 },
   { sides = 10, value = 3 },
   { sides = 10, value = 6 },
@@ -1206,10 +1198,9 @@ rands = [
 
 [[ test ]]
 game_system = "EmbryoMachine"
-input = "EM[1...10]"
+input = "EM7"
 output = "(2R10>=7[20,2]) ＞ 13[6,7] ＞ 13 ＞ 成功 ＞ 命中レベルB ＞ [17]右脚"
 rands = [
-  { sides = 10, value = 7 },
   { sides = 10, value = 6 },
   { sides = 10, value = 7 },
   { sides = 10, value = 7 },
@@ -1218,10 +1209,9 @@ rands = [
 
 [[ test ]]
 game_system = "EmbryoMachine"
-input = "EM[1...10]"
+input = "EM10"
 output = "(2R10>=10[20,2]) ＞ 11[3,8] ＞ 11 ＞ 成功 ＞ 命中レベルB ＞ [12]胴"
 rands = [
-  { sides = 10, value = 10 },
   { sides = 10, value = 3 },
   { sides = 10, value = 8 },
   { sides = 10, value = 5 },
@@ -1230,10 +1220,9 @@ rands = [
 
 [[ test ]]
 game_system = "EmbryoMachine"
-input = "EM[1...10]+1"
+input = "EM9+1"
 output = "(2R10+1>=9[20,2]) ＞ 10[3,7]+1 ＞ 11 ＞ 成功 ＞ 命中レベルB ＞ [11]胴"
 rands = [
-  { sides = 10, value = 9 },
   { sides = 10, value = 7 },
   { sides = 10, value = 3 },
   { sides = 10, value = 3 },
@@ -1242,10 +1231,9 @@ rands = [
 
 [[ test ]]
 game_system = "EmbryoMachine"
-input = "EM[1...10]+1"
+input = "EM9+1"
 output = "(2R10+1>=9[20,2]) ＞ 13[3,10]+1 ＞ 14 ＞ 成功 ＞ 命中レベルA ＞ [7]左脚"
 rands = [
-  { sides = 10, value = 9 },
   { sides = 10, value = 10 },
   { sides = 10, value = 3 },
   { sides = 10, value = 4 },
@@ -1254,10 +1242,9 @@ rands = [
 
 [[ test ]]
 game_system = "EmbryoMachine"
-input = "EM[1...10]+1"
+input = "EM8+1"
 output = "(2R10+1>=8[20,2]) ＞ 17[8,9]+1 ＞ 18 ＞ 成功 ＞ 命中レベルB ＞ [18]頭"
 rands = [
-  { sides = 10, value = 8 },
   { sides = 10, value = 9 },
   { sides = 10, value = 8 },
   { sides = 10, value = 10 },
@@ -1266,10 +1253,9 @@ rands = [
 
 [[ test ]]
 game_system = "EmbryoMachine"
-input = "EM[1...10]+1"
+input = "EM6+1"
 output = "(2R10+1>=6[20,2]) ＞ 5[1,4]+1 ＞ 6 ＞ 成功 ＞ 命中レベルC ＞ [3]頭"
 rands = [
-  { sides = 10, value = 6 },
   { sides = 10, value = 1 },
   { sides = 10, value = 4 },
   { sides = 10, value = 1 },
@@ -1278,10 +1264,9 @@ rands = [
 
 [[ test ]]
 game_system = "EmbryoMachine"
-input = "EM[1...10]+1"
+input = "EM10+1"
 output = "(2R10+1>=10[20,2]) ＞ 6[1,5]+1 ＞ 7 ＞ 失敗"
 rands = [
-  { sides = 10, value = 10 },
   { sides = 10, value = 1 },
   { sides = 10, value = 5 },
   { sides = 10, value = 9 },
@@ -1290,10 +1275,9 @@ rands = [
 
 [[ test ]]
 game_system = "EmbryoMachine"
-input = "EM[1...10]+1"
+input = "EM6+1"
 output = "(2R10+1>=6[20,2]) ＞ 11[3,8]+1 ＞ 12 ＞ 成功 ＞ 命中レベルB ＞ [10]胴"
 rands = [
-  { sides = 10, value = 6 },
   { sides = 10, value = 3 },
   { sides = 10, value = 8 },
   { sides = 10, value = 1 },
@@ -1302,10 +1286,9 @@ rands = [
 
 [[ test ]]
 game_system = "EmbryoMachine"
-input = "EM[1...10]+1"
+input = "EM3+1"
 output = "(2R10+1>=3[20,2]) ＞ 6[1,5]+1 ＞ 7 ＞ 成功 ＞ 命中レベルC ＞ [10]胴"
 rands = [
-  { sides = 10, value = 3 },
   { sides = 10, value = 1 },
   { sides = 10, value = 5 },
   { sides = 10, value = 7 },
@@ -1314,10 +1297,9 @@ rands = [
 
 [[ test ]]
 game_system = "EmbryoMachine"
-input = "EM[1...10]+1"
+input = "EM10+1"
 output = "(2R10+1>=10[20,2]) ＞ 8[4,4]+1 ＞ 9 ＞ 失敗"
 rands = [
-  { sides = 10, value = 10 },
   { sides = 10, value = 4 },
   { sides = 10, value = 4 },
   { sides = 10, value = 6 },
@@ -1326,10 +1308,9 @@ rands = [
 
 [[ test ]]
 game_system = "EmbryoMachine"
-input = "EM[1...10]+1"
+input = "EM10+1"
 output = "(2R10+1>=10[20,2]) ＞ 8[2,6]+1 ＞ 9 ＞ 失敗"
 rands = [
-  { sides = 10, value = 10 },
   { sides = 10, value = 2 },
   { sides = 10, value = 6 },
   { sides = 10, value = 6 },
@@ -1338,10 +1319,9 @@ rands = [
 
 [[ test ]]
 game_system = "EmbryoMachine"
-input = "EM[1...10]+1"
+input = "EM1+1"
 output = "(2R10+1>=1[20,2]) ＞ 5[2,3]+1 ＞ 6 ＞ 成功 ＞ 命中レベルC ＞ [14]右腕"
 rands = [
-  { sides = 10, value = 1 },
   { sides = 10, value = 3 },
   { sides = 10, value = 2 },
   { sides = 10, value = 9 },
@@ -1350,10 +1330,9 @@ rands = [
 
 [[ test ]]
 game_system = "EmbryoMachine"
-input = "EM[1...10]+10"
+input = "EM9+10"
 output = "(2R10+10>=9[20,2]) ＞ 2[1,1]+10 ＞ 12 ＞ ファンブル"
 rands = [
-  { sides = 10, value = 9 },
   { sides = 10, value = 1 },
   { sides = 10, value = 1 },
   { sides = 10, value = 9 },
@@ -1362,11 +1341,10 @@ rands = [
 
 [[ test ]]
 game_system = "EmbryoMachine"
-input = "EM[1...10]+10"
+input = "EM8+10"
 output = "(2R10+10>=8[20,2]) ＞ 9[1,8]+10 ＞ 19 ＞ 成功 ＞ 命中レベルB ＞ [13]右腕"
 rands = [
   { sides = 10, value = 8 },
-  { sides = 10, value = 8 },
   { sides = 10, value = 1 },
   { sides = 10, value = 6 },
   { sides = 10, value = 7 },
@@ -1374,10 +1352,9 @@ rands = [
 
 [[ test ]]
 game_system = "EmbryoMachine"
-input = "EM[1...10]+10"
+input = "EM1+10"
 output = "(2R10+10>=1[20,2]) ＞ 9[4,5]+10 ＞ 19 ＞ 成功 ＞ 命中レベルC ＞ [6]左脚"
 rands = [
-  { sides = 10, value = 1 },
   { sides = 10, value = 4 },
   { sides = 10, value = 5 },
   { sides = 10, value = 3 },
@@ -1386,10 +1363,9 @@ rands = [
 
 [[ test ]]
 game_system = "EmbryoMachine"
-input = "EM[1...10]+10"
+input = "EM3+10"
 output = "(2R10+10>=3[20,2]) ＞ 18[9,9]+10 ＞ 28 ＞ 成功 ＞ 命中レベルB ＞ [11]胴"
 rands = [
-  { sides = 10, value = 3 },
   { sides = 10, value = 9 },
   { sides = 10, value = 9 },
   { sides = 10, value = 9 },
@@ -1398,10 +1374,9 @@ rands = [
 
 [[ test ]]
 game_system = "EmbryoMachine"
-input = "EM[1...10]+10"
+input = "EM4+10"
 output = "(2R10+10>=4[20,2]) ＞ 6[1,5]+10 ＞ 16 ＞ 成功 ＞ 命中レベルC ＞ [19]頭"
 rands = [
-  { sides = 10, value = 4 },
   { sides = 10, value = 5 },
   { sides = 10, value = 1 },
   { sides = 10, value = 9 },
@@ -1410,10 +1385,9 @@ rands = [
 
 [[ test ]]
 game_system = "EmbryoMachine"
-input = "EM[1...10]+10"
+input = "EM2+10"
 output = "(2R10+10>=2[20,2]) ＞ 13[3,10]+10 ＞ 23 ＞ 成功 ＞ 命中レベルA ＞ [9]左腕"
 rands = [
-  { sides = 10, value = 2 },
   { sides = 10, value = 10 },
   { sides = 10, value = 3 },
   { sides = 10, value = 1 },
@@ -1422,10 +1396,9 @@ rands = [
 
 [[ test ]]
 game_system = "EmbryoMachine"
-input = "EM[1...10]+10"
+input = "EM4+10"
 output = "(2R10+10>=4[20,2]) ＞ 7[2,5]+10 ＞ 17 ＞ 成功 ＞ 命中レベルC ＞ [8]左腕"
 rands = [
-  { sides = 10, value = 4 },
   { sides = 10, value = 5 },
   { sides = 10, value = 2 },
   { sides = 10, value = 1 },
@@ -1434,11 +1407,10 @@ rands = [
 
 [[ test ]]
 game_system = "EmbryoMachine"
-input = "EM[1...10]+10"
+input = "EM5+10"
 output = "(2R10+10>=5[20,2]) ＞ 15[5,10]+10 ＞ 25 ＞ 成功 ＞ 命中レベルA ＞ [13]右腕"
 rands = [
   { sides = 10, value = 5 },
-  { sides = 10, value = 5 },
   { sides = 10, value = 10 },
   { sides = 10, value = 3 },
   { sides = 10, value = 10 },
@@ -1446,10 +1418,9 @@ rands = [
 
 [[ test ]]
 game_system = "EmbryoMachine"
-input = "EM[1...10]+10"
+input = "EM5+10"
 output = "(2R10+10>=5[20,2]) ＞ 7[3,4]+10 ＞ 17 ＞ 成功 ＞ 命中レベルC ＞ [14]右腕"
 rands = [
-  { sides = 10, value = 5 },
   { sides = 10, value = 3 },
   { sides = 10, value = 4 },
   { sides = 10, value = 6 },
@@ -1458,10 +1429,9 @@ rands = [
 
 [[ test ]]
 game_system = "EmbryoMachine"
-input = "EM[1...10]+10"
+input = "EM7+10"
 output = "(2R10+10>=7[20,2]) ＞ 4[1,3]+10 ＞ 14 ＞ 成功 ＞ 命中レベルC ＞ [10]胴"
 rands = [
-  { sides = 10, value = 7 },
   { sides = 10, value = 3 },
   { sides = 10, value = 1 },
   { sides = 10, value = 3 },
@@ -1470,10 +1440,9 @@ rands = [
 
 [[ test ]]
 game_system = "EmbryoMachine"
-input = "EM[1...10]+1@19"
+input = "EM3+1@19"
 output = "(2R10+1>=3[19,2]) ＞ 9[4,5]+1 ＞ 10 ＞ 成功 ＞ 命中レベルC ＞ [10]胴"
 rands = [
-  { sides = 10, value = 3 },
   { sides = 10, value = 4 },
   { sides = 10, value = 5 },
   { sides = 10, value = 7 },
@@ -1482,10 +1451,9 @@ rands = [
 
 [[ test ]]
 game_system = "EmbryoMachine"
-input = "EM[1...10]+1@19"
+input = "EM7+1@19"
 output = "(2R10+1>=7[19,2]) ＞ 16[7,9]+1 ＞ 17 ＞ 成功 ＞ 命中レベルB ＞ [11]胴"
 rands = [
-  { sides = 10, value = 7 },
   { sides = 10, value = 9 },
   { sides = 10, value = 7 },
   { sides = 10, value = 4 },
@@ -1494,11 +1462,10 @@ rands = [
 
 [[ test ]]
 game_system = "EmbryoMachine"
-input = "EM[1...10]+1@19"
+input = "EM3+1@19"
 output = "(2R10+1>=3[19,2]) ＞ 4[1,3]+1 ＞ 5 ＞ 成功 ＞ 命中レベルC ＞ [2]頭"
 rands = [
   { sides = 10, value = 3 },
-  { sides = 10, value = 3 },
   { sides = 10, value = 1 },
   { sides = 10, value = 1 },
   { sides = 10, value = 1 },
@@ -1506,10 +1473,9 @@ rands = [
 
 [[ test ]]
 game_system = "EmbryoMachine"
-input = "EM[1...10]+1@19"
+input = "EM4+1@19"
 output = "(2R10+1>=4[19,2]) ＞ 12[4,8]+1 ＞ 13 ＞ 成功 ＞ 命中レベルB ＞ [11]胴"
 rands = [
-  { sides = 10, value = 4 },
   { sides = 10, value = 8 },
   { sides = 10, value = 4 },
   { sides = 10, value = 2 },
@@ -1518,10 +1484,9 @@ rands = [
 
 [[ test ]]
 game_system = "EmbryoMachine"
-input = "EM[1...10]+1@19"
+input = "EM5+1@19"
 output = "(2R10+1>=5[19,2]) ＞ 14[4,10]+1 ＞ 15 ＞ 成功 ＞ 命中レベルA ＞ [16]右脚"
 rands = [
-  { sides = 10, value = 5 },
   { sides = 10, value = 4 },
   { sides = 10, value = 10 },
   { sides = 10, value = 8 },
@@ -1530,10 +1495,9 @@ rands = [
 
 [[ test ]]
 game_system = "EmbryoMachine"
-input = "EM[1...10]+1@19"
+input = "EM2+1@19"
 output = "(2R10+1>=2[19,2]) ＞ 15[7,8]+1 ＞ 16 ＞ 成功 ＞ 命中レベルB ＞ [13]右腕"
 rands = [
-  { sides = 10, value = 2 },
   { sides = 10, value = 8 },
   { sides = 10, value = 7 },
   { sides = 10, value = 6 },
@@ -1542,10 +1506,9 @@ rands = [
 
 [[ test ]]
 game_system = "EmbryoMachine"
-input = "EM[1...10]+1@19"
+input = "EM8+1@19"
 output = "(2R10+1>=8[19,2]) ＞ 10[5,5]+1 ＞ 11 ＞ 成功 ＞ 命中レベルC ＞ [8]左腕"
 rands = [
-  { sides = 10, value = 8 },
   { sides = 10, value = 5 },
   { sides = 10, value = 5 },
   { sides = 10, value = 6 },
@@ -1554,10 +1517,9 @@ rands = [
 
 [[ test ]]
 game_system = "EmbryoMachine"
-input = "EM[1...10]+1@19"
+input = "EM1+1@19"
 output = "(2R10+1>=1[19,2]) ＞ 8[4,4]+1 ＞ 9 ＞ 成功 ＞ 命中レベルC ＞ [9]左腕"
 rands = [
-  { sides = 10, value = 1 },
   { sides = 10, value = 4 },
   { sides = 10, value = 4 },
   { sides = 10, value = 4 },
@@ -1566,10 +1528,9 @@ rands = [
 
 [[ test ]]
 game_system = "EmbryoMachine"
-input = "EM[1...10]+1@19"
+input = "EM8+1@19"
 output = "(2R10+1>=8[19,2]) ＞ 10[1,9]+1 ＞ 11 ＞ 成功 ＞ 命中レベルB ＞ [13]右腕"
 rands = [
-  { sides = 10, value = 8 },
   { sides = 10, value = 1 },
   { sides = 10, value = 9 },
   { sides = 10, value = 5 },
@@ -1578,10 +1539,9 @@ rands = [
 
 [[ test ]]
 game_system = "EmbryoMachine"
-input = "EM[1...10]+1@19"
+input = "EM2+1@19"
 output = "(2R10+1>=2[19,2]) ＞ 15[5,10]+1 ＞ 16 ＞ 成功 ＞ 命中レベルA ＞ [6]左脚"
 rands = [
-  { sides = 10, value = 2 },
   { sides = 10, value = 5 },
   { sides = 10, value = 10 },
   { sides = 10, value = 2 },
@@ -1590,10 +1550,9 @@ rands = [
 
 [[ test ]]
 game_system = "EmbryoMachine"
-input = "EM[1...10]+1#3"
+input = "EM1+1#3"
 output = "(2R10+1>=1[20,3]) ＞ 15[6,9]+1 ＞ 16 ＞ 成功 ＞ 命中レベルB ＞ [12]胴"
 rands = [
-  { sides = 10, value = 1 },
   { sides = 10, value = 9 },
   { sides = 10, value = 6 },
   { sides = 10, value = 5 },
@@ -1602,11 +1561,10 @@ rands = [
 
 [[ test ]]
 game_system = "EmbryoMachine"
-input = "EM[1...10]+1#3"
+input = "EM7+1#3"
 output = "(2R10+1>=7[20,3]) ＞ 15[7,8]+1 ＞ 16 ＞ 成功 ＞ 命中レベルB ＞ [7]左脚"
 rands = [
   { sides = 10, value = 7 },
-  { sides = 10, value = 7 },
   { sides = 10, value = 8 },
   { sides = 10, value = 1 },
   { sides = 10, value = 6 },
@@ -1614,10 +1572,9 @@ rands = [
 
 [[ test ]]
 game_system = "EmbryoMachine"
-input = "EM[1...10]+1#3"
+input = "EM6+1#3"
 output = "(2R10+1>=6[20,3]) ＞ 10[1,9]+1 ＞ 11 ＞ 成功 ＞ 命中レベルB ＞ [10]胴"
 rands = [
-  { sides = 10, value = 6 },
   { sides = 10, value = 1 },
   { sides = 10, value = 9 },
   { sides = 10, value = 8 },
@@ -1626,10 +1583,9 @@ rands = [
 
 [[ test ]]
 game_system = "EmbryoMachine"
-input = "EM[1...10]+1#3"
+input = "EM2+1#3"
 output = "(2R10+1>=2[20,3]) ＞ 17[8,9]+1 ＞ 18 ＞ 成功 ＞ 命中レベルB ＞ [12]胴"
 rands = [
-  { sides = 10, value = 2 },
   { sides = 10, value = 9 },
   { sides = 10, value = 8 },
   { sides = 10, value = 5 },
@@ -1638,11 +1594,10 @@ rands = [
 
 [[ test ]]
 game_system = "EmbryoMachine"
-input = "EM[1...10]+1#3"
+input = "EM4+1#3"
 output = "(2R10+1>=4[20,3]) ＞ 7[3,4]+1 ＞ 8 ＞ 成功 ＞ 命中レベルC ＞ [10]胴"
 rands = [
   { sides = 10, value = 4 },
-  { sides = 10, value = 4 },
   { sides = 10, value = 3 },
   { sides = 10, value = 7 },
   { sides = 10, value = 3 },
@@ -1650,10 +1605,9 @@ rands = [
 
 [[ test ]]
 game_system = "EmbryoMachine"
-input = "EM[1...10]+1#3"
+input = "EM3+1#3"
 output = "(2R10+1>=3[20,3]) ＞ 11[5,6]+1 ＞ 12 ＞ 成功 ＞ 命中レベルC ＞ [17]右脚"
 rands = [
-  { sides = 10, value = 3 },
   { sides = 10, value = 5 },
   { sides = 10, value = 6 },
   { sides = 10, value = 7 },
@@ -1662,10 +1616,9 @@ rands = [
 
 [[ test ]]
 game_system = "EmbryoMachine"
-input = "EM[1...10]+1#3"
+input = "EM5+1#3"
 output = "(2R10+1>=5[20,3]) ＞ 8[4,4]+1 ＞ 9 ＞ 成功 ＞ 命中レベルC ＞ [12]胴"
 rands = [
-  { sides = 10, value = 5 },
   { sides = 10, value = 4 },
   { sides = 10, value = 4 },
   { sides = 10, value = 3 },
@@ -1674,10 +1627,9 @@ rands = [
 
 [[ test ]]
 game_system = "EmbryoMachine"
-input = "EM[1...10]+1#3"
+input = "EM7+1#3"
 output = "(2R10+1>=7[20,3]) ＞ 7[1,6]+1 ＞ 8 ＞ 成功 ＞ 命中レベルC ＞ [12]胴"
 rands = [
-  { sides = 10, value = 7 },
   { sides = 10, value = 6 },
   { sides = 10, value = 1 },
   { sides = 10, value = 7 },
@@ -1686,11 +1638,10 @@ rands = [
 
 [[ test ]]
 game_system = "EmbryoMachine"
-input = "EM[1...10]+1#3"
+input = "EM5+1#3"
 output = "(2R10+1>=5[20,3]) ＞ 6[1,5]+1 ＞ 7 ＞ 成功 ＞ 命中レベルC ＞ [11]胴"
 rands = [
   { sides = 10, value = 5 },
-  { sides = 10, value = 5 },
   { sides = 10, value = 1 },
   { sides = 10, value = 4 },
   { sides = 10, value = 7 },
@@ -1698,10 +1649,9 @@ rands = [
 
 [[ test ]]
 game_system = "EmbryoMachine"
-input = "EM[1...10]+1#3"
+input = "EM6+1#3"
 output = "(2R10+1>=6[20,3]) ＞ 17[7,10]+1 ＞ 18 ＞ 成功 ＞ 命中レベルA ＞ [10]胴"
 rands = [
-  { sides = 10, value = 6 },
   { sides = 10, value = 7 },
   { sides = 10, value = 10 },
   { sides = 10, value = 8 },
@@ -1710,10 +1660,9 @@ rands = [
 
 [[ test ]]
 game_system = "EmbryoMachine"
-input = "EM[1...10]+1@19#3"
+input = "EM2+1@19#3"
 output = "(2R10+1>=2[19,3]) ＞ 10[4,6]+1 ＞ 11 ＞ 成功 ＞ 命中レベルC ＞ [10]胴"
 rands = [
-  { sides = 10, value = 2 },
   { sides = 10, value = 6 },
   { sides = 10, value = 4 },
   { sides = 10, value = 4 },
@@ -1722,11 +1671,10 @@ rands = [
 
 [[ test ]]
 game_system = "EmbryoMachine"
-input = "EM[1...10]+1@19#3"
+input = "EM6+1@19#3"
 output = "(2R10+1>=6[19,3]) ＞ 16[6,10]+1 ＞ 17 ＞ 成功 ＞ 命中レベルA ＞ [14]右腕"
 rands = [
   { sides = 10, value = 6 },
-  { sides = 10, value = 6 },
   { sides = 10, value = 10 },
   { sides = 10, value = 8 },
   { sides = 10, value = 6 },
@@ -1734,10 +1682,9 @@ rands = [
 
 [[ test ]]
 game_system = "EmbryoMachine"
-input = "EM[1...10]+1@19#3"
+input = "EM6+1@19#3"
 output = "(2R10+1>=6[19,3]) ＞ 9[1,8]+1 ＞ 10 ＞ 成功 ＞ 命中レベルB ＞ [9]左腕"
 rands = [
-  { sides = 10, value = 6 },
   { sides = 10, value = 1 },
   { sides = 10, value = 8 },
   { sides = 10, value = 5 },
@@ -1746,10 +1693,9 @@ rands = [
 
 [[ test ]]
 game_system = "EmbryoMachine"
-input = "EM[1...10]+1@19#3"
+input = "EM5+1@19#3"
 output = "(2R10+1>=5[19,3]) ＞ 14[6,8]+1 ＞ 15 ＞ 成功 ＞ 命中レベルB ＞ [9]左腕"
 rands = [
-  { sides = 10, value = 5 },
   { sides = 10, value = 8 },
   { sides = 10, value = 6 },
   { sides = 10, value = 5 },
@@ -1758,10 +1704,9 @@ rands = [
 
 [[ test ]]
 game_system = "EmbryoMachine"
-input = "EM[1...10]+1@19#3"
+input = "EM7+1@19#3"
 output = "(2R10+1>=7[19,3]) ＞ 10[4,6]+1 ＞ 11 ＞ 成功 ＞ 命中レベルC ＞ [7]左脚"
 rands = [
-  { sides = 10, value = 7 },
   { sides = 10, value = 4 },
   { sides = 10, value = 6 },
   { sides = 10, value = 5 },
@@ -1770,10 +1715,9 @@ rands = [
 
 [[ test ]]
 game_system = "EmbryoMachine"
-input = "EM[1...10]+1@19#3"
+input = "EM6+1@19#3"
 output = "(2R10+1>=6[19,3]) ＞ 11[3,8]+1 ＞ 12 ＞ 成功 ＞ 命中レベルB ＞ [12]胴"
 rands = [
-  { sides = 10, value = 6 },
   { sides = 10, value = 8 },
   { sides = 10, value = 3 },
   { sides = 10, value = 4 },
@@ -1782,10 +1726,9 @@ rands = [
 
 [[ test ]]
 game_system = "EmbryoMachine"
-input = "EM[1...10]+1@19#3"
+input = "EM4+1@19#3"
 output = "(2R10+1>=4[19,3]) ＞ 16[6,10]+1 ＞ 17 ＞ 成功 ＞ 命中レベルA ＞ [4]頭"
 rands = [
-  { sides = 10, value = 4 },
   { sides = 10, value = 6 },
   { sides = 10, value = 10 },
   { sides = 10, value = 3 },
@@ -1794,10 +1737,9 @@ rands = [
 
 [[ test ]]
 game_system = "EmbryoMachine"
-input = "EM[1...10]+1@19#3"
+input = "EM2+1@19#3"
 output = "(2R10+1>=2[19,3]) ＞ 7[3,4]+1 ＞ 8 ＞ 成功 ＞ 命中レベルC ＞ [13]右腕"
 rands = [
-  { sides = 10, value = 2 },
   { sides = 10, value = 3 },
   { sides = 10, value = 4 },
   { sides = 10, value = 9 },
@@ -1806,10 +1748,9 @@ rands = [
 
 [[ test ]]
 game_system = "EmbryoMachine"
-input = "EM[1...10]+1@19#3"
+input = "EM1+1@19#3"
 output = "(2R10+1>=1[19,3]) ＞ 10[4,6]+1 ＞ 11 ＞ 成功 ＞ 命中レベルC ＞ [9]左腕"
 rands = [
-  { sides = 10, value = 1 },
   { sides = 10, value = 4 },
   { sides = 10, value = 6 },
   { sides = 10, value = 5 },
@@ -1818,10 +1759,9 @@ rands = [
 
 [[ test ]]
 game_system = "EmbryoMachine"
-input = "EM[1...10]+1@19#3"
+input = "EM8+1@19#3"
 output = "(2R10+1>=8[19,3]) ＞ 12[5,7]+1 ＞ 13 ＞ 成功 ＞ 命中レベルB ＞ [11]胴"
 rands = [
-  { sides = 10, value = 8 },
   { sides = 10, value = 7 },
   { sides = 10, value = 5 },
   { sides = 10, value = 3 },
@@ -1830,10 +1770,9 @@ rands = [
 
 [[ test ]]
 game_system = "EmbryoMachine"
-input = "EM[1...10]+2@20#2"
+input = "EM4+2@20#2"
 output = "(2R10+2>=4[20,2]) ＞ 10[2,8]+2 ＞ 12 ＞ 成功 ＞ 命中レベルB ＞ [10]胴"
 rands = [
-  { sides = 10, value = 4 },
   { sides = 10, value = 2 },
   { sides = 10, value = 8 },
   { sides = 10, value = 7 },
@@ -1842,10 +1781,9 @@ rands = [
 
 [[ test ]]
 game_system = "EmbryoMachine"
-input = "EM[1...10]+2@20#2"
+input = "EM6+2@20#2"
 output = "(2R10+2>=6[20,2]) ＞ 13[3,10]+2 ＞ 15 ＞ 成功 ＞ 命中レベルA ＞ [10]胴"
 rands = [
-  { sides = 10, value = 6 },
   { sides = 10, value = 10 },
   { sides = 10, value = 3 },
   { sides = 10, value = 4 },
@@ -1854,10 +1792,9 @@ rands = [
 
 [[ test ]]
 game_system = "EmbryoMachine"
-input = "EM[1...10]+2@20#2"
+input = "EM1+2@20#2"
 output = "(2R10+2>=1[20,2]) ＞ 18[9,9]+2 ＞ 20 ＞ 成功 ＞ 命中レベルB ＞ [10]胴"
 rands = [
-  { sides = 10, value = 1 },
   { sides = 10, value = 9 },
   { sides = 10, value = 9 },
   { sides = 10, value = 9 },
@@ -1866,11 +1803,10 @@ rands = [
 
 [[ test ]]
 game_system = "EmbryoMachine"
-input = "EM[1...10]+2@20#2"
+input = "EM10+2@20#2"
 output = "(2R10+2>=10[20,2]) ＞ 18[8,10]+2 ＞ 20 ＞ 成功 ＞ 命中レベルA ＞ [12]胴"
 rands = [
   { sides = 10, value = 10 },
-  { sides = 10, value = 10 },
   { sides = 10, value = 8 },
   { sides = 10, value = 7 },
   { sides = 10, value = 5 },
@@ -1878,10 +1814,9 @@ rands = [
 
 [[ test ]]
 game_system = "EmbryoMachine"
-input = "EM[1...10]+2@20#2"
+input = "EM7+2@20#2"
 output = "(2R10+2>=7[20,2]) ＞ 14[5,9]+2 ＞ 16 ＞ 成功 ＞ 命中レベルB ＞ [11]胴"
 rands = [
-  { sides = 10, value = 7 },
   { sides = 10, value = 9 },
   { sides = 10, value = 5 },
   { sides = 10, value = 5 },
@@ -1890,10 +1825,9 @@ rands = [
 
 [[ test ]]
 game_system = "EmbryoMachine"
-input = "EM[1...10]+2@20#2"
+input = "EM4+2@20#2"
 output = "(2R10+2>=4[20,2]) ＞ 8[1,7]+2 ＞ 10 ＞ 成功 ＞ 命中レベルB ＞ [8]左腕"
 rands = [
-  { sides = 10, value = 4 },
   { sides = 10, value = 1 },
   { sides = 10, value = 7 },
   { sides = 10, value = 5 },
@@ -1902,10 +1836,9 @@ rands = [
 
 [[ test ]]
 game_system = "EmbryoMachine"
-input = "EM[1...10]+2@20#2"
+input = "EM4+2@20#2"
 output = "(2R10+2>=4[20,2]) ＞ 12[2,10]+2 ＞ 14 ＞ 成功 ＞ 命中レベルA ＞ [14]右腕"
 rands = [
-  { sides = 10, value = 4 },
   { sides = 10, value = 2 },
   { sides = 10, value = 10 },
   { sides = 10, value = 8 },
@@ -1914,10 +1847,9 @@ rands = [
 
 [[ test ]]
 game_system = "EmbryoMachine"
-input = "EM[1...10]+2@20#2"
+input = "EM8+2@20#2"
 output = "(2R10+2>=8[20,2]) ＞ 9[2,7]+2 ＞ 11 ＞ 成功 ＞ 命中レベルB ＞ [10]胴"
 rands = [
-  { sides = 10, value = 8 },
   { sides = 10, value = 2 },
   { sides = 10, value = 7 },
   { sides = 10, value = 2 },
@@ -1926,10 +1858,9 @@ rands = [
 
 [[ test ]]
 game_system = "EmbryoMachine"
-input = "EM[1...10]+2@20#2"
+input = "EM1+2@20#2"
 output = "(2R10+2>=1[20,2]) ＞ 12[6,6]+2 ＞ 14 ＞ 成功 ＞ 命中レベルC ＞ [9]左腕"
 rands = [
-  { sides = 10, value = 1 },
   { sides = 10, value = 6 },
   { sides = 10, value = 6 },
   { sides = 10, value = 1 },
@@ -1938,10 +1869,9 @@ rands = [
 
 [[ test ]]
 game_system = "EmbryoMachine"
-input = "EM[1...10]+2@20#2"
+input = "EM2+2@20#2"
 output = "(2R10+2>=2[20,2]) ＞ 7[1,6]+2 ＞ 9 ＞ 成功 ＞ 命中レベルC ＞ [5]左脚"
 rands = [
-  { sides = 10, value = 2 },
   { sides = 10, value = 6 },
   { sides = 10, value = 1 },
   { sides = 10, value = 1 },
@@ -1950,10 +1880,9 @@ rands = [
 
 [[ test ]]
 game_system = "EmbryoMachine"
-input = "EM[1...10]-1@20#2"
+input = "EM8-1@20#2"
 output = "(2R10-1>=8[20,2]) ＞ 11[2,9]-1 ＞ 10 ＞ 成功 ＞ 命中レベルB ＞ [8]左腕"
 rands = [
-  { sides = 10, value = 8 },
   { sides = 10, value = 9 },
   { sides = 10, value = 2 },
   { sides = 10, value = 7 },
@@ -1962,10 +1891,9 @@ rands = [
 
 [[ test ]]
 game_system = "EmbryoMachine"
-input = "EM[1...10]-1@20#2"
+input = "EM4-1@20#2"
 output = "(2R10-1>=4[20,2]) ＞ 9[1,8]-1 ＞ 8 ＞ 成功 ＞ 命中レベルB ＞ [14]右腕"
 rands = [
-  { sides = 10, value = 4 },
   { sides = 10, value = 1 },
   { sides = 10, value = 8 },
   { sides = 10, value = 6 },
@@ -1974,10 +1902,9 @@ rands = [
 
 [[ test ]]
 game_system = "EmbryoMachine"
-input = "EM[1...10]-1@20#2"
+input = "EM4-1@20#2"
 output = "(2R10-1>=4[20,2]) ＞ 16[6,10]-1 ＞ 15 ＞ 成功 ＞ 命中レベルA ＞ [14]右腕"
 rands = [
-  { sides = 10, value = 4 },
   { sides = 10, value = 10 },
   { sides = 10, value = 6 },
   { sides = 10, value = 8 },
@@ -1986,10 +1913,9 @@ rands = [
 
 [[ test ]]
 game_system = "EmbryoMachine"
-input = "EM[1...10]-1@20#2"
+input = "EM7-1@20#2"
 output = "(2R10-1>=7[20,2]) ＞ 10[4,6]-1 ＞ 9 ＞ 成功 ＞ 命中レベルC ＞ [8]左腕"
 rands = [
-  { sides = 10, value = 7 },
   { sides = 10, value = 6 },
   { sides = 10, value = 4 },
   { sides = 10, value = 3 },
@@ -1998,10 +1924,9 @@ rands = [
 
 [[ test ]]
 game_system = "EmbryoMachine"
-input = "EM[1...10]-1@20#2"
+input = "EM6-1@20#2"
 output = "(2R10-1>=6[20,2]) ＞ 12[3,9]-1 ＞ 11 ＞ 成功 ＞ 命中レベルB ＞ [15]右脚"
 rands = [
-  { sides = 10, value = 6 },
   { sides = 10, value = 9 },
   { sides = 10, value = 3 },
   { sides = 10, value = 9 },
@@ -2010,10 +1935,9 @@ rands = [
 
 [[ test ]]
 game_system = "EmbryoMachine"
-input = "EM[1...10]-1@20#2"
+input = "EM1-1@20#2"
 output = "(2R10-1>=1[20,2]) ＞ 10[4,6]-1 ＞ 9 ＞ 成功 ＞ 命中レベルC ＞ [3]頭"
 rands = [
-  { sides = 10, value = 1 },
   { sides = 10, value = 6 },
   { sides = 10, value = 4 },
   { sides = 10, value = 1 },
@@ -2022,10 +1946,9 @@ rands = [
 
 [[ test ]]
 game_system = "EmbryoMachine"
-input = "EM[1...10]-1@20#2"
+input = "EM8-1@20#2"
 output = "(2R10-1>=8[20,2]) ＞ 6[1,5]-1 ＞ 5 ＞ 失敗"
 rands = [
-  { sides = 10, value = 8 },
   { sides = 10, value = 1 },
   { sides = 10, value = 5 },
   { sides = 10, value = 2 },
@@ -2034,10 +1957,9 @@ rands = [
 
 [[ test ]]
 game_system = "EmbryoMachine"
-input = "EM[1...10]-1@20#2"
+input = "EM2-1@20#2"
 output = "(2R10-1>=2[20,2]) ＞ 15[6,9]-1 ＞ 14 ＞ 成功 ＞ 命中レベルB ＞ [11]胴"
 rands = [
-  { sides = 10, value = 2 },
   { sides = 10, value = 6 },
   { sides = 10, value = 9 },
   { sides = 10, value = 1 },
@@ -2046,10 +1968,9 @@ rands = [
 
 [[ test ]]
 game_system = "EmbryoMachine"
-input = "EM[1...10]-1@20#2"
+input = "EM3-1@20#2"
 output = "(2R10-1>=3[20,2]) ＞ 14[7,7]-1 ＞ 13 ＞ 成功 ＞ 命中レベルB ＞ [9]左腕"
 rands = [
-  { sides = 10, value = 3 },
   { sides = 10, value = 7 },
   { sides = 10, value = 7 },
   { sides = 10, value = 3 },
@@ -2058,10 +1979,9 @@ rands = [
 
 [[ test ]]
 game_system = "EmbryoMachine"
-input = "EM[1...10]-1@20#2"
+input = "EM8-1@20#2"
 output = "(2R10-1>=8[20,2]) ＞ 19[9,10]-1 ＞ 18 ＞ 成功 ＞ 命中レベルA ＞ [10]胴"
 rands = [
-  { sides = 10, value = 8 },
   { sides = 10, value = 9 },
   { sides = 10, value = 10 },
   { sides = 10, value = 1 },
@@ -2070,13 +1990,9 @@ rands = [
 
 [[ test ]]
 game_system = "EmbryoMachine"
-input = "EM[1...10]+[1...5]@[18...20]#[1...3]"
+input = "EM4+4@19#2"
 output = "(2R10+4>=4[19,2]) ＞ 12[6,6]+4 ＞ 16 ＞ 成功 ＞ 命中レベルC ＞ [3]頭"
 rands = [
-  { sides = 10, value = 4 },
-  { sides = 5, value = 4 },
-  { sides = 3, value = 2 },
-  { sides = 3, value = 2 },
   { sides = 10, value = 6 },
   { sides = 10, value = 6 },
   { sides = 10, value = 2 },
@@ -2085,13 +2001,9 @@ rands = [
 
 [[ test ]]
 game_system = "EmbryoMachine"
-input = "EM[1...10]+[1...5]@[18...20]#[1...3]"
+input = "EM8+1@19#1"
 output = "(2R10+1>=8[19,1]) ＞ 10[2,8]+1 ＞ 11 ＞ 成功 ＞ 命中レベルB ＞ [10]胴"
 rands = [
-  { sides = 10, value = 8 },
-  { sides = 5, value = 1 },
-  { sides = 3, value = 2 },
-  { sides = 3, value = 1 },
   { sides = 10, value = 2 },
   { sides = 10, value = 8 },
   { sides = 10, value = 4 },
@@ -2100,13 +2012,9 @@ rands = [
 
 [[ test ]]
 game_system = "EmbryoMachine"
-input = "EM[1...10]+[1...5]@[18...20]#[1...3]"
+input = "EM7+3@19#3"
 output = "(2R10+3>=7[19,3]) ＞ 7[1,6]+3 ＞ 10 ＞ 成功 ＞ 命中レベルC ＞ [6]左脚"
 rands = [
-  { sides = 10, value = 7 },
-  { sides = 5, value = 3 },
-  { sides = 3, value = 2 },
-  { sides = 3, value = 3 },
   { sides = 10, value = 1 },
   { sides = 10, value = 6 },
   { sides = 10, value = 4 },
@@ -2115,13 +2023,9 @@ rands = [
 
 [[ test ]]
 game_system = "EmbryoMachine"
-input = "EM[1...10]+[1...5]@[18...20]#[1...3]"
+input = "EM10+1@19#2"
 output = "(2R10+1>=10[19,2]) ＞ 3[1,2]+1 ＞ 4 ＞ 失敗"
 rands = [
-  { sides = 10, value = 10 },
-  { sides = 5, value = 1 },
-  { sides = 3, value = 2 },
-  { sides = 3, value = 2 },
   { sides = 10, value = 2 },
   { sides = 10, value = 1 },
   { sides = 10, value = 1 },
@@ -2130,13 +2034,9 @@ rands = [
 
 [[ test ]]
 game_system = "EmbryoMachine"
-input = "EM[1...10]+[1...5]@[18...20]#[1...3]"
+input = "EM2+2@20#2"
 output = "(2R10+2>=2[20,2]) ＞ 13[4,9]+2 ＞ 15 ＞ 成功 ＞ 命中レベルB ＞ [17]右脚"
 rands = [
-  { sides = 10, value = 2 },
-  { sides = 5, value = 2 },
-  { sides = 3, value = 3 },
-  { sides = 3, value = 2 },
   { sides = 10, value = 4 },
   { sides = 10, value = 9 },
   { sides = 10, value = 7 },
@@ -2145,14 +2045,10 @@ rands = [
 
 [[ test ]]
 game_system = "EmbryoMachine"
-input = "EM[1...10]+[1...5]@[18...20]#[1...3]"
+input = "EM8+3@20#2"
 output = "(2R10+3>=8[20,2]) ＞ 11[3,8]+3 ＞ 14 ＞ 成功 ＞ 命中レベルB ＞ [4]頭"
 rands = [
   { sides = 10, value = 8 },
-  { sides = 5, value = 3 },
-  { sides = 3, value = 3 },
-  { sides = 3, value = 2 },
-  { sides = 10, value = 8 },
   { sides = 10, value = 3 },
   { sides = 10, value = 1 },
   { sides = 10, value = 3 },
@@ -2160,13 +2056,9 @@ rands = [
 
 [[ test ]]
 game_system = "EmbryoMachine"
-input = "EM[1...10]+[1...5]@[18...20]#[1...3]"
+input = "EM5+3@18#2"
 output = "(2R10+3>=5[18,2]) ＞ 9[1,8]+3 ＞ 12 ＞ 成功 ＞ 命中レベルB ＞ [13]右腕"
 rands = [
-  { sides = 10, value = 5 },
-  { sides = 5, value = 3 },
-  { sides = 3, value = 1 },
-  { sides = 3, value = 2 },
   { sides = 10, value = 1 },
   { sides = 10, value = 8 },
   { sides = 10, value = 9 },
@@ -2175,13 +2067,9 @@ rands = [
 
 [[ test ]]
 game_system = "EmbryoMachine"
-input = "EM[1...10]+[1...5]@[18...20]#[1...3]"
+input = "EM7+5@18#1"
 output = "(2R10+5>=7[18,1]) ＞ 10[3,7]+5 ＞ 15 ＞ 成功 ＞ 命中レベルB ＞ [15]右脚"
 rands = [
-  { sides = 10, value = 7 },
-  { sides = 5, value = 5 },
-  { sides = 3, value = 1 },
-  { sides = 3, value = 1 },
   { sides = 10, value = 3 },
   { sides = 10, value = 7 },
   { sides = 10, value = 5 },
@@ -2190,13 +2078,9 @@ rands = [
 
 [[ test ]]
 game_system = "EmbryoMachine"
-input = "EM[1...10]+[1...5]@[18...20]#[1...3]"
+input = "EM9+2@18#3"
 output = "(2R10+2>=9[18,3]) ＞ 11[5,6]+2 ＞ 13 ＞ 成功 ＞ 命中レベルC ＞ [14]右腕"
 rands = [
-  { sides = 10, value = 9 },
-  { sides = 5, value = 2 },
-  { sides = 3, value = 1 },
-  { sides = 3, value = 3 },
   { sides = 10, value = 5 },
   { sides = 10, value = 6 },
   { sides = 10, value = 9 },
@@ -2205,13 +2089,9 @@ rands = [
 
 [[ test ]]
 game_system = "EmbryoMachine"
-input = "EM[1...10]+[1...5]@[18...20]#[1...3]"
+input = "EM2+4@19#3"
 output = "(2R10+4>=2[19,3]) ＞ 13[6,7]+4 ＞ 17 ＞ 成功 ＞ 命中レベルB ＞ [13]右腕"
 rands = [
-  { sides = 10, value = 2 },
-  { sides = 5, value = 4 },
-  { sides = 3, value = 2 },
-  { sides = 3, value = 3 },
   { sides = 10, value = 7 },
   { sides = 10, value = 6 },
   { sides = 10, value = 7 },

--- a/test/data/GehennaAn.toml
+++ b/test/data/GehennaAn.toml
@@ -178,12 +178,9 @@ rands = [
 
 [[ test ]]
 game_system = "GehennaAn"
-input = "[1...20]GA[1...20]+[1...10]"
+input = "14GA1+2"
 output = "(14R6+2>=1[1]) ＞ 14[1,2,3,4,4,4,4,4,6,6,6,6,6,6]+2 ＞ 成功16、失敗0 ＞ 連撃[+7]/闘技[3]"
 rands = [
-  { sides = 20, value = 14 },
-  { sides = 20, value = 1 },
-  { sides = 10, value = 2 },
   { sides = 6, value = 6 },
   { sides = 6, value = 4 },
   { sides = 6, value = 4 },
@@ -202,12 +199,9 @@ rands = [
 
 [[ test ]]
 game_system = "GehennaAn"
-input = "[1...20]GA[1...20]-[1...10]"
+input = "20GA4-4"
 output = "(20R6-4>=4[1]) ＞ 11[1,1,1,2,2,2,3,3,3,4,4,4,4,4,5,5,5,6,6,6]-4 ＞ 成功7、失敗9 ＞ 連撃[+3]/闘技[2]"
 rands = [
-  { sides = 20, value = 20 },
-  { sides = 20, value = 4 },
-  { sides = 10, value = 4 },
   { sides = 6, value = 4 },
   { sides = 6, value = 6 },
   { sides = 6, value = 5 },

--- a/test/data/Nechronica.toml
+++ b/test/data/Nechronica.toml
@@ -730,10 +730,9 @@ rands = [
 
 [[ test ]]
 game_system = "Nechronica"
-input = "[1...5]NC"
+input = "5NC"
 output = "(5R10[0]) ＞ [3,6,8,8,9]  ＞ 9[3,6,8,8,9] ＞ 成功"
 rands = [
-  { sides = 5, value = 5 },
   { sides = 10, value = 3 },
   { sides = 10, value = 8 },
   { sides = 10, value = 8 },
@@ -743,19 +742,17 @@ rands = [
 
 [[ test ]]
 game_system = "Nechronica"
-input = "[1...5]NC"
+input = "1NC"
 output = "(1R10[0]) ＞ [5]  ＞ 5[5] ＞ 失敗"
 rands = [
-  { sides = 5, value = 1 },
   { sides = 10, value = 5 },
 ]
 
 [[ test ]]
 game_system = "Nechronica"
-input = "[1...5]NC"
+input = "4NC"
 output = "(4R10[0]) ＞ [1,5,6,7]  ＞ 7[1,5,6,7] ＞ 成功"
 rands = [
-  { sides = 5, value = 4 },
   { sides = 10, value = 6 },
   { sides = 10, value = 7 },
   { sides = 10, value = 1 },
@@ -764,10 +761,9 @@ rands = [
 
 [[ test ]]
 game_system = "Nechronica"
-input = "[1...5]NC"
+input = "4NC"
 output = "(4R10[0]) ＞ [1,2,4,8]  ＞ 8[1,2,4,8] ＞ 成功"
 rands = [
-  { sides = 5, value = 4 },
   { sides = 10, value = 1 },
   { sides = 10, value = 8 },
   { sides = 10, value = 2 },
@@ -776,10 +772,9 @@ rands = [
 
 [[ test ]]
 game_system = "Nechronica"
-input = "[1...5]NC"
+input = "3NC"
 output = "(3R10[0]) ＞ [4,8,9]  ＞ 9[4,8,9] ＞ 成功"
 rands = [
-  { sides = 5, value = 3 },
   { sides = 10, value = 4 },
   { sides = 10, value = 8 },
   { sides = 10, value = 9 },
@@ -787,10 +782,9 @@ rands = [
 
 [[ test ]]
 game_system = "Nechronica"
-input = "[1...5]NC"
+input = "3NC"
 output = "(3R10[0]) ＞ [6,9,9]  ＞ 9[6,9,9] ＞ 成功"
 rands = [
-  { sides = 5, value = 3 },
   { sides = 10, value = 9 },
   { sides = 10, value = 6 },
   { sides = 10, value = 9 },
@@ -798,10 +792,9 @@ rands = [
 
 [[ test ]]
 game_system = "Nechronica"
-input = "[1...5]NC"
+input = "5NC"
 output = "(5R10[0]) ＞ [1,2,4,8,9]  ＞ 9[1,2,4,8,9] ＞ 成功"
 rands = [
-  { sides = 5, value = 5 },
   { sides = 10, value = 8 },
   { sides = 10, value = 1 },
   { sides = 10, value = 2 },
@@ -811,20 +804,18 @@ rands = [
 
 [[ test ]]
 game_system = "Nechronica"
-input = "[1...5]NC"
+input = "2NC"
 output = "(2R10[0]) ＞ [2,7]  ＞ 7[2,7] ＞ 成功"
 rands = [
-  { sides = 5, value = 2 },
   { sides = 10, value = 7 },
   { sides = 10, value = 2 },
 ]
 
 [[ test ]]
 game_system = "Nechronica"
-input = "[1...5]NC"
+input = "5NC"
 output = "(5R10[0]) ＞ [3,5,7,8,10]  ＞ 10[3,5,7,8,10] ＞ 成功"
 rands = [
-  { sides = 5, value = 5 },
   { sides = 10, value = 8 },
   { sides = 10, value = 10 },
   { sides = 10, value = 5 },
@@ -834,10 +825,9 @@ rands = [
 
 [[ test ]]
 game_system = "Nechronica"
-input = "[1...5]NC"
+input = "4NC"
 output = "(4R10[0]) ＞ [1,6,6,10]  ＞ 10[1,6,6,10] ＞ 成功"
 rands = [
-  { sides = 5, value = 4 },
   { sides = 10, value = 6 },
   { sides = 10, value = 10 },
   { sides = 10, value = 1 },
@@ -846,22 +836,18 @@ rands = [
 
 [[ test ]]
 game_system = "Nechronica"
-input = "[1...5]NC+[1...5]"
+input = "2NC+1"
 output = "(2R10+1[0]) ＞ [2,5]+1  ＞ 6[3,6] ＞ 成功"
 rands = [
-  { sides = 5, value = 2 },
-  { sides = 5, value = 1 },
   { sides = 10, value = 5 },
   { sides = 10, value = 2 },
 ]
 
 [[ test ]]
 game_system = "Nechronica"
-input = "[1...5]NC+[1...5]"
+input = "4NC+3"
 output = "(4R10+3[0]) ＞ [5,6,6,10]+3  ＞ 13[8,9,9,13] ＞ 大成功"
 rands = [
-  { sides = 5, value = 4 },
-  { sides = 5, value = 3 },
   { sides = 10, value = 10 },
   { sides = 10, value = 6 },
   { sides = 10, value = 5 },
@@ -870,11 +856,9 @@ rands = [
 
 [[ test ]]
 game_system = "Nechronica"
-input = "[1...5]NC+[1...5]"
+input = "3NC+5"
 output = "(3R10+5[0]) ＞ [2,5,9]+5  ＞ 14[7,10,14] ＞ 大成功"
 rands = [
-  { sides = 5, value = 3 },
-  { sides = 5, value = 5 },
   { sides = 10, value = 9 },
   { sides = 10, value = 2 },
   { sides = 10, value = 5 },
@@ -882,11 +866,9 @@ rands = [
 
 [[ test ]]
 game_system = "Nechronica"
-input = "[1...5]NC+[1...5]"
+input = "4NC+3"
 output = "(4R10+3[0]) ＞ [2,2,6,8]+3  ＞ 11[5,5,9,11] ＞ 大成功"
 rands = [
-  { sides = 5, value = 4 },
-  { sides = 5, value = 3 },
   { sides = 10, value = 6 },
   { sides = 10, value = 2 },
   { sides = 10, value = 2 },
@@ -895,11 +877,9 @@ rands = [
 
 [[ test ]]
 game_system = "Nechronica"
-input = "[1...5]NC+[1...5]"
+input = "5NC+2"
 output = "(5R10+2[0]) ＞ [1,3,6,7,8]+2  ＞ 10[3,5,8,9,10] ＞ 成功"
 rands = [
-  { sides = 5, value = 5 },
-  { sides = 5, value = 2 },
   { sides = 10, value = 8 },
   { sides = 10, value = 6 },
   { sides = 10, value = 7 },
@@ -909,32 +889,26 @@ rands = [
 
 [[ test ]]
 game_system = "Nechronica"
-input = "[1...5]NC+[1...5]"
+input = "2NC+5"
 output = "(2R10+5[0]) ＞ [2,3]+5  ＞ 8[7,8] ＞ 成功"
 rands = [
-  { sides = 5, value = 2 },
-  { sides = 5, value = 5 },
   { sides = 10, value = 3 },
   { sides = 10, value = 2 },
 ]
 
 [[ test ]]
 game_system = "Nechronica"
-input = "[1...5]NC+[1...5]"
+input = "1NC+5"
 output = "(1R10+5[0]) ＞ [4]+5  ＞ 9[9] ＞ 成功"
 rands = [
-  { sides = 5, value = 1 },
-  { sides = 5, value = 5 },
   { sides = 10, value = 4 },
 ]
 
 [[ test ]]
 game_system = "Nechronica"
-input = "[1...5]NC+[1...5]"
+input = "4NC+5"
 output = "(4R10+5[0]) ＞ [1,3,8,9]+5  ＞ 14[6,8,13,14] ＞ 大成功"
 rands = [
-  { sides = 5, value = 4 },
-  { sides = 5, value = 5 },
   { sides = 10, value = 9 },
   { sides = 10, value = 1 },
   { sides = 10, value = 8 },
@@ -943,11 +917,9 @@ rands = [
 
 [[ test ]]
 game_system = "Nechronica"
-input = "[1...5]NC+[1...5]"
+input = "4NC+4"
 output = "(4R10+4[0]) ＞ [2,5,6,8]+4  ＞ 12[6,9,10,12] ＞ 大成功"
 rands = [
-  { sides = 5, value = 4 },
-  { sides = 5, value = 4 },
   { sides = 10, value = 8 },
   { sides = 10, value = 6 },
   { sides = 10, value = 2 },
@@ -956,11 +928,9 @@ rands = [
 
 [[ test ]]
 game_system = "Nechronica"
-input = "[1...5]NC+[1...5]"
+input = "1NC+5"
 output = "(1R10+5[0]) ＞ [7]+5  ＞ 12[12] ＞ 大成功"
 rands = [
-  { sides = 5, value = 1 },
-  { sides = 5, value = 5 },
   { sides = 10, value = 7 },
 ]
 
@@ -1326,10 +1296,9 @@ rands = [
 
 [[ test ]]
 game_system = "Nechronica"
-input = "[1...5]NA"
+input = "4NA"
 output = "(4R10[1]) ＞ [1,1,2,10]  ＞ 10[1,1,2,10] ＞ 成功 ＞ 頭（なければ攻撃側任意）"
 rands = [
-  { sides = 5, value = 4 },
   { sides = 10, value = 1 },
   { sides = 10, value = 10 },
   { sides = 10, value = 1 },
@@ -1338,10 +1307,9 @@ rands = [
 
 [[ test ]]
 game_system = "Nechronica"
-input = "[1...5]NA"
+input = "3NA"
 output = "(3R10[1]) ＞ [4,10,10]  ＞ 10[4,10,10] ＞ 成功 ＞ 頭（なければ攻撃側任意）"
 rands = [
-  { sides = 5, value = 3 },
   { sides = 10, value = 4 },
   { sides = 10, value = 10 },
   { sides = 10, value = 10 },
@@ -1349,10 +1317,9 @@ rands = [
 
 [[ test ]]
 game_system = "Nechronica"
-input = "[1...5]NA"
+input = "4NA"
 output = "(4R10[1]) ＞ [5,6,7,9]  ＞ 9[5,6,7,9] ＞ 成功 ＞ 腕（なければ攻撃側任意）"
 rands = [
-  { sides = 5, value = 4 },
   { sides = 10, value = 6 },
   { sides = 10, value = 7 },
   { sides = 10, value = 5 },
@@ -1361,29 +1328,26 @@ rands = [
 
 [[ test ]]
 game_system = "Nechronica"
-input = "[1...5]NA"
+input = "1NA"
 output = "(1R10[1]) ＞ [3]  ＞ 3[3] ＞ 失敗"
 rands = [
-  { sides = 5, value = 1 },
   { sides = 10, value = 3 },
 ]
 
 [[ test ]]
 game_system = "Nechronica"
-input = "[1...5]NA"
+input = "2NA"
 output = "(2R10[1]) ＞ [1,3]  ＞ 3[1,3] ＞ 大失敗 ＞ 使用パーツ全損"
 rands = [
-  { sides = 5, value = 2 },
   { sides = 10, value = 1 },
   { sides = 10, value = 3 },
 ]
 
 [[ test ]]
 game_system = "Nechronica"
-input = "[1...5]NA"
+input = "5NA"
 output = "(5R10[1]) ＞ [4,5,5,6,7]  ＞ 7[4,5,5,6,7] ＞ 成功 ＞ 脚（なければ攻撃側任意）"
 rands = [
-  { sides = 5, value = 5 },
   { sides = 10, value = 7 },
   { sides = 10, value = 4 },
   { sides = 10, value = 5 },
@@ -1393,10 +1357,9 @@ rands = [
 
 [[ test ]]
 game_system = "Nechronica"
-input = "[1...5]NA"
+input = "4NA"
 output = "(4R10[1]) ＞ [1,1,2,5]  ＞ 5[1,1,2,5] ＞ 大失敗 ＞ 使用パーツ全損"
 rands = [
-  { sides = 5, value = 4 },
   { sides = 10, value = 2 },
   { sides = 10, value = 1 },
   { sides = 10, value = 1 },
@@ -1405,19 +1368,17 @@ rands = [
 
 [[ test ]]
 game_system = "Nechronica"
-input = "[1...5]NA"
+input = "1NA"
 output = "(1R10[1]) ＞ [9]  ＞ 9[9] ＞ 成功 ＞ 腕（なければ攻撃側任意）"
 rands = [
-  { sides = 5, value = 1 },
   { sides = 10, value = 9 },
 ]
 
 [[ test ]]
 game_system = "Nechronica"
-input = "[1...5]NA"
+input = "3NA"
 output = "(3R10[1]) ＞ [1,5,8]  ＞ 8[1,5,8] ＞ 成功 ＞ 胴（なければ攻撃側任意）"
 rands = [
-  { sides = 5, value = 3 },
   { sides = 10, value = 8 },
   { sides = 10, value = 5 },
   { sides = 10, value = 1 },
@@ -1425,31 +1386,26 @@ rands = [
 
 [[ test ]]
 game_system = "Nechronica"
-input = "[1...5]NA"
+input = "2NA"
 output = "(2R10[1]) ＞ [5,6]  ＞ 6[5,6] ＞ 成功 ＞ 防御側任意"
 rands = [
-  { sides = 5, value = 2 },
   { sides = 10, value = 5 },
   { sides = 10, value = 6 },
 ]
 
 [[ test ]]
 game_system = "Nechronica"
-input = "[1...5]NA+[1...5]"
+input = "1NA+4"
 output = "(1R10+4[1]) ＞ [8]+4  ＞ 12[12] ＞ 大成功 ＞ 攻撃側任意(追加ダメージ2)"
 rands = [
-  { sides = 5, value = 1 },
-  { sides = 5, value = 4 },
   { sides = 10, value = 8 },
 ]
 
 [[ test ]]
 game_system = "Nechronica"
-input = "[1...5]NA+[1...5]"
+input = "3NA+5"
 output = "(3R10+5[1]) ＞ [5,6,8]+5  ＞ 13[10,11,13] ＞ 大成功 ＞ 攻撃側任意(追加ダメージ3)"
 rands = [
-  { sides = 5, value = 3 },
-  { sides = 5, value = 5 },
   { sides = 10, value = 8 },
   { sides = 10, value = 5 },
   { sides = 10, value = 6 },
@@ -1457,22 +1413,18 @@ rands = [
 
 [[ test ]]
 game_system = "Nechronica"
-input = "[1...5]NA+[1...5]"
+input = "2NA+1"
 output = "(2R10+1[1]) ＞ [4,7]+1  ＞ 8[5,8] ＞ 成功 ＞ 胴（なければ攻撃側任意）"
 rands = [
-  { sides = 5, value = 2 },
-  { sides = 5, value = 1 },
   { sides = 10, value = 4 },
   { sides = 10, value = 7 },
 ]
 
 [[ test ]]
 game_system = "Nechronica"
-input = "[1...5]NA+[1...5]"
+input = "5NA+4"
 output = "(5R10+4[1]) ＞ [1,4,8,9,9]+4  ＞ 13[5,8,12,13,13] ＞ 大成功 ＞ 攻撃側任意(追加ダメージ3)"
 rands = [
-  { sides = 5, value = 5 },
-  { sides = 5, value = 4 },
   { sides = 10, value = 4 },
   { sides = 10, value = 9 },
   { sides = 10, value = 8 },
@@ -1482,64 +1434,52 @@ rands = [
 
 [[ test ]]
 game_system = "Nechronica"
-input = "[1...5]NA+[1...5]"
+input = "2NA+4"
 output = "(2R10+4[1]) ＞ [3,3]+4  ＞ 7[7,7] ＞ 成功 ＞ 脚（なければ攻撃側任意）"
 rands = [
-  { sides = 5, value = 2 },
-  { sides = 5, value = 4 },
   { sides = 10, value = 3 },
   { sides = 10, value = 3 },
 ]
 
 [[ test ]]
 game_system = "Nechronica"
-input = "[1...5]NA+[1...5]"
+input = "1NA+1"
 output = "(1R10+1[1]) ＞ [1]+1  ＞ 2[2] ＞ 失敗"
 rands = [
-  { sides = 5, value = 1 },
-  { sides = 5, value = 1 },
   { sides = 10, value = 1 },
 ]
 
 [[ test ]]
 game_system = "Nechronica"
-input = "[1...5]NA+[1...5]"
+input = "2NA+1"
 output = "(2R10+1[1]) ＞ [4,5]+1  ＞ 6[5,6] ＞ 成功 ＞ 防御側任意"
 rands = [
-  { sides = 5, value = 2 },
-  { sides = 5, value = 1 },
   { sides = 10, value = 4 },
   { sides = 10, value = 5 },
 ]
 
 [[ test ]]
 game_system = "Nechronica"
-input = "[1...5]NA+[1...5]"
+input = "2NA+4"
 output = "(2R10+4[1]) ＞ [1,7]+4  ＞ 11[5,11] ＞ 大成功 ＞ 攻撃側任意(追加ダメージ1)"
 rands = [
-  { sides = 5, value = 2 },
-  { sides = 5, value = 4 },
   { sides = 10, value = 7 },
   { sides = 10, value = 1 },
 ]
 
 [[ test ]]
 game_system = "Nechronica"
-input = "[1...5]NA+[1...5]"
+input = "1NA+4"
 output = "(1R10+4[1]) ＞ [6]+4  ＞ 10[10] ＞ 成功 ＞ 頭（なければ攻撃側任意）"
 rands = [
-  { sides = 5, value = 1 },
-  { sides = 5, value = 4 },
   { sides = 10, value = 6 },
 ]
 
 [[ test ]]
 game_system = "Nechronica"
-input = "[1...5]NA+[1...5]"
+input = "1NA+5"
 output = "(1R10+5[1]) ＞ [3]+5  ＞ 8[8] ＞ 成功 ＞ 胴（なければ攻撃側任意）"
 rands = [
-  { sides = 5, value = 1 },
-  { sides = 5, value = 5 },
   { sides = 10, value = 3 },
 ]
 

--- a/test/data/Nechronica_Korean.toml
+++ b/test/data/Nechronica_Korean.toml
@@ -730,10 +730,9 @@ rands = [
 
 [[ test ]]
 game_system = "Nechronica:Korean"
-input = "[1...5]NC"
+input = "5NC"
 output = "(5R10[0]) ＞ [3,6,8,8,9]  ＞ 9[3,6,8,8,9] ＞ 성공"
 rands = [
-  { sides = 5, value = 5 },
   { sides = 10, value = 3 },
   { sides = 10, value = 8 },
   { sides = 10, value = 8 },
@@ -743,19 +742,17 @@ rands = [
 
 [[ test ]]
 game_system = "Nechronica:Korean"
-input = "[1...5]NC"
+input = "1NC"
 output = "(1R10[0]) ＞ [5]  ＞ 5[5] ＞ 실패"
 rands = [
-  { sides = 5, value = 1 },
   { sides = 10, value = 5 },
 ]
 
 [[ test ]]
 game_system = "Nechronica:Korean"
-input = "[1...5]NC"
+input = "4NC"
 output = "(4R10[0]) ＞ [1,5,6,7]  ＞ 7[1,5,6,7] ＞ 성공"
 rands = [
-  { sides = 5, value = 4 },
   { sides = 10, value = 6 },
   { sides = 10, value = 7 },
   { sides = 10, value = 1 },
@@ -764,10 +761,9 @@ rands = [
 
 [[ test ]]
 game_system = "Nechronica:Korean"
-input = "[1...5]NC"
+input = "4NC"
 output = "(4R10[0]) ＞ [1,2,4,8]  ＞ 8[1,2,4,8] ＞ 성공"
 rands = [
-  { sides = 5, value = 4 },
   { sides = 10, value = 1 },
   { sides = 10, value = 8 },
   { sides = 10, value = 2 },
@@ -776,10 +772,9 @@ rands = [
 
 [[ test ]]
 game_system = "Nechronica:Korean"
-input = "[1...5]NC"
+input = "3NC"
 output = "(3R10[0]) ＞ [4,8,9]  ＞ 9[4,8,9] ＞ 성공"
 rands = [
-  { sides = 5, value = 3 },
   { sides = 10, value = 4 },
   { sides = 10, value = 8 },
   { sides = 10, value = 9 },
@@ -787,10 +782,9 @@ rands = [
 
 [[ test ]]
 game_system = "Nechronica:Korean"
-input = "[1...5]NC"
+input = "3NC"
 output = "(3R10[0]) ＞ [6,9,9]  ＞ 9[6,9,9] ＞ 성공"
 rands = [
-  { sides = 5, value = 3 },
   { sides = 10, value = 9 },
   { sides = 10, value = 6 },
   { sides = 10, value = 9 },
@@ -798,10 +792,9 @@ rands = [
 
 [[ test ]]
 game_system = "Nechronica:Korean"
-input = "[1...5]NC"
+input = "5NC"
 output = "(5R10[0]) ＞ [1,2,4,8,9]  ＞ 9[1,2,4,8,9] ＞ 성공"
 rands = [
-  { sides = 5, value = 5 },
   { sides = 10, value = 8 },
   { sides = 10, value = 1 },
   { sides = 10, value = 2 },
@@ -811,20 +804,18 @@ rands = [
 
 [[ test ]]
 game_system = "Nechronica:Korean"
-input = "[1...5]NC"
+input = "2NC"
 output = "(2R10[0]) ＞ [2,7]  ＞ 7[2,7] ＞ 성공"
 rands = [
-  { sides = 5, value = 2 },
   { sides = 10, value = 7 },
   { sides = 10, value = 2 },
 ]
 
 [[ test ]]
 game_system = "Nechronica:Korean"
-input = "[1...5]NC"
+input = "5NC"
 output = "(5R10[0]) ＞ [3,5,7,8,10]  ＞ 10[3,5,7,8,10] ＞ 성공"
 rands = [
-  { sides = 5, value = 5 },
   { sides = 10, value = 8 },
   { sides = 10, value = 10 },
   { sides = 10, value = 5 },
@@ -834,10 +825,9 @@ rands = [
 
 [[ test ]]
 game_system = "Nechronica:Korean"
-input = "[1...5]NC"
+input = "4NC"
 output = "(4R10[0]) ＞ [1,6,6,10]  ＞ 10[1,6,6,10] ＞ 성공"
 rands = [
-  { sides = 5, value = 4 },
   { sides = 10, value = 6 },
   { sides = 10, value = 10 },
   { sides = 10, value = 1 },
@@ -846,22 +836,18 @@ rands = [
 
 [[ test ]]
 game_system = "Nechronica:Korean"
-input = "[1...5]NC+[1...5]"
+input = "2NC+1"
 output = "(2R10+1[0]) ＞ [2,5]+1  ＞ 6[3,6] ＞ 성공"
 rands = [
-  { sides = 5, value = 2 },
-  { sides = 5, value = 1 },
   { sides = 10, value = 5 },
   { sides = 10, value = 2 },
 ]
 
 [[ test ]]
 game_system = "Nechronica:Korean"
-input = "[1...5]NC+[1...5]"
+input = "4NC+3"
 output = "(4R10+3[0]) ＞ [5,6,6,10]+3  ＞ 13[8,9,9,13] ＞ 대성공"
 rands = [
-  { sides = 5, value = 4 },
-  { sides = 5, value = 3 },
   { sides = 10, value = 10 },
   { sides = 10, value = 6 },
   { sides = 10, value = 5 },
@@ -870,11 +856,9 @@ rands = [
 
 [[ test ]]
 game_system = "Nechronica:Korean"
-input = "[1...5]NC+[1...5]"
+input = "3NC+5"
 output = "(3R10+5[0]) ＞ [2,5,9]+5  ＞ 14[7,10,14] ＞ 대성공"
 rands = [
-  { sides = 5, value = 3 },
-  { sides = 5, value = 5 },
   { sides = 10, value = 9 },
   { sides = 10, value = 2 },
   { sides = 10, value = 5 },
@@ -882,11 +866,9 @@ rands = [
 
 [[ test ]]
 game_system = "Nechronica:Korean"
-input = "[1...5]NC+[1...5]"
+input = "4NC+3"
 output = "(4R10+3[0]) ＞ [2,2,6,8]+3  ＞ 11[5,5,9,11] ＞ 대성공"
 rands = [
-  { sides = 5, value = 4 },
-  { sides = 5, value = 3 },
   { sides = 10, value = 6 },
   { sides = 10, value = 2 },
   { sides = 10, value = 2 },
@@ -895,11 +877,9 @@ rands = [
 
 [[ test ]]
 game_system = "Nechronica:Korean"
-input = "[1...5]NC+[1...5]"
+input = "5NC+2"
 output = "(5R10+2[0]) ＞ [1,3,6,7,8]+2  ＞ 10[3,5,8,9,10] ＞ 성공"
 rands = [
-  { sides = 5, value = 5 },
-  { sides = 5, value = 2 },
   { sides = 10, value = 8 },
   { sides = 10, value = 6 },
   { sides = 10, value = 7 },
@@ -909,32 +889,26 @@ rands = [
 
 [[ test ]]
 game_system = "Nechronica:Korean"
-input = "[1...5]NC+[1...5]"
+input = "2NC+5"
 output = "(2R10+5[0]) ＞ [2,3]+5  ＞ 8[7,8] ＞ 성공"
 rands = [
-  { sides = 5, value = 2 },
-  { sides = 5, value = 5 },
   { sides = 10, value = 3 },
   { sides = 10, value = 2 },
 ]
 
 [[ test ]]
 game_system = "Nechronica:Korean"
-input = "[1...5]NC+[1...5]"
+input = "1NC+5"
 output = "(1R10+5[0]) ＞ [4]+5  ＞ 9[9] ＞ 성공"
 rands = [
-  { sides = 5, value = 1 },
-  { sides = 5, value = 5 },
   { sides = 10, value = 4 },
 ]
 
 [[ test ]]
 game_system = "Nechronica:Korean"
-input = "[1...5]NC+[1...5]"
+input = "4NC+5"
 output = "(4R10+5[0]) ＞ [1,3,8,9]+5  ＞ 14[6,8,13,14] ＞ 대성공"
 rands = [
-  { sides = 5, value = 4 },
-  { sides = 5, value = 5 },
   { sides = 10, value = 9 },
   { sides = 10, value = 1 },
   { sides = 10, value = 8 },
@@ -943,11 +917,9 @@ rands = [
 
 [[ test ]]
 game_system = "Nechronica:Korean"
-input = "[1...5]NC+[1...5]"
+input = "4NC+4"
 output = "(4R10+4[0]) ＞ [2,5,6,8]+4  ＞ 12[6,9,10,12] ＞ 대성공"
 rands = [
-  { sides = 5, value = 4 },
-  { sides = 5, value = 4 },
   { sides = 10, value = 8 },
   { sides = 10, value = 6 },
   { sides = 10, value = 2 },
@@ -956,11 +928,9 @@ rands = [
 
 [[ test ]]
 game_system = "Nechronica:Korean"
-input = "[1...5]NC+[1...5]"
+input = "1NC+5"
 output = "(1R10+5[0]) ＞ [7]+5  ＞ 12[12] ＞ 대성공"
 rands = [
-  { sides = 5, value = 1 },
-  { sides = 5, value = 5 },
   { sides = 10, value = 7 },
 ]
 
@@ -1326,10 +1296,9 @@ rands = [
 
 [[ test ]]
 game_system = "Nechronica:Korean"
-input = "[1...5]NA"
+input = "4NA"
 output = "(4R10[1]) ＞ [1,1,2,10]  ＞ 10[1,1,2,10] ＞ 성공 ＞ 머리（없으면 공격측 임의）"
 rands = [
-  { sides = 5, value = 4 },
   { sides = 10, value = 1 },
   { sides = 10, value = 10 },
   { sides = 10, value = 1 },
@@ -1338,10 +1307,9 @@ rands = [
 
 [[ test ]]
 game_system = "Nechronica:Korean"
-input = "[1...5]NA"
+input = "3NA"
 output = "(3R10[1]) ＞ [4,10,10]  ＞ 10[4,10,10] ＞ 성공 ＞ 머리（없으면 공격측 임의）"
 rands = [
-  { sides = 5, value = 3 },
   { sides = 10, value = 4 },
   { sides = 10, value = 10 },
   { sides = 10, value = 10 },
@@ -1349,10 +1317,9 @@ rands = [
 
 [[ test ]]
 game_system = "Nechronica:Korean"
-input = "[1...5]NA"
+input = "4NA"
 output = "(4R10[1]) ＞ [5,6,7,9]  ＞ 9[5,6,7,9] ＞ 성공 ＞ 팔（없으면 공격측 임의）"
 rands = [
-  { sides = 5, value = 4 },
   { sides = 10, value = 6 },
   { sides = 10, value = 7 },
   { sides = 10, value = 5 },
@@ -1361,29 +1328,26 @@ rands = [
 
 [[ test ]]
 game_system = "Nechronica:Korean"
-input = "[1...5]NA"
+input = "1NA"
 output = "(1R10[1]) ＞ [3]  ＞ 3[3] ＞ 실패"
 rands = [
-  { sides = 5, value = 1 },
   { sides = 10, value = 3 },
 ]
 
 [[ test ]]
 game_system = "Nechronica:Korean"
-input = "[1...5]NA"
+input = "2NA"
 output = "(2R10[1]) ＞ [1,3]  ＞ 3[1,3] ＞ 대실패 ＞ 사용파츠 전부 손실"
 rands = [
-  { sides = 5, value = 2 },
   { sides = 10, value = 1 },
   { sides = 10, value = 3 },
 ]
 
 [[ test ]]
 game_system = "Nechronica:Korean"
-input = "[1...5]NA"
+input = "5NA"
 output = "(5R10[1]) ＞ [4,5,5,6,7]  ＞ 7[4,5,5,6,7] ＞ 성공 ＞ 다리（없으면 공격측 임의）"
 rands = [
-  { sides = 5, value = 5 },
   { sides = 10, value = 7 },
   { sides = 10, value = 4 },
   { sides = 10, value = 5 },
@@ -1393,10 +1357,9 @@ rands = [
 
 [[ test ]]
 game_system = "Nechronica:Korean"
-input = "[1...5]NA"
+input = "4NA"
 output = "(4R10[1]) ＞ [1,1,2,5]  ＞ 5[1,1,2,5] ＞ 대실패 ＞ 사용파츠 전부 손실"
 rands = [
-  { sides = 5, value = 4 },
   { sides = 10, value = 2 },
   { sides = 10, value = 1 },
   { sides = 10, value = 1 },
@@ -1405,19 +1368,17 @@ rands = [
 
 [[ test ]]
 game_system = "Nechronica:Korean"
-input = "[1...5]NA"
+input = "1NA"
 output = "(1R10[1]) ＞ [9]  ＞ 9[9] ＞ 성공 ＞ 팔（없으면 공격측 임의）"
 rands = [
-  { sides = 5, value = 1 },
   { sides = 10, value = 9 },
 ]
 
 [[ test ]]
 game_system = "Nechronica:Korean"
-input = "[1...5]NA"
+input = "3NA"
 output = "(3R10[1]) ＞ [1,5,8]  ＞ 8[1,5,8] ＞ 성공 ＞ 몸통（없으면 공격측 임의）"
 rands = [
-  { sides = 5, value = 3 },
   { sides = 10, value = 8 },
   { sides = 10, value = 5 },
   { sides = 10, value = 1 },
@@ -1425,31 +1386,26 @@ rands = [
 
 [[ test ]]
 game_system = "Nechronica:Korean"
-input = "[1...5]NA"
+input = "2NA"
 output = "(2R10[1]) ＞ [5,6]  ＞ 6[5,6] ＞ 성공 ＞ 방어측 임의"
 rands = [
-  { sides = 5, value = 2 },
   { sides = 10, value = 5 },
   { sides = 10, value = 6 },
 ]
 
 [[ test ]]
 game_system = "Nechronica:Korean"
-input = "[1...5]NA+[1...5]"
+input = "1NA+4"
 output = "(1R10+4[1]) ＞ [8]+4  ＞ 12[12] ＞ 대성공 ＞ 공격측 임의(추가 데미지2)"
 rands = [
-  { sides = 5, value = 1 },
-  { sides = 5, value = 4 },
   { sides = 10, value = 8 },
 ]
 
 [[ test ]]
 game_system = "Nechronica:Korean"
-input = "[1...5]NA+[1...5]"
+input = "3NA+5"
 output = "(3R10+5[1]) ＞ [5,6,8]+5  ＞ 13[10,11,13] ＞ 대성공 ＞ 공격측 임의(추가 데미지3)"
 rands = [
-  { sides = 5, value = 3 },
-  { sides = 5, value = 5 },
   { sides = 10, value = 8 },
   { sides = 10, value = 5 },
   { sides = 10, value = 6 },
@@ -1457,22 +1413,18 @@ rands = [
 
 [[ test ]]
 game_system = "Nechronica:Korean"
-input = "[1...5]NA+[1...5]"
+input = "2NA+1"
 output = "(2R10+1[1]) ＞ [4,7]+1  ＞ 8[5,8] ＞ 성공 ＞ 몸통（없으면 공격측 임의）"
 rands = [
-  { sides = 5, value = 2 },
-  { sides = 5, value = 1 },
   { sides = 10, value = 4 },
   { sides = 10, value = 7 },
 ]
 
 [[ test ]]
 game_system = "Nechronica:Korean"
-input = "[1...5]NA+[1...5]"
+input = "5NA+4"
 output = "(5R10+4[1]) ＞ [1,4,8,9,9]+4  ＞ 13[5,8,12,13,13] ＞ 대성공 ＞ 공격측 임의(추가 데미지3)"
 rands = [
-  { sides = 5, value = 5 },
-  { sides = 5, value = 4 },
   { sides = 10, value = 4 },
   { sides = 10, value = 9 },
   { sides = 10, value = 8 },
@@ -1482,64 +1434,52 @@ rands = [
 
 [[ test ]]
 game_system = "Nechronica:Korean"
-input = "[1...5]NA+[1...5]"
+input = "2NA+4"
 output = "(2R10+4[1]) ＞ [3,3]+4  ＞ 7[7,7] ＞ 성공 ＞ 다리（없으면 공격측 임의）"
 rands = [
-  { sides = 5, value = 2 },
-  { sides = 5, value = 4 },
   { sides = 10, value = 3 },
   { sides = 10, value = 3 },
 ]
 
 [[ test ]]
 game_system = "Nechronica:Korean"
-input = "[1...5]NA+[1...5]"
+input = "1NA+1"
 output = "(1R10+1[1]) ＞ [1]+1  ＞ 2[2] ＞ 실패"
 rands = [
-  { sides = 5, value = 1 },
-  { sides = 5, value = 1 },
   { sides = 10, value = 1 },
 ]
 
 [[ test ]]
 game_system = "Nechronica:Korean"
-input = "[1...5]NA+[1...5]"
+input = "2NA+1"
 output = "(2R10+1[1]) ＞ [4,5]+1  ＞ 6[5,6] ＞ 성공 ＞ 방어측 임의"
 rands = [
-  { sides = 5, value = 2 },
-  { sides = 5, value = 1 },
   { sides = 10, value = 4 },
   { sides = 10, value = 5 },
 ]
 
 [[ test ]]
 game_system = "Nechronica:Korean"
-input = "[1...5]NA+[1...5]"
+input = "2NA+4"
 output = "(2R10+4[1]) ＞ [1,7]+4  ＞ 11[5,11] ＞ 대성공 ＞ 공격측 임의(추가 데미지1)"
 rands = [
-  { sides = 5, value = 2 },
-  { sides = 5, value = 4 },
   { sides = 10, value = 7 },
   { sides = 10, value = 1 },
 ]
 
 [[ test ]]
 game_system = "Nechronica:Korean"
-input = "[1...5]NA+[1...5]"
+input = "1NA+4"
 output = "(1R10+4[1]) ＞ [6]+4  ＞ 10[10] ＞ 성공 ＞ 머리（없으면 공격측 임의）"
 rands = [
-  { sides = 5, value = 1 },
-  { sides = 5, value = 4 },
   { sides = 10, value = 6 },
 ]
 
 [[ test ]]
 game_system = "Nechronica:Korean"
-input = "[1...5]NA+[1...5]"
+input = "1NA+5"
 output = "(1R10+5[1]) ＞ [3]+5  ＞ 8[8] ＞ 성공 ＞ 몸통（없으면 공격측 임의）"
 rands = [
-  { sides = 5, value = 1 },
-  { sides = 5, value = 5 },
   { sides = 10, value = 3 },
 ]
 

--- a/test/data/None.toml
+++ b/test/data/None.toml
@@ -319,82 +319,6 @@ rands = [
 
 [[ test ]]
 game_system = "DiceBot"
-input = "[1...5]D6"
-output = "(4D6) ＞ 15[5,3,4,3] ＞ 15"
-rands = [
-  { sides = 5, value = 4 },
-  { sides = 6, value = 5 },
-  { sides = 6, value = 3 },
-  { sides = 6, value = 4 },
-  { sides = 6, value = 3 },
-]
-
-[[ test ]]
-game_system = "DiceBot"
-input = "([2...4]+2)D10"
-output = "(6D10) ＞ 29[8,7,2,1,6,5] ＞ 29"
-rands = [
-  { sides = 3, value = 3 },
-  { sides = 10, value = 8 },
-  { sides = 10, value = 7 },
-  { sides = 10, value = 2 },
-  { sides = 10, value = 1 },
-  { sides = 10, value = 6 },
-  { sides = 10, value = 5 },
-]
-
-[[ test ]]
-game_system = "DiceBot"
-input = "2d[1...5]"
-output = "(2D2) ＞ 3[1,2] ＞ 3"
-rands = [
-  { sides = 5, value = 2 },
-  { sides = 2, value = 1 },
-  { sides = 2, value = 2 },
-]
-
-[[ test ]]
-game_system = "DiceBot"
-input = "2d([2...4]+2)"
-output = "(2D5) ＞ 7[4,3] ＞ 7"
-rands = [
-  { sides = 3, value = 2 },
-  { sides = 5, value = 4 },
-  { sides = 5, value = 3 },
-]
-
-[[ test ]]
-game_system = "DiceBot"
-input = "([1...4]+1)d([2...4]+2)-1"
-output = "(3D6-1) ＞ 14[5,5,4]-1 ＞ 13"
-rands = [
-  { sides = 4, value = 2 },
-  { sides = 3, value = 3 },
-  { sides = 6, value = 5 },
-  { sides = 6, value = 5 },
-  { sides = 6, value = 4 },
-]
-
-[[ test ]]
-game_system = "DiceBot"
-input = "1D6+[1D6]"
-output = "(1D6+2) ＞ 3[3]+2 ＞ 5"
-rands = [
-  { sides = 6, value = 2 },
-  { sides = 6, value = 3 },
-]
-
-[[ test ]]
-game_system = "DiceBot"
-input = "1d6+[1d6]"
-output = "(1D6+2) ＞ 3[3]+2 ＞ 5"
-rands = [
-  { sides = 6, value = 2 },
-  { sides = 6, value = 3 },
-]
-
-[[ test ]]
-game_system = "DiceBot"
 input = "1D6/0"
 output = "(1D6/0) ＞ 1[1]/0 ＞ 1"
 rands = [
@@ -661,58 +585,6 @@ rands = [
 
 [[ test ]]
 game_system = "DiceBot"
-input = "[1...3]b6"
-output = "(1B6) ＞ 5"
-rands = [
-  { sides = 3, value = 1 },
-  { sides = 6, value = 5 },
-]
-
-[[ test ]]
-game_system = "DiceBot"
-input = "[1...3]b6"
-output = "(3B6) ＞ 2,4,6"
-rands = [
-  { sides = 3, value = 3 },
-  { sides = 6, value = 2 },
-  { sides = 6, value = 4 },
-  { sides = 6, value = 6 },
-]
-
-[[ test ]]
-game_system = "DiceBot"
-input = "2b[4...6]"
-output = "(2B4) ＞ 3,4"
-rands = [
-  { sides = 3, value = 1 },
-  { sides = 4, value = 3 },
-  { sides = 4, value = 4 },
-]
-
-[[ test ]]
-game_system = "DiceBot"
-input = "2b[4...6]"
-output = "(2B5) ＞ 5,1"
-rands = [
-  { sides = 3, value = 2 },
-  { sides = 5, value = 5 },
-  { sides = 5, value = 1 },
-]
-
-[[ test ]]
-game_system = "DiceBot"
-input = "[1...3]b[4...6]"
-output = "(3B6) ＞ 6,4,3"
-rands = [
-  { sides = 3, value = 3 },
-  { sides = 3, value = 3 },
-  { sides = 6, value = 6 },
-  { sides = 6, value = 4 },
-  { sides = 6, value = 3 },
-]
-
-[[ test ]]
-game_system = "DiceBot"
 input = "(1*2)b6"
 output = "(2B6) ＞ 3,4"
 rands = [
@@ -722,55 +594,11 @@ rands = [
 
 [[ test ]]
 game_system = "DiceBot"
-input = "([1...3]+1)b6"
-output = "(3B6) ＞ 2,4,3"
-rands = [
-  { sides = 3, value = 2 },
-  { sides = 6, value = 2 },
-  { sides = 6, value = 4 },
-  { sides = 6, value = 3 },
-]
-
-[[ test ]]
-game_system = "DiceBot"
 input = "2b(2+4)"
 output = "(2B6) ＞ 3,4"
 rands = [
   { sides = 6, value = 3 },
   { sides = 6, value = 4 },
-]
-
-[[ test ]]
-game_system = "DiceBot"
-input = "2b([3...5]+1)"
-output = "(2B5) ＞ 1,3"
-rands = [
-  { sides = 3, value = 2 },
-  { sides = 5, value = 1 },
-  { sides = 5, value = 3 },
-]
-
-[[ test ]]
-game_system = "DiceBot"
-input = "[1...5]b(2*3)"
-output = "(5B6) ＞ 3,5,1,5,6"
-rands = [
-  { sides = 5, value = 5 },
-  { sides = 6, value = 3 },
-  { sides = 6, value = 5 },
-  { sides = 6, value = 1 },
-  { sides = 6, value = 5 },
-  { sides = 6, value = 6 },
-]
-
-[[ test ]]
-game_system = "DiceBot"
-input = "(1+1)b[1...5]"
-output = "(2B4) ＞ 3,4"
-rands = [
-  { sides = 5, value = 4 },
-  { sides = 4, value = 3 },
-  { sides = 4, value = 4 },
 ]
 
 [[ test ]]
@@ -995,58 +823,6 @@ rands = [
 
 [[ test ]]
 game_system = "DiceBot"
-input = "[1...3]b6>3"
-output = "(1B6>3) ＞ 5 ＞ 成功数1"
-rands = [
-  { sides = 3, value = 1 },
-  { sides = 6, value = 5 },
-]
-
-[[ test ]]
-game_system = "DiceBot"
-input = "[1...3]b6>3"
-output = "(3B6>3) ＞ 2,4,6 ＞ 成功数2"
-rands = [
-  { sides = 3, value = 3 },
-  { sides = 6, value = 2 },
-  { sides = 6, value = 4 },
-  { sides = 6, value = 6 },
-]
-
-[[ test ]]
-game_system = "DiceBot"
-input = "2b[4...6]>3"
-output = "(2B4>3) ＞ 3,4 ＞ 成功数1"
-rands = [
-  { sides = 3, value = 1 },
-  { sides = 4, value = 3 },
-  { sides = 4, value = 4 },
-]
-
-[[ test ]]
-game_system = "DiceBot"
-input = "2b[4...6]>3"
-output = "(2B5>3) ＞ 5,1 ＞ 成功数1"
-rands = [
-  { sides = 3, value = 2 },
-  { sides = 5, value = 5 },
-  { sides = 5, value = 1 },
-]
-
-[[ test ]]
-game_system = "DiceBot"
-input = "[1...3]b[4...6]>3"
-output = "(3B6>3) ＞ 6,4,3 ＞ 成功数2"
-rands = [
-  { sides = 3, value = 3 },
-  { sides = 3, value = 3 },
-  { sides = 6, value = 6 },
-  { sides = 6, value = 4 },
-  { sides = 6, value = 3 },
-]
-
-[[ test ]]
-game_system = "DiceBot"
 input = "(1*2)b6>3"
 output = "(2B6>3) ＞ 3,4 ＞ 成功数1"
 rands = [
@@ -1056,32 +832,11 @@ rands = [
 
 [[ test ]]
 game_system = "DiceBot"
-input = "([1...3]+1)b6>3"
-output = "(3B6>3) ＞ 2,4,3 ＞ 成功数1"
-rands = [
-  { sides = 3, value = 2 },
-  { sides = 6, value = 2 },
-  { sides = 6, value = 4 },
-  { sides = 6, value = 3 },
-]
-
-[[ test ]]
-game_system = "DiceBot"
 input = "2b(2+4)>3"
 output = "(2B6>3) ＞ 3,4 ＞ 成功数1"
 rands = [
   { sides = 6, value = 3 },
   { sides = 6, value = 4 },
-]
-
-[[ test ]]
-game_system = "DiceBot"
-input = "2b([3...5]+1)>3"
-output = "(2B5>3) ＞ 1,3 ＞ 成功数0"
-rands = [
-  { sides = 3, value = 2 },
-  { sides = 5, value = 1 },
-  { sides = 5, value = 3 },
 ]
 
 [[ test ]]

--- a/test/data/Torg.toml
+++ b/test/data/Torg.toml
@@ -163,643 +163,483 @@ rands = [
 
 [[ test ]]
 game_system = "Torg"
-input = "RT[1...20]"
+input = "RT13"
 output = "一般結果表[13] ＞ すごい"
-rands = [
-  { sides = 20, value = 13 },
-]
+rands = []
 
 [[ test ]]
 game_system = "Torg"
-input = "RT[1...20]"
+input = "RT6"
 output = "一般結果表[6] ＞ まあよい"
-rands = [
-  { sides = 20, value = 6 },
-]
+rands = []
 
 [[ test ]]
 game_system = "Torg"
-input = "RT[1...20]"
+input = "RT3"
 output = "一般結果表[3] ＞ まあよい"
-rands = [
-  { sides = 20, value = 3 },
-]
+rands = []
 
 [[ test ]]
 game_system = "Torg"
-input = "RT[1...20]"
+input = "RT4"
 output = "一般結果表[4] ＞ まあよい"
-rands = [
-  { sides = 20, value = 4 },
-]
+rands = []
 
 [[ test ]]
 game_system = "Torg"
-input = "RT[1...20]"
+input = "RT3"
 output = "一般結果表[3] ＞ まあよい"
-rands = [
-  { sides = 20, value = 3 },
-]
+rands = []
 
 [[ test ]]
 game_system = "Torg"
-input = "RT[1...20]"
+input = "RT11"
 output = "一般結果表[11] ＞ かなりよい"
-rands = [
-  { sides = 20, value = 11 },
-]
+rands = []
 
 [[ test ]]
 game_system = "Torg"
-input = "RT[1...20]"
+input = "RT15"
 output = "一般結果表[15] ＞ すごい"
-rands = [
-  { sides = 20, value = 15 },
-]
+rands = []
 
 [[ test ]]
 game_system = "Torg"
-input = "RT[1...20]"
+input = "RT4"
 output = "一般結果表[4] ＞ まあよい"
-rands = [
-  { sides = 20, value = 4 },
-]
+rands = []
 
 [[ test ]]
 game_system = "Torg"
-input = "RT[1...20]"
+input = "RT11"
 output = "一般結果表[11] ＞ かなりよい"
-rands = [
-  { sides = 20, value = 11 },
-]
+rands = []
 
 [[ test ]]
 game_system = "Torg"
-input = "RT[1...20]"
+input = "RT16"
 output = "一般結果表[16] ＞ すごい"
-rands = [
-  { sides = 20, value = 16 },
-]
+rands = []
 
 [[ test ]]
 game_system = "Torg"
-input = "IT[1...20]"
+input = "IT16"
 output = "威圧/威嚇表[16] ＞ モラル崩壊"
-rands = [
-  { sides = 20, value = 16 },
-]
+rands = []
 
 [[ test ]]
 game_system = "Torg"
-input = "IT[1...20]"
+input = "IT17"
 output = "威圧/威嚇表[17] ＞ プレイヤーズコール"
-rands = [
-  { sides = 20, value = 17 },
-]
+rands = []
 
 [[ test ]]
 game_system = "Torg"
-input = "IT[1...20]"
+input = "IT14"
 output = "威圧/威嚇表[14] ＞ 逆転負け"
-rands = [
-  { sides = 20, value = 14 },
-]
+rands = []
 
 [[ test ]]
 game_system = "Torg"
-input = "IT[1...20]"
+input = "IT2"
 output = "威圧/威嚇表[2] ＞ 技能なし"
-rands = [
-  { sides = 20, value = 2 },
-]
+rands = []
 
 [[ test ]]
 game_system = "Torg"
-input = "IT[1...20]"
+input = "IT17"
 output = "威圧/威嚇表[17] ＞ プレイヤーズコール"
-rands = [
-  { sides = 20, value = 17 },
-]
+rands = []
 
 [[ test ]]
 game_system = "Torg"
-input = "IT[1...20]"
+input = "IT8"
 output = "威圧/威嚇表[8] ＞ 萎縮"
-rands = [
-  { sides = 20, value = 8 },
-]
+rands = []
 
 [[ test ]]
 game_system = "Torg"
-input = "IT[1...20]"
+input = "IT4"
 output = "威圧/威嚇表[4] ＞ 技能なし"
-rands = [
-  { sides = 20, value = 4 },
-]
+rands = []
 
 [[ test ]]
 game_system = "Torg"
-input = "IT[1...20]"
+input = "IT19"
 output = "威圧/威嚇表[19] ＞ プレイヤーズコール"
-rands = [
-  { sides = 20, value = 19 },
-]
+rands = []
 
 [[ test ]]
 game_system = "Torg"
-input = "IT[1...20]"
+input = "IT1"
 output = "威圧/威嚇表[1] ＞ 技能なし"
-rands = [
-  { sides = 20, value = 1 },
-]
+rands = []
 
 [[ test ]]
 game_system = "Torg"
-input = "IT[1...20]"
+input = "IT5"
 output = "威圧/威嚇表[5] ＞ 萎縮"
-rands = [
-  { sides = 20, value = 5 },
-]
+rands = []
 
 [[ test ]]
 game_system = "Torg"
-input = "TT[1...20]"
+input = "TT6"
 output = "挑発/トリック表[6] ＞ 萎縮"
-rands = [
-  { sides = 20, value = 6 },
-]
+rands = []
 
 [[ test ]]
 game_system = "Torg"
-input = "TT[1...20]"
+input = "TT1"
 output = "挑発/トリック表[1] ＞ 技能なし"
-rands = [
-  { sides = 20, value = 1 },
-]
+rands = []
 
 [[ test ]]
 game_system = "Torg"
-input = "TT[1...20]"
+input = "TT13"
 output = "挑発/トリック表[13] ＞ 逆転負け"
-rands = [
-  { sides = 20, value = 13 },
-]
+rands = []
 
 [[ test ]]
 game_system = "Torg"
-input = "TT[1...20]"
+input = "TT6"
 output = "挑発/トリック表[6] ＞ 萎縮"
-rands = [
-  { sides = 20, value = 6 },
-]
+rands = []
 
 [[ test ]]
 game_system = "Torg"
-input = "TT[1...20]"
+input = "TT17"
 output = "挑発/トリック表[17] ＞ プレイヤーズコール"
-rands = [
-  { sides = 20, value = 17 },
-]
+rands = []
 
 [[ test ]]
 game_system = "Torg"
-input = "TT[1...20]"
+input = "TT5"
 output = "挑発/トリック表[5] ＞ 萎縮"
-rands = [
-  { sides = 20, value = 5 },
-]
+rands = []
 
 [[ test ]]
 game_system = "Torg"
-input = "TT[1...20]"
+input = "TT6"
 output = "挑発/トリック表[6] ＞ 萎縮"
-rands = [
-  { sides = 20, value = 6 },
-]
+rands = []
 
 [[ test ]]
 game_system = "Torg"
-input = "TT[1...20]"
+input = "TT3"
 output = "挑発/トリック表[3] ＞ 技能なし"
-rands = [
-  { sides = 20, value = 3 },
-]
+rands = []
 
 [[ test ]]
 game_system = "Torg"
-input = "TT[1...20]"
+input = "TT9"
 output = "挑発/トリック表[9] ＞ 萎縮"
-rands = [
-  { sides = 20, value = 9 },
-]
+rands = []
 
 [[ test ]]
 game_system = "Torg"
-input = "TT[1...20]"
+input = "TT15"
 output = "挑発/トリック表[15] ＞ 高揚／逆転負け"
-rands = [
-  { sides = 20, value = 15 },
-]
+rands = []
 
 [[ test ]]
 game_system = "Torg"
-input = "MT[1...20]"
+input = "MT3"
 output = "間合い表[3] ＞ 技能なし"
-rands = [
-  { sides = 20, value = 3 },
-]
+rands = []
 
 [[ test ]]
 game_system = "Torg"
-input = "MT[1...20]"
+input = "MT12"
 output = "間合い表[12] ＞ 萎縮／疲労"
-rands = [
-  { sides = 20, value = 12 },
-]
+rands = []
 
 [[ test ]]
 game_system = "Torg"
-input = "MT[1...20]"
+input = "MT4"
 output = "間合い表[4] ＞ 技能なし"
-rands = [
-  { sides = 20, value = 4 },
-]
+rands = []
 
 [[ test ]]
 game_system = "Torg"
-input = "MT[1...20]"
+input = "MT5"
 output = "間合い表[5] ＞ 疲労"
-rands = [
-  { sides = 20, value = 5 },
-]
+rands = []
 
 [[ test ]]
 game_system = "Torg"
-input = "MT[1...20]"
+input = "MT5"
 output = "間合い表[5] ＞ 疲労"
-rands = [
-  { sides = 20, value = 5 },
-]
+rands = []
 
 [[ test ]]
 game_system = "Torg"
-input = "MT[1...20]"
+input = "MT6"
 output = "間合い表[6] ＞ 疲労"
-rands = [
-  { sides = 20, value = 6 },
-]
+rands = []
 
 [[ test ]]
 game_system = "Torg"
-input = "MT[1...20]"
+input = "MT14"
 output = "間合い表[14] ＞ 萎縮／疲労"
-rands = [
-  { sides = 20, value = 14 },
-]
+rands = []
 
 [[ test ]]
 game_system = "Torg"
-input = "MT[1...20]"
+input = "MT13"
 output = "間合い表[13] ＞ 萎縮／疲労"
-rands = [
-  { sides = 20, value = 13 },
-]
+rands = []
 
 [[ test ]]
 game_system = "Torg"
-input = "MT[1...20]"
+input = "MT19"
 output = "間合い表[19] ＞ プレイヤーズコール"
-rands = [
-  { sides = 20, value = 19 },
-]
+rands = []
 
 [[ test ]]
 game_system = "Torg"
-input = "MT[1...20]"
+input = "MT20"
 output = "間合い表[20] ＞ プレイヤーズコール"
-rands = [
-  { sides = 20, value = 20 },
-]
+rands = []
 
 [[ test ]]
 game_system = "Torg"
-input = "ODT[1...20]"
+input = "ODT13"
 output = "オーズダメージ表[13] ＞ 3レベル負傷  KO13"
-rands = [
-  { sides = 20, value = 13 },
-]
+rands = []
 
 [[ test ]]
 game_system = "Torg"
-input = "ODT[1...20]"
+input = "ODT7"
 output = "オーズダメージ表[7] ＞ 転倒 K／O5"
-rands = [
-  { sides = 20, value = 7 },
-]
+rands = []
 
 [[ test ]]
 game_system = "Torg"
-input = "ODT[1...20]"
+input = "ODT11"
 output = "オーズダメージ表[11] ＞ 2レベル負傷  K／O11"
-rands = [
-  { sides = 20, value = 11 },
-]
+rands = []
 
 [[ test ]]
 game_system = "Torg"
-input = "ODT[1...20]"
+input = "ODT19"
 output = "オーズダメージ表[19] ＞ 6レベル負傷  KO15"
-rands = [
-  { sides = 20, value = 19 },
-]
+rands = []
 
 [[ test ]]
 game_system = "Torg"
-input = "ODT[1...20]"
+input = "ODT2"
 output = "オーズダメージ表[2] ＞ K1"
-rands = [
-  { sides = 20, value = 2 },
-]
+rands = []
 
 [[ test ]]
 game_system = "Torg"
-input = "ODT[1...20]"
+input = "ODT14"
 output = "オーズダメージ表[14] ＞ 3レベル負傷  KO14"
-rands = [
-  { sides = 20, value = 14 },
-]
+rands = []
 
 [[ test ]]
 game_system = "Torg"
-input = "ODT[1...20]"
+input = "ODT18"
 output = "オーズダメージ表[18] ＞ 5レベル負傷  KO15"
-rands = [
-  { sides = 20, value = 18 },
-]
+rands = []
 
 [[ test ]]
 game_system = "Torg"
-input = "ODT[1...20]"
+input = "ODT6"
 output = "オーズダメージ表[6] ＞ 転倒 K／O4"
-rands = [
-  { sides = 20, value = 6 },
-]
+rands = []
 
 [[ test ]]
 game_system = "Torg"
-input = "ODT[1...20]"
+input = "ODT18"
 output = "オーズダメージ表[18] ＞ 5レベル負傷  KO15"
-rands = [
-  { sides = 20, value = 18 },
-]
+rands = []
 
 [[ test ]]
 game_system = "Torg"
-input = "ODT[1...20]"
+input = "ODT9"
 output = "オーズダメージ表[9] ＞ 1レベル負傷  K／O9"
-rands = [
-  { sides = 20, value = 9 },
-]
+rands = []
 
 [[ test ]]
 game_system = "Torg"
-input = "DT[1...20]"
+input = "DT6"
 output = "ポシビリティ能力者ダメージ表[6] ＞ 転倒 O2"
-rands = [
-  { sides = 20, value = 6 },
-]
+rands = []
 
 [[ test ]]
 game_system = "Torg"
-input = "DT[1...20]"
+input = "DT17"
 output = "ポシビリティ能力者ダメージ表[17] ＞ 4レベル負傷  KO5"
-rands = [
-  { sides = 20, value = 17 },
-]
+rands = []
 
 [[ test ]]
 game_system = "Torg"
-input = "DT[1...20]"
+input = "DT17"
 output = "ポシビリティ能力者ダメージ表[17] ＞ 4レベル負傷  KO5"
-rands = [
-  { sides = 20, value = 17 },
-]
+rands = []
 
 [[ test ]]
 game_system = "Torg"
-input = "DT[1...20]"
+input = "DT1"
 output = "ポシビリティ能力者ダメージ表[1] ＞ 1"
-rands = [
-  { sides = 20, value = 1 },
-]
+rands = []
 
 [[ test ]]
 game_system = "Torg"
-input = "DT[1...20]"
+input = "DT3"
 output = "ポシビリティ能力者ダメージ表[3] ＞ K2"
-rands = [
-  { sides = 20, value = 3 },
-]
+rands = []
 
 [[ test ]]
 game_system = "Torg"
-input = "DT[1...20]"
+input = "DT4"
 output = "ポシビリティ能力者ダメージ表[4] ＞ 2"
-rands = [
-  { sides = 20, value = 4 },
-]
+rands = []
 
 [[ test ]]
 game_system = "Torg"
-input = "DT[1...20]"
+input = "DT10"
 output = "ポシビリティ能力者ダメージ表[10] ＞ 1レベル負傷  K4"
-rands = [
-  { sides = 20, value = 10 },
-]
+rands = []
 
 [[ test ]]
 game_system = "Torg"
-input = "DT[1...20]"
+input = "DT14"
 output = "ポシビリティ能力者ダメージ表[14] ＞ 2レベル負傷  KO5"
-rands = [
-  { sides = 20, value = 14 },
-]
+rands = []
 
 [[ test ]]
 game_system = "Torg"
-input = "DT[1...20]"
+input = "DT1"
 output = "ポシビリティ能力者ダメージ表[1] ＞ 1"
-rands = [
-  { sides = 20, value = 1 },
-]
+rands = []
 
 [[ test ]]
 game_system = "Torg"
-input = "DT[1...20]"
+input = "DT16"
 output = "ポシビリティ能力者ダメージ表[16] ＞ 3レベル負傷  KO5"
-rands = [
-  { sides = 20, value = 16 },
-]
+rands = []
 
 [[ test ]]
 game_system = "Torg"
-input = "BT[1...80]"
+input = "BT53"
 output = "ボーナス表[53] ＞ 14"
-rands = [
-  { sides = 80, value = 53 },
-]
+rands = []
 
 [[ test ]]
 game_system = "Torg"
-input = "BT[1...80]"
+input = "BT27"
 output = "ボーナス表[27] ＞ 9"
-rands = [
-  { sides = 80, value = 27 },
-]
+rands = []
 
 [[ test ]]
 game_system = "Torg"
-input = "BT[1...80]"
+input = "BT44"
 output = "ボーナス表[44] ＞ 12"
-rands = [
-  { sides = 80, value = 44 },
-]
+rands = []
 
 [[ test ]]
 game_system = "Torg"
-input = "BT[1...80]"
+input = "BT58"
 output = "ボーナス表[58] ＞ 15"
-rands = [
-  { sides = 80, value = 58 },
-]
+rands = []
 
 [[ test ]]
 game_system = "Torg"
-input = "BT[1...80]"
+input = "BT50"
 output = "ボーナス表[50] ＞ 13"
-rands = [
-  { sides = 80, value = 50 },
-]
+rands = []
 
 [[ test ]]
 game_system = "Torg"
-input = "BT[1...80]"
+input = "BT34"
 output = "ボーナス表[34] ＞ 10"
-rands = [
-  { sides = 80, value = 34 },
-]
+rands = []
 
 [[ test ]]
 game_system = "Torg"
-input = "BT[1...80]"
+input = "BT48"
 output = "ボーナス表[48] ＞ 13"
-rands = [
-  { sides = 80, value = 48 },
-]
+rands = []
 
 [[ test ]]
 game_system = "Torg"
-input = "BT[1...80]"
+input = "BT54"
 output = "ボーナス表[54] ＞ 14"
-rands = [
-  { sides = 80, value = 54 },
-]
+rands = []
 
 [[ test ]]
 game_system = "Torg"
-input = "BT[1...80]"
+input = "BT20"
 output = "ボーナス表[20] ＞ 7"
-rands = [
-  { sides = 80, value = 20 },
-]
+rands = []
 
 [[ test ]]
 game_system = "Torg"
-input = "BT[1...80]"
+input = "BT71"
 output = "ボーナス表[71] ＞ 18"
-rands = [
-  { sides = 80, value = 71 },
-]
+rands = []
 
 [[ test ]]
 game_system = "Torg"
-input = "BT[1...80]+1"
+input = "BT4+1"
 output = "ボーナス表[4+1] ＞ -8[4]+1 ＞ -7"
-rands = [
-  { sides = 80, value = 4 },
-]
+rands = []
 
 [[ test ]]
 game_system = "Torg"
-input = "BT[1...80]+1"
+input = "BT21+1"
 output = "ボーナス表[21+1] ＞ 8[21]+1 ＞ 9"
-rands = [
-  { sides = 80, value = 21 },
-]
+rands = []
 
 [[ test ]]
 game_system = "Torg"
-input = "BT[1...80]+1"
+input = "BT13+1"
 output = "ボーナス表[13+1] ＞ 1[13]+1 ＞ 2"
-rands = [
-  { sides = 80, value = 13 },
-]
+rands = []
 
 [[ test ]]
 game_system = "Torg"
-input = "BT[1...80]+1"
+input = "BT39+1"
 output = "ボーナス表[39+1] ＞ 11[39]+1 ＞ 12"
-rands = [
-  { sides = 80, value = 39 },
-]
+rands = []
 
 [[ test ]]
 game_system = "Torg"
-input = "BT[1...80]+1"
+input = "BT13+1"
 output = "ボーナス表[13+1] ＞ 1[13]+1 ＞ 2"
-rands = [
-  { sides = 80, value = 13 },
-]
+rands = []
 
 [[ test ]]
 game_system = "Torg"
-input = "BT[1...80]+1"
+input = "BT56+1"
 output = "ボーナス表[56+1] ＞ 15[56]+1 ＞ 16"
-rands = [
-  { sides = 80, value = 56 },
-]
+rands = []
 
 [[ test ]]
 game_system = "Torg"
-input = "BT[1...80]+1"
+input = "BT40+1"
 output = "ボーナス表[40+1] ＞ 11[40]+1 ＞ 12"
-rands = [
-  { sides = 80, value = 40 },
-]
+rands = []
 
 [[ test ]]
 game_system = "Torg"
-input = "BT[1...80]+1"
+input = "BT12+1"
 output = "ボーナス表[12+1] ＞ 0[12]+1 ＞ 1"
-rands = [
-  { sides = 80, value = 12 },
-]
+rands = []
 
 [[ test ]]
 game_system = "Torg"
-input = "BT[1...80]+1"
+input = "BT44+1"
 output = "ボーナス表[44+1] ＞ 12[44]+1 ＞ 13"
-rands = [
-  { sides = 80, value = 44 },
-]
+rands = []
 
 [[ test ]]
 game_system = "Torg"
-input = "BT[1...80]+1"
+input = "BT17+1"
 output = "ボーナス表[17+1] ＞ 4[17]+1 ＞ 5"
-rands = [
-  { sides = 80, value = 17 },
-]
+rands = []
 
 [[ test ]]
 game_system = "Torg"


### PR DESCRIPTION
コマンドに `[1...6]` や `[1D6]` と書くと事前処理でダイスロールされていたが、これを廃止する。
マニュアルにも記載されておらず、不要な機能となっている。