### PR TITLE
register_prefixに可変長引数で渡すようにする

### DIFF
--- a/lib/bcdice/game_system/AFF2e.rb
+++ b/lib/bcdice/game_system/AFF2e.rb
@@ -21,7 +21,7 @@ module BCDice
       MESSAGETEXT
 
       # ダイスボットで使用するコマンドを配列で列挙する
-      register_prefix(['FF.+', 'FR.+', 'FD.+'])
+      register_prefix('FF.+', 'FR.+', 'FD.+')
 
       def explicit_sign(i)
         format('%+d', i)

--- a/lib/bcdice/game_system/AceKillerGene.rb
+++ b/lib/bcdice/game_system/AceKillerGene.rb
@@ -27,10 +27,10 @@ module BCDice
         　例）DCSL7　DCEL22
       INFO_MESSAGE_TEXT
 
-      register_prefix([
+      register_prefix(
         '(AK|AKG)(\-?\d+)(\/\d+)?(@\d+)?',
         'DC(SL|BL|IM|BR|RF|EL).+'
-      ])
+      )
 
       def eval_game_system_specific_command(command)
         case command

--- a/lib/bcdice/game_system/Airgetlamh.rb
+++ b/lib/bcdice/game_system/Airgetlamh.rb
@@ -41,9 +41,9 @@ module BCDice
         ・15AAx4c0 → 15d10で目標値6、威力4、クリティカル無しの命中判定。
       MESSAGETEXT
 
-      register_prefix([
-        ['(\d+)?A(A|L)(\d+)?((x|\*)(\d+)(\+(\d+))?)?(C(\d+))?']
-      ])
+      register_prefix(
+        '(\d+)?A(A|L)(\d+)?((x|\*)(\d+)(\+(\d+))?)?(C(\d+))?'
+      )
 
       def initialize(command)
         super(command)

--- a/lib/bcdice/game_system/Alsetto.rb
+++ b/lib/bcdice/game_system/Alsetto.rb
@@ -37,7 +37,7 @@ module BCDice
         ・8ALC4x5 → 8d6で目標値4、攻撃力5、トライアンフ無しの命中判定。
       MESSAGETEXT
 
-      register_prefix(['\d+AL(C|G)?(\d+)?(x|\*)\d+', '\d+ALC?(\d+)?'])
+      register_prefix('\d+AL(C|G)?(\d+)?(x|\*)\d+', '\d+ALC?(\d+)?')
 
       def initialize(command)
         super(command)

--- a/lib/bcdice/game_system/Alshard.rb
+++ b/lib/bcdice/game_system/Alshard.rb
@@ -16,7 +16,7 @@ module BCDice
       ID = 'Alshard'
 
       # 固有のコマンドの接頭辞を設定する
-      register_prefix(['2D6.*', 'AL.*'])
+      register_prefix('2D6.*', 'AL.*')
 
       # 成功判定のエイリアスコマンドを設定する
       set_aliases_for_srs_roll('AL')

--- a/lib/bcdice/game_system/AlterRaise.rb
+++ b/lib/bcdice/game_system/AlterRaise.rb
@@ -34,10 +34,10 @@ module BCDice
         QUI：平穏・経験表をダイスロール
       MESSAGETEXT
 
-      register_prefix([
+      register_prefix(
         'EMA(\d+)?', 'PER(\d+)?', 'LOC(\d+)?', 'QUI(\d+)?', 'DEL(\d+)?',
         'TRA(\d+)?', 'SCE(\d+)?', 'STA(\d+)?', 'EMO(\d+)?'
-      ])
+      )
 
       def eval_game_system_specific_command(command)
         output =

--- a/lib/bcdice/game_system/AnimaAnimus.rb
+++ b/lib/bcdice/game_system/AnimaAnimus.rb
@@ -90,7 +90,7 @@ module BCDice
       }.freeze
 
       # ダイスボットで使用するコマンドを配列で列挙する
-      register_prefix(['\d+AN<=\d([\+\-]\d+)*'] + TABLES.keys)
+      register_prefix('\d+AN<=\d([\+\-]\d+)*', TABLES.keys)
     end
   end
 end

--- a/lib/bcdice/game_system/ArsMagica.rb
+++ b/lib/bcdice/game_system/ArsMagica.rb
@@ -26,7 +26,7 @@ module BCDice
         　　最初の0が判断基準で、その右側5つがボッチダイスです。1*2,8*2,0*1なので1botchという訳です。
       INFO_MESSAGE_TEXT
 
-      register_prefix(['ArS.*', '1R10.*'])
+      register_prefix('ArS.*', '1R10.*')
 
       def eval_game_system_specific_command(string)
         unless parse_ars(string) || parse_1r10(string)

--- a/lib/bcdice/game_system/Avandner.rb
+++ b/lib/bcdice/game_system/Avandner.rb
@@ -34,7 +34,7 @@ module BCDice
         ・8av4*7+10 → 8d10で目標値4、攻撃力7、クリティカルトリガー10の命中判定。
       MESSAGETEXT
 
-      register_prefix(['\d+AV\d+((x|\*)\d+(\+\d+)?)?(c\d+)?'])
+      register_prefix('\d+AV\d+((x|\*)\d+(\+\d+)?)?(c\d+)?')
 
       def initialize(command)
         super(command)

--- a/lib/bcdice/game_system/BBN.rb
+++ b/lib/bcdice/game_system/BBN.rb
@@ -2,7 +2,7 @@ module BCDice
   module GameSystem
     class BBN < Base
       # ダイスボットで使用するコマンドを配列で列挙する
-      register_prefix(['\d+BN.*'])
+      register_prefix('\d+BN.*')
 
       ID = 'BBN'.freeze
 

--- a/lib/bcdice/game_system/BadLife.rb
+++ b/lib/bcdice/game_system/BadLife.rb
@@ -41,7 +41,7 @@ module BCDice
         ・スキル表：SKL
       MESSAGETEXT
 
-      register_prefix(['\d?(BAD|BL|GL).*', '[TDGKSB]RN', 'SKL'])
+      register_prefix('\d?(BAD|BL|GL).*', '[TDGKSB]RN', 'SKL')
 
       def eval_game_system_specific_command(command)
         command = command.upcase

--- a/lib/bcdice/game_system/BarnaKronika.rb
+++ b/lib/bcdice/game_system/BarnaKronika.rb
@@ -26,7 +26,7 @@ module BCDice
         　セット数が1以上の時はセット数も表示し、攻撃判定の場合は命中部位も表示します。
       INFO_MESSAGE_TEXT
 
-      register_prefix(['\d+BK.*', '\d+BA.*', '\d+BKC\d+.*', '\d+BAC\d+.*', '\d+R6.*'])
+      register_prefix('\d+BK.*', '\d+BA.*', '\d+BKC\d+.*', '\d+BAC\d+.*', '\d+R6.*')
 
       def initialize(command)
         super(command)

--- a/lib/bcdice/game_system/BeastBindTrinity.rb
+++ b/lib/bcdice/game_system/BeastBindTrinity.rb
@@ -342,7 +342,7 @@ module BCDice
         ),
       }.freeze
 
-      register_prefix(['\d+BB.*', '\d+R6.*'] + TABLES.keys)
+      register_prefix('\d+BB.*', '\d+R6.*', TABLES.keys)
     end
   end
 end

--- a/lib/bcdice/game_system/BeginningIdol.rb
+++ b/lib/bcdice/game_system/BeginningIdol.rb
@@ -54,7 +54,7 @@ module BCDice
         []内は省略可　D66入れ替えあり
       INFO_MESSAGE_TEXT
 
-      register_prefix([
+      register_prefix(
         '[1-7]*PD\d+(?:[\+\-]\d+)?',
         'HW',
         'BWT',
@@ -142,7 +142,7 @@ module BCDice
         'LIT',
         'TIT',
         'CIT'
-      ])
+      )
 
       def initialize(command)
         super(command)

--- a/lib/bcdice/game_system/BeginningIdol_Korean.rb
+++ b/lib/bcdice/game_system/BeginningIdol_Korean.rb
@@ -52,7 +52,7 @@ module BCDice
         []内は省略可　D66 다이스가 존재
       INFO_MESSAGE_TEXT
 
-      register_prefix([
+      register_prefix(
         '[1-7]*PD\d+(?:[\+\-]\d+)?',
         'HW',
         'BWT',
@@ -137,7 +137,7 @@ module BCDice
         'LIT',
         'TIT',
         'CIT'
-      ])
+      )
 
       def initialize(command)
         super(command)

--- a/lib/bcdice/game_system/BladeOfArcana.rb
+++ b/lib/bcdice/game_system/BladeOfArcana.rb
@@ -32,13 +32,13 @@ module BCDice
         　　例）CTR+→因縁表（R版）を出目2～21でロールする。
       INFO_MESSAGE_TEXT
 
-      register_prefix([
+      register_prefix(
         '\d+A\d*[CF]?\d*[CF]?\d*',
         'CT3[\+\-]?',
         'CTR[\+\-]?',
         'DJV\-?',
         'AKST[\+\-]?'
-      ])
+      )
 
       def initialize(command)
         super(command)

--- a/lib/bcdice/game_system/BlindMythos.rb
+++ b/lib/bcdice/game_system/BlindMythos.rb
@@ -454,7 +454,7 @@ module BCDice
         ),
       }.freeze
 
-      register_prefix(['BM.*', 'ReRoll\d+.*', 'RP\d+', 'DT'] + TABLES.keys)
+      register_prefix('BM.*', 'ReRoll\d+.*', 'RP\d+', 'DT', TABLES.keys)
     end
   end
 end

--- a/lib/bcdice/game_system/CardRanker.rb
+++ b/lib/bcdice/game_system/CardRanker.rb
@@ -243,7 +243,7 @@ module BCDice
           ]
         ),
       }.freeze
-      register_prefix(['RM', 'CM.*'] + TABLES.keys)
+      register_prefix('RM', 'CM.*', TABLES.keys)
     end
   end
 end

--- a/lib/bcdice/game_system/ChaosFlare.rb
+++ b/lib/bcdice/game_system/ChaosFlare.rb
@@ -41,7 +41,7 @@ module BCDice
           - FT7
       INFO_MESSAGE_TEXT
 
-      register_prefix(['\d*CF.*', 'FT\d*'])
+      register_prefix('\d*CF.*', 'FT\d*')
 
       # ゲーム別成功度判定(2D6)。以前の処理をそのまま残しています。
       def check_2D6(total, dice_total, _dice_list, cmp_op, target)

--- a/lib/bcdice/game_system/Chill.rb
+++ b/lib/bcdice/game_system/Chill.rb
@@ -22,7 +22,7 @@ module BCDice
         　例）SR7　　　sr13　　　SR(7+4)　　　Ssr10
       INFO_MESSAGE_TEXT
 
-      register_prefix(['SR\d+.*'])
+      register_prefix('SR\d+.*')
 
       def check_1D100(total, _dice_total, cmp_op, target)
         return '' if target == '?'

--- a/lib/bcdice/game_system/CodeLayerd.rb
+++ b/lib/bcdice/game_system/CodeLayerd.rb
@@ -28,7 +28,7 @@ module BCDice
           0CL : 1CL[0]と同じ判定
       MESSAGETEXT
 
-      register_prefix(['[+-]?\d*CL([+-]\d+)?[@\d]*.*'])
+      register_prefix('[+-]?\d*CL([+-]\d+)?[@\d]*.*')
 
       def eval_game_system_specific_command(command)
         debug('eval_game_system_specific_command command', command)

--- a/lib/bcdice/game_system/ColossalHunter.rb
+++ b/lib/bcdice/game_system/ColossalHunter.rb
@@ -563,7 +563,7 @@ module BCDice
 
         }.freeze
 
-      register_prefix(["CH.*", "B6T", "CNP"] + TABLES.keys)
+      register_prefix("CH.*", "B6T", "CNP", TABLES.keys)
     end
   end
 end

--- a/lib/bcdice/game_system/CrashWorld.rb
+++ b/lib/bcdice/game_system/CrashWorld.rb
@@ -19,7 +19,7 @@ module BCDice
         例・CW8
       INFO_MESSAGE_TEXT
 
-      register_prefix(['CW\d+'])
+      register_prefix('CW\d+')
 
       def eval_game_system_specific_command(command)
         result = nil

--- a/lib/bcdice/game_system/Cthulhu.rb
+++ b/lib/bcdice/game_system/Cthulhu.rb
@@ -48,7 +48,7 @@ module BCDice
 
       INFO_MESSAGE_TEXT
 
-      register_prefix(['CC(B)?\(\d+\)', 'CC(B)?.*', 'RES(B)?.*', 'CBR(B)?\(\d+,\d+\)'])
+      register_prefix('CC(B)?\(\d+\)', 'CC(B)?.*', 'RES(B)?.*', 'CBR(B)?\(\d+,\d+\)')
 
       def initialize(command)
         super(command)

--- a/lib/bcdice/game_system/Cthulhu7th.rb
+++ b/lib/bcdice/game_system/Cthulhu7th.rb
@@ -45,7 +45,7 @@ module BCDice
         　　強力でない呪文の場合　FCL／強力な呪文の場合　FCM
       INFO_MESSAGE_TEXT
 
-      register_prefix(['CC\(\d+\)', 'CC.*', 'CBR\(\d+,\d+\)', 'FAR.*', 'BMR', 'BMS', 'FCL', 'FCM', 'PH', 'MA'])
+      register_prefix('CC\(\d+\)', 'CC.*', 'CBR\(\d+,\d+\)', 'FAR.*', 'BMR', 'BMS', 'FCL', 'FCM', 'PH', 'MA')
 
       def initialize(command)
         super(command)

--- a/lib/bcdice/game_system/Cthulhu7th_ChineseTraditional.rb
+++ b/lib/bcdice/game_system/Cthulhu7th_ChineseTraditional.rb
@@ -35,7 +35,7 @@ module BCDice
         ・實時型　Short／總結型　Longer
       INFO_MESSAGE_TEXT
 
-      register_prefix(['CC\(\d+\)', 'CC.*', 'CBR\(\d+,\d+\)', 'FAR\(\d+\)', 'FAR.*'])
+      register_prefix('CC\(\d+\)', 'CC.*', 'CBR\(\d+,\d+\)', 'FAR\(\d+\)', 'FAR.*')
 
       def initialize(command)
         super(command)

--- a/lib/bcdice/game_system/Cthulhu7th_Korean.rb
+++ b/lib/bcdice/game_system/Cthulhu7th_Korean.rb
@@ -32,7 +32,7 @@ module BCDice
         예）FAR(25,70,98)　FAR(50,80,98,-1)
       INFO_MESSAGE_TEXT
 
-      register_prefix(['CC\(\d+\)', 'CC.*', 'CBR\(\d+,\d+\)', 'FAR\(\d+\)', 'FAR.*'])
+      register_prefix('CC\(\d+\)', 'CC.*', 'CBR\(\d+,\d+\)', 'FAR\(\d+\)', 'FAR.*')
 
       def initialize(command)
         super(command)

--- a/lib/bcdice/game_system/CthulhuTech.rb
+++ b/lib/bcdice/game_system/CthulhuTech.rb
@@ -6,7 +6,7 @@ require 'bcdice/arithmetic_evaluator'
 module BCDice
   module GameSystem
     class CthulhuTech < Base
-      register_prefix(['\d+D10.*'])
+      register_prefix('\d+D10.*')
 
       # ゲームシステムの識別子
       ID = 'CthulhuTech'

--- a/lib/bcdice/game_system/DarkBlaze.rb
+++ b/lib/bcdice/game_system/DarkBlaze.rb
@@ -29,7 +29,7 @@ module BCDice
         　例）BT1　　　BT2　　　BT[1...3]
       INFO_MESSAGE_TEXT
 
-      register_prefix(['DB.*', 'BT.*', '3R6.*'])
+      register_prefix('DB.*', 'BT.*', '3R6.*')
 
       def replace_text(string)
         return string unless string =~ /DB/i

--- a/lib/bcdice/game_system/DarkDaysDrive.rb
+++ b/lib/bcdice/game_system/DarkDaysDrive.rb
@@ -419,7 +419,7 @@ module BCDice
         ),
       }.freeze
 
-      register_prefix(['RTT'] + TABLES.keys)
+      register_prefix('RTT', TABLES.keys)
     end
   end
 end

--- a/lib/bcdice/game_system/DarkSouls.rb
+++ b/lib/bcdice/game_system/DarkSouls.rb
@@ -25,7 +25,7 @@ module BCDice
         　　DS+2@10 → 2D6+2で目標値10の判定
       MESSAGETEXT
 
-      register_prefix(['(\d+)?(A)?DS([-+\d]*)(@\d+)?'])
+      register_prefix('(\d+)?(A)?DS([-+\d]*)(@\d+)?')
 
       def eval_game_system_specific_command(command)
         return nil unless (m = /(\d+)?(A)?DS([-+\d]*)(@(\d+))?$/i.match(command.upcase))

--- a/lib/bcdice/game_system/DeadlineHeroes.rb
+++ b/lib/bcdice/game_system/DeadlineHeroes.rb
@@ -32,12 +32,12 @@ module BCDice
         ・リアルネームチャート　日本（RNCJ）、海外（RNCO）
       INFO_MESSAGE_TEXT
 
-      register_prefix([
+      register_prefix(
         'DLH\\d+([\\+\\-]\\d+)*',
         'DC(L|S|C)\d+',
         'RNC[JO]',
         'HNC'
-      ])
+      )
 
       def eval_game_system_specific_command(command)
         case command

--- a/lib/bcdice/game_system/DemonParasite.rb
+++ b/lib/bcdice/game_system/DemonParasite.rb
@@ -28,7 +28,7 @@ module BCDice
         ・D66ダイスあり
       INFO_MESSAGE_TEXT
 
-      register_prefix(['[NAMUC]?URGE\d+'])
+      register_prefix('[NAMUC]?URGE\d+')
 
       def initialize(command)
         super(command)

--- a/lib/bcdice/game_system/DiceOfTheDead.rb
+++ b/lib/bcdice/game_system/DiceOfTheDead.rb
@@ -21,7 +21,7 @@ module BCDice
         （上記二つは最初からシークレットダイスで行われます）
       INFO_MESSAGE_TEXT
 
-      register_prefix(['(ZMB|BIO).*'])
+      register_prefix('(ZMB|BIO).*')
 
       def initialize(command)
         super(command)

--- a/lib/bcdice/game_system/EarthDawn.rb
+++ b/lib/bcdice/game_system/EarthDawn.rb
@@ -20,7 +20,7 @@ module BCDice
         例）9E　10E8　10E+D12
       INFO_MESSAGE_TEXT
 
-      register_prefix(['\d+e.*'])
+      register_prefix('\d+e.*')
 
       def initialize(command)
         super(command)

--- a/lib/bcdice/game_system/EarthDawn3.rb
+++ b/lib/bcdice/game_system/EarthDawn3.rb
@@ -24,7 +24,7 @@ module BCDice
         　　ステップ12、目標値8、カルマダイスD12：10E8+1D6
       INFO_MESSAGE_TEXT
 
-      register_prefix(['\d+e.*'])
+      register_prefix('\d+e.*')
 
       def initialize(command)
         super(command)

--- a/lib/bcdice/game_system/EarthDawn4.rb
+++ b/lib/bcdice/game_system/EarthDawn4.rb
@@ -24,7 +24,7 @@ module BCDice
         　　ステップ10、目標値8、カルマダイス：10E8K
       INFO_MESSAGE_TEXT
 
-      register_prefix(['\d+e.*'])
+      register_prefix('\d+e.*')
 
       def initialize(command)
         super(command)

--- a/lib/bcdice/game_system/Elysion.rb
+++ b/lib/bcdice/game_system/Elysion.rb
@@ -1200,14 +1200,14 @@ module BCDice
         ),
       }.freeze
 
-      register_prefix([
+      register_prefix(
         'EL.*',
         'DATE.*', 'FDATE.*', 'ODATE.*', 'MDATE.*',
         'RBT', 'SBT', 'BBT', 'CBT', 'DBT', 'IBT', 'FBT', 'LBT', 'PBT', 'NBT', 'ABT', 'VBT', 'GBT', 'HBT',
         'BFT', 'FWT', 'FT',
         'SRT', 'ORT', 'DRT', 'URT',
-        'NJ\d+', 'BS\d+'
-      ] + TABLES.keys)
+        'NJ\d+', 'BS\d+', TABLES.keys
+      )
     end
   end
 end

--- a/lib/bcdice/game_system/EmbryoMachine.rb
+++ b/lib/bcdice/game_system/EmbryoMachine.rb
@@ -24,7 +24,7 @@ module BCDice
         　・射撃攻撃ファンブル表　SFT
       INFO_MESSAGE_TEXT
 
-      register_prefix(['EM\d+.*', 'HLT', 'MFT', 'SFT', '2R10.*'])
+      register_prefix('EM\d+.*', 'HLT', 'MFT', 'SFT', '2R10.*')
 
       def initialize(command)
         super(command)

--- a/lib/bcdice/game_system/EndBreaker.rb
+++ b/lib/bcdice/game_system/EndBreaker.rb
@@ -20,7 +20,7 @@ module BCDice
           ・生死不明表 (LDUT)
       MESSAGETEXT
 
-      register_prefix(['\d+EB', 'LDUT'])
+      register_prefix('\d+EB', 'LDUT')
 
       def initialize(command)
         super(command)

--- a/lib/bcdice/game_system/EtrianOdysseySRS.rb
+++ b/lib/bcdice/game_system/EtrianOdysseySRS.rb
@@ -16,7 +16,7 @@ module BCDice
       SORT_KEY = 'せかいしゆのめいきゆうSRS'
 
       # 固有のコマンドの接頭辞を設定する
-      register_prefix(['2D6.*', 'EO.*', 'SQ.*'])
+      register_prefix('2D6.*', 'EO.*', 'SQ.*')
 
       # 成功判定のエイリアスコマンドを設定する
       set_aliases_for_srs_roll('EO', 'SQ')

--- a/lib/bcdice/game_system/FilledWith.rb
+++ b/lib/bcdice/game_system/FilledWith.rb
@@ -44,7 +44,7 @@ module BCDice
         ・迷宮追加オプション表(ROPd)
       MESSAGETEXT
 
-      register_prefix(['3FW.*', '[\+\-\d]*-3FW.*', 'LOT[NP]', 'HST', 'COOK[1-8]', 'RAND.*', 'RENC.*', 'RED.*', 'TRS.*', 'TRAP[ENHL]', 'ROP[ENHL]'])
+      register_prefix('3FW.*', '[\+\-\d]*-3FW.*', 'LOT[NP]', 'HST', 'COOK[1-8]', 'RAND.*', 'RENC.*', 'RED.*', 'TRS.*', 'TRAP[ENHL]', 'ROP[ENHL]')
 
       def initialize(command)
         super(command)

--- a/lib/bcdice/game_system/FullMetalPanic.rb
+++ b/lib/bcdice/game_system/FullMetalPanic.rb
@@ -16,7 +16,7 @@ module BCDice
       SORT_KEY = 'ふるめたるはにつくRPG'
 
       # 固有のコマンドの接頭辞を設定する
-      register_prefix(['2D6.*', 'MG.*', 'FP.*'])
+      register_prefix('2D6.*', 'MG.*', 'FP.*')
 
       # 成功判定のエイリアスコマンドを設定する
       set_aliases_for_srs_roll('MG', 'FP')

--- a/lib/bcdice/game_system/GURPS.rb
+++ b/lib/bcdice/game_system/GURPS.rb
@@ -32,7 +32,7 @@ module BCDice
         ・D66ダイスあり
       INFO_MESSAGE_TEXT
 
-      register_prefix(['\w*CRT', '\w*FMB', 'HIT', 'FEAR((\+)?\d*)', 'REACT((\+|\-)?\d*)', '[\d\+\-]+\-3[dD]6?[\d\+\-]*'])
+      register_prefix('\w*CRT', '\w*FMB', 'HIT', 'FEAR((\+)?\d*)', 'REACT((\+|\-)?\d*)', '[\d\+\-]+\-3[dD]6?[\d\+\-]*')
 
       def initialize(command)
         super(command)

--- a/lib/bcdice/game_system/Garako.rb
+++ b/lib/bcdice/game_system/Garako.rb
@@ -553,7 +553,7 @@ module BCDice
         )
       }.freeze
 
-      register_prefix(['GR.*', '(C|E|F|A|L)DC\d+'] + TABLES.keys)
+      register_prefix('GR.*', '(C|E|F|A|L)DC\d+', TABLES.keys)
     end
   end
 end

--- a/lib/bcdice/game_system/GardenOrder.rb
+++ b/lib/bcdice/game_system/GardenOrder.rb
@@ -25,10 +25,10 @@ module BCDice
         　例）DCSL7　DCEL22
       INFO_MESSAGE_TEXT
 
-      register_prefix([
+      register_prefix(
         'GO(\-?\d+)(\/\d+)?(@\d+)?',
         'DC(SL|BL|IM|BR|RF|EL).+'
-      ])
+      )
 
       def eval_game_system_specific_command(command)
         case command

--- a/lib/bcdice/game_system/GehennaAn.rb
+++ b/lib/bcdice/game_system/GehennaAn.rb
@@ -23,7 +23,7 @@ module BCDice
         　幸運の助けを自動処理します。(連撃増加値、闘技チットを表示抑制します)
       INFO_MESSAGE_TEXT
 
-      register_prefix(['\d+G\d+.*', '\d+GA\d+.*', '\d+R6.*'])
+      register_prefix('\d+G\d+.*', '\d+GA\d+.*', '\d+R6.*')
 
       def initialize(command)
         super(command)

--- a/lib/bcdice/game_system/GeishaGirlwithKatana.rb
+++ b/lib/bcdice/game_system/GeishaGirlwithKatana.rb
@@ -26,7 +26,7 @@ module BCDice
         　例）GL
       MESSAGETEXT
 
-      register_prefix(['GK(#\d+)?', 'GL'])
+      register_prefix('GK(#\d+)?', 'GL')
 
       def eval_game_system_specific_command(command)
         output = nil

--- a/lib/bcdice/game_system/GoblinSlayer.rb
+++ b/lib/bcdice/game_system/GoblinSlayer.rb
@@ -41,7 +41,7 @@ module BCDice
       MESSAGETEXT
 
       # 因果点は共有リソースなのでMCPIはシークレットダイスを無効化
-      register_prefix(['GS\(\d+\)', 'GS.*', '^MCPI.*\$\d+$', 'DB\d+'])
+      register_prefix('GS\(\d+\)', 'GS.*', '^MCPI.*\$\d+$', 'DB\d+')
 
       def initialize(command)
         super(command)

--- a/lib/bcdice/game_system/GoldenSkyStories.rb
+++ b/lib/bcdice/game_system/GoldenSkyStories.rb
@@ -21,7 +21,7 @@ module BCDice
           あーしたてんきになーれ
       MESSAGETEXT
 
-      register_prefix(['geta'])
+      register_prefix('geta')
 
       def initialize(command)
         super(command)

--- a/lib/bcdice/game_system/Gorilla.rb
+++ b/lib/bcdice/game_system/Gorilla.rb
@@ -21,7 +21,7 @@ module BCDice
         例) G>=7 : 2D6して7以上なら成功
       MESSAGETEXT
 
-      register_prefix(['G.*'])
+      register_prefix('G.*')
 
       def change_text(string)
         string = string.gsub(/^(S)?G/i) { "#{Regexp.last_match(1)}2D6" }

--- a/lib/bcdice/game_system/GranCrest.rb
+++ b/lib/bcdice/game_system/GranCrest.rb
@@ -24,7 +24,7 @@ module BCDice
         　組織表（OCT）、拠点表（BCT）、文化表（CCT）
       MESSAGETEXT
 
-      register_prefix([
+      register_prefix(
         'MT',
         'PFT',
         'NFT',
@@ -35,7 +35,7 @@ module BCDice
         'OCT',
         'BCT',
         'CCT'
-      ])
+      )
 
       def initialize(command)
         super(command)

--- a/lib/bcdice/game_system/GundogRevised.rb
+++ b/lib/bcdice/game_system/GundogRevised.rb
@@ -26,7 +26,7 @@ module BCDice
         　修正を後ろに書くことも出来ます。
       INFO_MESSAGE_TEXT
 
-      register_prefix(['(.DPT|.FT)(\+|\-)?\d*'])
+      register_prefix('(.DPT|.FT)(\+|\-)?\d*')
 
       def initialize(command)
         super(command)

--- a/lib/bcdice/game_system/GundogZero.rb
+++ b/lib/bcdice/game_system/GundogZero.rb
@@ -26,7 +26,7 @@ module BCDice
         　修正を後ろに書くことも出来ます。
       INFO_MESSAGE_TEXT
 
-      register_prefix(['(.DPT|.FT)\d*'])
+      register_prefix('(.DPT|.FT)\d*')
 
       def eval_game_system_specific_command(command)
         string = command.upcase

--- a/lib/bcdice/game_system/GurpsFW.rb
+++ b/lib/bcdice/game_system/GurpsFW.rb
@@ -52,7 +52,7 @@ module BCDice
         ・迷宮追加オプション表(RANDOP)
       INFO_MESSAGE_TEXT
 
-      register_prefix([
+      register_prefix(
         'CRT',
         'HCRT',
         'FMB',
@@ -70,7 +70,7 @@ module BCDice
         'KHST',
         'RANDOP',
         'LOT(N|P)'
-      ])
+      )
 
       def initialize(command)
         super(command)

--- a/lib/bcdice/game_system/HarnMaster.rb
+++ b/lib/bcdice/game_system/HarnMaster.rb
@@ -21,7 +21,7 @@ module BCDice
         ・人型用　中段命中部位表 (SLH)／上段命中部位 (SLHU)／上段命中部位 (SLHD)
       MESSAGETEXT
 
-      register_prefix(['SHK\d+.*', 'SLH', 'SLHU', 'SLHD'])
+      register_prefix('SHK\d+.*', 'SLH', 'SLHU', 'SLHD')
 
       def check_1D100(total, _dice_total, cmp_op, target)
         return '' if target == '?'

--- a/lib/bcdice/game_system/HatsuneMiku.rb
+++ b/lib/bcdice/game_system/HatsuneMiku.rb
@@ -700,7 +700,7 @@ module BCDice
         ),
       }.freeze
 
-      register_prefix(['R([A-DS]|\d+).*'] + TABLES.keys)
+      register_prefix('R([A-DS]|\d+).*', TABLES.keys)
     end
   end
 end

--- a/lib/bcdice/game_system/HouraiGakuen.rb
+++ b/lib/bcdice/game_system/HouraiGakuen.rb
@@ -31,7 +31,7 @@ module BCDice
           例）Hourai : 仁義八徳は、【義】(奇数、奇数、偶数)
       INFO_MESSAGE_TEXT
 
-      register_prefix(['ROL.*', 'MED\(\d+,\d+\)', 'RES\(\d+,\d+\)', 'INY.*', 'HTK.*', 'GOG.*'])
+      register_prefix('ROL.*', 'MED\(\d+,\d+\)', 'RES\(\d+,\d+\)', 'INY.*', 'HTK.*', 'GOG.*')
 
       # ゲームの名前
       # チャット欄表示名

--- a/lib/bcdice/game_system/HuntersMoon.rb
+++ b/lib/bcdice/game_system/HuntersMoon.rb
@@ -497,7 +497,7 @@ module BCDice
         ),
       }.freeze
 
-      register_prefix(['SA2?T\d*'] + TABLES.keys)
+      register_prefix('SA2?T\d*', TABLES.keys)
     end
   end
 end

--- a/lib/bcdice/game_system/Illusio.rb
+++ b/lib/bcdice/game_system/Illusio.rb
@@ -32,9 +32,9 @@ module BCDice
         @sort_add_dice = true # ダイスのソート有
       end
 
-      register_prefix([
+      register_prefix(
         '(\d+)?IL([1-6])?([1-6])?([1-6])?([1-6])?([1-6])?([1-6])?(P)?'
-      ])
+      )
 
       def eval_game_system_specific_command(command)
         if command =~ /(\d+)?IL([1-6])?([1-6])?([1-6])?([1-6])?([1-6])?([1-6])?(P)?$/i

--- a/lib/bcdice/game_system/KanColle.rb
+++ b/lib/bcdice/game_system/KanColle.rb
@@ -929,10 +929,11 @@ module BCDice
         ),
       }.freeze
 
-      register_prefix([
+      register_prefix(
         'DVT', 'DVTM', 'WP1T', 'WP2T', 'WP3T', 'WP4T',
         'KTM', 'BT', 'KHT', 'KMT', 'KST', 'KSYT', 'KKT', 'KSNT',
-      ] + TABLES.keys)
+        TABLES.keys
+      )
     end
   end
 end

--- a/lib/bcdice/game_system/KemonoNoMori.rb
+++ b/lib/bcdice/game_system/KemonoNoMori.rb
@@ -252,7 +252,7 @@ module BCDice
         ),
       }.freeze
 
-      register_prefix(['K[AC]\d[-+\d]*', 'CTR'] + TABLES.keys)
+      register_prefix('K[AC]\d[-+\d]*', 'CTR', TABLES.keys)
     end
   end
 end

--- a/lib/bcdice/game_system/KurayamiCrying.rb
+++ b/lib/bcdice/game_system/KurayamiCrying.rb
@@ -43,7 +43,7 @@ module BCDice
         ),
       }.freeze
 
-      register_prefix(["ACT.*"] + TABLES.keys)
+      register_prefix("ACT.*", TABLES.keys)
     end
   end
 end

--- a/lib/bcdice/game_system/LiveraDoll.rb
+++ b/lib/bcdice/game_system/LiveraDoll.rb
@@ -44,10 +44,10 @@ module BCDice
         例：WO3（白のオーナーズネイルの3番目『罪なき純白』）
       MESSAGETEXT
 
-      register_prefix([
+      register_prefix(
         '(C|K|W|R|B|G|E)(L|D|O)\d+',
         '(\d+)?ATK([1-6])?([1-6])?([1-6])?([1-6])?([1-6])?([1-6])?'
-      ])
+      )
 
       def initialize(command)
         super(command)

--- a/lib/bcdice/game_system/LostRoyal.rb
+++ b/lib/bcdice/game_system/LostRoyal.rb
@@ -35,7 +35,7 @@ module BCDice
         　　x にはダイスの数（ 1 - 2 ）を指定
       INFO_MESSAGE_TEXT
 
-      register_prefix(['LR\[[0-5],[0-5],[0-5],[0-5],[0-5],[0-5]\]', 'FC', 'WPC', 'EC', 'HR[1-2]'])
+      register_prefix('LR\[[0-5],[0-5],[0-5],[0-5],[0-5],[0-5]\]', 'FC', 'WPC', 'EC', 'HR[1-2]')
 
       def initialize(command)
         super(command)

--- a/lib/bcdice/game_system/MagicaLogia.rb
+++ b/lib/bcdice/game_system/MagicaLogia.rb
@@ -44,7 +44,7 @@ module BCDice
         ・D66ダイスあり
       INFO_MESSAGE_TEXT
 
-      register_prefix(['WT', 'FCT', 'ST', 'FT', 'AT', 'BGT', 'DAT', 'FAT', 'WIT', 'RTT', 'TPT', 'TCT', 'PCT', 'MCT', 'ICT', 'SCT', 'XCT', 'WCT', 'CCT', 'BST', 'PT', 'XEST', 'IWST', 'MCST', 'WDST', 'LWST', 'MIT', 'MOT', 'MAT', 'MUT', 'MFT', 'MLT', 'STB', 'RTS', 'RTB', 'RTF', 'RTP', 'RTD', 'RTN', 'MGCT', 'MBST', 'MAST', 'TCST', 'PWST', 'PAST', 'GBST', 'SLST', 'WLAT', 'WMT', 'FFT', 'OLST', 'TPTB', 'FLT'])
+      register_prefix('WT', 'FCT', 'ST', 'FT', 'AT', 'BGT', 'DAT', 'FAT', 'WIT', 'RTT', 'TPT', 'TCT', 'PCT', 'MCT', 'ICT', 'SCT', 'XCT', 'WCT', 'CCT', 'BST', 'PT', 'XEST', 'IWST', 'MCST', 'WDST', 'LWST', 'MIT', 'MOT', 'MAT', 'MUT', 'MFT', 'MLT', 'STB', 'RTS', 'RTB', 'RTF', 'RTP', 'RTD', 'RTN', 'MGCT', 'MBST', 'MAST', 'TCST', 'PWST', 'PAST', 'GBST', 'SLST', 'WLAT', 'WMT', 'FFT', 'OLST', 'TPTB', 'FLT')
 
       def initialize(command)
         super(command)

--- a/lib/bcdice/game_system/MeikyuDays.rb
+++ b/lib/bcdice/game_system/MeikyuDays.rb
@@ -409,7 +409,7 @@ module BCDice
         ),
       }.freeze
 
-      register_prefix(['\d+MD6?.*', '\d+R6.*'] + TABLES.keys)
+      register_prefix('\d+MD6?.*', '\d+R6.*', TABLES.keys)
     end
   end
 end

--- a/lib/bcdice/game_system/MeikyuKingdom.rb
+++ b/lib/bcdice/game_system/MeikyuKingdom.rb
@@ -41,7 +41,7 @@ module BCDice
         ・D66ダイスあり
       INFO_MESSAGE_TEXT
 
-      register_prefix([
+      register_prefix(
         '\d+MK.*', '\d+R6.*',
         'LRT', 'ORT', 'CRT', 'ART', 'FRT',
         'TBT', 'CBT', 'SBT', 'VBT', 'FBT', 'ABT', 'WBT', 'LBT',
@@ -57,7 +57,7 @@ module BCDice
         '\d+RET',
         'PNT\d*', 'MLT\d*',
         'KNT\d+', 'WORD\d+'
-      ])
+      )
 
       def initialize(command)
         super(command)

--- a/lib/bcdice/game_system/MeikyuKingdomBasic.rb
+++ b/lib/bcdice/game_system/MeikyuKingdomBasic.rb
@@ -56,7 +56,7 @@ module BCDice
          ・D66ダイスあり
       INFO_MESSAGE_TEXT
 
-      register_prefix([ # ダイスボットで使用するコマンドを配列で列挙すること。
+      register_prefix(
         '\d+MK.*', '\d+R6.*',
         'IG', 'TT', 'NT', 'RMS',
         'CFT', 'FWT', 'CAT', 'KDT', 'KCT',
@@ -72,8 +72,8 @@ module BCDice
         'BUS', 'SHS', 'ASS', 'SUS', 'SCS', 'LAS', 'NES', 'COS', 'ENS', 'TOS',
         'ABUS', 'ASHS', 'AASS', 'ASUS', 'ASCS', 'ALAS', 'ANES', 'ACOS', 'AENS', 'ATOS',
         'SE', 'ARN', 'WEN', 'NEN', 'CEN', 'SEN', 'OEN',
-        'DFT\d+',
-      ])
+        'DFT\d+'
+      )
 
       def initialize(command)
         super(command)

--- a/lib/bcdice/game_system/MetalHead.rb
+++ b/lib/bcdice/game_system/MetalHead.rb
@@ -35,7 +35,7 @@ module BCDice
           例）CRCM98 対物で数値98の戦闘結果を参照する。
       MESSAGETEXT
 
-      register_prefix(['AR', 'SR', 'HR<=.+', 'CC', 'ACT', 'ACL', 'ACS', 'CRC[A-Z]\d+'])
+      register_prefix('AR', 'SR', 'HR<=.+', 'CC', 'ACT', 'ACL', 'ACS', 'CRC[A-Z]\d+')
 
       def eval_game_system_specific_command(command)
         result = roll_tables(command, TABLES)

--- a/lib/bcdice/game_system/MetalHeadExtream.rb
+++ b/lib/bcdice/game_system/MetalHeadExtream.rb
@@ -50,13 +50,13 @@ module BCDice
         荒野ランダムエンカウント表：WENC[n]
       MESSAGETEXT
 
-      register_prefix([
+      register_prefix(
         '[AS]R\d+.*',
         '(HU|BK|WA|SC|BG|IN|PT|HT|TA|AC|HE|TR|VT|BO|CS|TH|AM|GD|HC|BI|BT|AI)HIT\d*',
         'SUV[A-Z]\d+', '[HTALMEBPD]DMG[LMHO]',
         'CRT\d*', '[GSME]AC\d*', '[ASL]MA\d*(\+\d+)?',
         'SEC', 'NAC', 'LDC', '[W]ENC\d*'
-      ])
+      )
 
       def eval_game_system_specific_command(command)
         text =

--- a/lib/bcdice/game_system/MetallicGuardian.rb
+++ b/lib/bcdice/game_system/MetallicGuardian.rb
@@ -7,7 +7,7 @@ module BCDice
   module GameSystem
     class MetallicGuardian < SRS
       # 固有のコマンドの接頭辞を設定する
-      register_prefix(['2D6.*', 'MG.*'])
+      register_prefix('2D6.*', 'MG.*')
 
       # 成功判定のエイリアスコマンドを設定する
       set_aliases_for_srs_roll('MG')

--- a/lib/bcdice/game_system/NeverCloud.rb
+++ b/lib/bcdice/game_system/NeverCloud.rb
@@ -26,7 +26,7 @@ module BCDice
       MESSAGETEXT
 
       # ダイスボットで使用するコマンドを配列で列挙する
-      register_prefix(['\d+NC.*', '\d+D6?([\+\-\d]*)>=\d+'])
+      register_prefix('\d+NC.*', '\d+D6?([\+\-\d]*)>=\d+')
 
       def eval_game_system_specific_command(command)
         m = /^(\d+)(?:NC|D6?)((?:[-+]\d+)*)(>=(\d+))?$/i.match(command)

--- a/lib/bcdice/game_system/NightWizard.rb
+++ b/lib/bcdice/game_system/NightWizard.rb
@@ -29,7 +29,7 @@ module BCDice
         　例）12NW-5@7#2$3 1NW 50nw+5@7,10#2,5 50nw-5+10@7,10#2,5+15+25
       INFO_MESSAGE_TEXT
 
-      register_prefix(['([-+]?\d+)?NW.*', '2R6.*'])
+      register_prefix('([-+]?\d+)?NW.*', '2R6.*')
 
       def initialize(command)
         super(command)

--- a/lib/bcdice/game_system/NightWizard3rd.rb
+++ b/lib/bcdice/game_system/NightWizard3rd.rb
@@ -14,7 +14,7 @@ module BCDice
       # ゲームシステムの識別子
       ID = 'NightWizard3rd'
 
-      register_prefix(['([-+]?\d+)?NW.*', '2R6.*'])
+      register_prefix('([-+]?\d+)?NW.*', '2R6.*')
 
       def fumble_base_number(parsed)
         parsed.passive_modify_number + parsed.active_modify_number

--- a/lib/bcdice/game_system/NinjaSlayer.rb
+++ b/lib/bcdice/game_system/NinjaSlayer.rb
@@ -40,13 +40,13 @@ module BCDice
       MESSAGETEXT
 
       # ダイスボットで使用するコマンドを配列で列挙する
-      register_prefix([
+      register_prefix(
         'NJ\d+.*',
         'EV\d+.*',
         'AT\d+.*',
         'EL\d+.*',
         'SB'
-      ])
+      )
 
       def initialize(command)
         super(command)
@@ -263,12 +263,13 @@ module BCDice
       }.freeze
 
       # ダイスボットで使用するコマンドを配列で列挙する
-      register_prefix([
+      register_prefix(
         'NJ\d+.*',
         'EV\d+.*',
         'AT\d+.*',
-        'EL\d+.*'
-      ] + TABLES.keys)
+        'EL\d+.*',
+        TABLES.keys
+      )
     end
   end
 end

--- a/lib/bcdice/game_system/OneWayHeroics.rb
+++ b/lib/bcdice/game_system/OneWayHeroics.rb
@@ -128,7 +128,7 @@ module BCDice
         return "失敗"
       end
 
-      register_prefix(['\d*JD.*', 'RETP?\d+', 'DNGNP?\d+'] + TABLES.keys)
+      register_prefix('\d*JD.*', 'RETP?\d+', 'DNGNP?\d+', TABLES.keys)
     end
   end
 end

--- a/lib/bcdice/game_system/OracleEngine.rb
+++ b/lib/bcdice/game_system/OracleEngine.rb
@@ -35,7 +35,7 @@ module BCDice
 MESSAGETEXT
 
       # ダイスボットで使用するコマンドを配列で列挙する
-      register_prefix(['\d+CL.*', '\d+R6.*', '\d+D6.*\$[\+\-]?\d+.*'])
+      register_prefix('\d+CL.*', '\d+R6.*', '\d+D6.*\$[\+\-]?\d+.*')
 
       def initialize(command)
         super(command)

--- a/lib/bcdice/game_system/OrgaRain.rb
+++ b/lib/bcdice/game_system/OrgaRain.rb
@@ -30,9 +30,9 @@ module BCDice
         @sort_add_dice = true # ダイスのソート有
       end
 
-      register_prefix([
+      register_prefix(
         '(\d+)?OR([0-9])?([0-9])?([0-9])?([0-9])?([0-9])?([0-9])?'
-      ])
+      )
 
       def eval_game_system_specific_command(command)
         if command =~ /(\d+)?OR([0-9])?([0-9])?([0-9])?([0-9])?([0-9])?([0-9])?$/i

--- a/lib/bcdice/game_system/Paradiso.rb
+++ b/lib/bcdice/game_system/Paradiso.rb
@@ -25,7 +25,7 @@ module BCDice
         　例）DC4:【攻撃力】4でダメージチェック　DC5[20]:【攻撃力】5でダメージチェック、うち1つは20mm機銃　DC5[20,30]:【攻撃力】5でダメージチェック、うち1つは20mm機銃、うち1つは30mmガンポッド
       MESSAGETEXT
 
-      register_prefix(['(\d+)*D20<=.*', '(\d+)*CP.*', 'RMT', 'TOT', 'EXT', 'SUT', 'DC(\d+).*'])
+      register_prefix('(\d+)*D20<=.*', '(\d+)*CP.*', 'RMT', 'TOT', 'EXT', 'SUT', 'DC(\d+).*')
 
       def eval_game_system_specific_command(command) # ダイスロールコマンド
         # 通常判定部分をgetJudgeResultコマンドに切り分け

--- a/lib/bcdice/game_system/Paranoia.rb
+++ b/lib/bcdice/game_system/Paranoia.rb
@@ -18,7 +18,7 @@ module BCDice
         ※このダイスボットは部屋のシステム名表示用となります。
       MESSAGETEXT
 
-      register_prefix(['geta'])
+      register_prefix('geta')
 
       def initialize(command)
         super(command)

--- a/lib/bcdice/game_system/ParanoiaRebooted.rb
+++ b/lib/bcdice/game_system/ParanoiaRebooted.rb
@@ -26,7 +26,7 @@ module BCDice
         例）MP2
       INFO_MESSAGE_TEXT
 
-      register_prefix(['ND.*', 'MP.*'])
+      register_prefix('ND.*', 'MP.*')
 
       def eval_game_system_specific_command(command)
         case command

--- a/lib/bcdice/game_system/ParasiteBlood.rb
+++ b/lib/bcdice/game_system/ParasiteBlood.rb
@@ -26,7 +26,7 @@ module BCDice
         ・D66ダイスあり
       INFO_MESSAGE_TEXT
 
-      register_prefix(['(N|A|M|U|C|)?URGE\d+'])
+      register_prefix('(N|A|M|U|C|)?URGE\d+')
 
       def get_urge(string) # パラサイトブラッドの衝動表
         unless /(\w*)URGE\s*(\d+)/i =~ string

--- a/lib/bcdice/game_system/Peekaboo.rb
+++ b/lib/bcdice/game_system/Peekaboo.rb
@@ -318,7 +318,7 @@ module BCDice
         ),
       }.freeze
 
-      register_prefix(['RTT'] + TABLES.keys)
+      register_prefix('RTT', TABLES.keys)
     end
   end
 end

--- a/lib/bcdice/game_system/Postman.rb
+++ b/lib/bcdice/game_system/Postman.rb
@@ -37,11 +37,11 @@ module BCDice
         ◆自由行動シチュエーション表：FRE
       MESSAGETEXT
 
-      register_prefix([
+      register_prefix(
         'WEA\d*',
         '(\d+)?PO.*',
         'FRE'
-      ])
+      )
 
       def initialize(command)
         super(command)

--- a/lib/bcdice/game_system/PulpCthulhu.rb
+++ b/lib/bcdice/game_system/PulpCthulhu.rb
@@ -47,7 +47,7 @@ module BCDice
         　・プッシュ時のキャスティング・ロールの失敗（Failed Casting Effects）表　FCE
       INFO_MESSAGE_TEXT
 
-      register_prefix(['CC\(\d+\)', 'CC.*', 'CBR\(\d+,\d+\)', 'FAR.*', 'BMR', 'BMS', 'FCE', 'PH', 'MA', 'IT'])
+      register_prefix('CC\(\d+\)', 'CC.*', 'CBR\(\d+,\d+\)', 'FAR.*', 'BMR', 'BMS', 'FCE', 'PH', 'MA', 'IT')
 
       def eval_game_system_specific_command(command)
         case command

--- a/lib/bcdice/game_system/Raisondetre.rb
+++ b/lib/bcdice/game_system/Raisondetre.rb
@@ -38,10 +38,10 @@ module BCDice
         @sort_add_dice = true # ダイスのソート有
       end
 
-      register_prefix([
+      register_prefix(
         '(-)?(\d+)?RD(\d+)?(@(\d+))?',
         '(-)?(\d+)?DD([1-9])?([\+\-]\d+)?'
-      ])
+      )
 
       def eval_game_system_specific_command(command)
         if command =~ /(-)?(\d+)?RD(\d+)?(@(\d+))?$/i

--- a/lib/bcdice/game_system/RecordOfLodossWar.rb
+++ b/lib/bcdice/game_system/RecordOfLodossWar.rb
@@ -19,7 +19,7 @@ module BCDice
         　判定と回避判定は、どちらもコマンドだけの場合、出目の表示と自動成功と自動失敗の判定のみを行います。
       INFO_MESSAGE_TEXT
 
-      register_prefix(['LW.*'])
+      register_prefix('LW.*')
 
       def eval_game_system_specific_command(command)
         parser = CommandParser.new("LW", "LWD")

--- a/lib/bcdice/game_system/RecordOfSteam.rb
+++ b/lib/bcdice/game_system/RecordOfSteam.rb
@@ -21,7 +21,7 @@ module BCDice
         RecordOfSteam : (4S3@2) ＞ 2,1,2,4,4,4,2,3,4,5,6,6 ＞ 4回転 ＞ 成功数5
       MESSAGETEXT
 
-      register_prefix(['\d+S\d+.*'])
+      register_prefix('\d+S\d+.*')
 
       # サンプルのダイスコマンドは「nSt@c」で n=ダイス個数, t=目標値, c=クリティカル値。@cのみ省略可
 

--- a/lib/bcdice/game_system/RokumonSekai2.rb
+++ b/lib/bcdice/game_system/RokumonSekai2.rb
@@ -22,7 +22,7 @@ module BCDice
         　例) 3RS+1<=9　3R6+1<=9[3]
       INFO_MESSAGE_TEXT
 
-      register_prefix(['\d+RS.*', '3R6.*'])
+      register_prefix('\d+RS.*', '3R6.*')
 
       def initialize(command)
         super(command)

--- a/lib/bcdice/game_system/Ryutama.rb
+++ b/lib/bcdice/game_system/Ryutama.rb
@@ -21,7 +21,7 @@ module BCDice
         例）R8,6>=13
       INFO_MESSAGE_TEXT
 
-      register_prefix(['R\d+.*'])
+      register_prefix('R\d+.*')
 
       def initialize(command)
         super(command)

--- a/lib/bcdice/game_system/SRS.rb
+++ b/lib/bcdice/game_system/SRS.rb
@@ -172,7 +172,7 @@ module BCDice
       end
 
       # 固有のコマンドの接頭辞を設定する
-      register_prefix(['2D6.*'])
+      register_prefix('2D6.*')
 
       # ダイスボットを初期化する
       def initialize(command)

--- a/lib/bcdice/game_system/SamsaraBallad.rb
+++ b/lib/bcdice/game_system/SamsaraBallad.rb
@@ -33,7 +33,7 @@ module BCDice
       MESSAGETEXT
 
       # ダイスボットで使用するコマンドを配列で列挙する
-      register_prefix(['SBS?.*'])
+      register_prefix('SBS?.*')
 
       def eval_game_system_specific_command(command)
         debug("eval_game_system_specific_command Begin")

--- a/lib/bcdice/game_system/Satasupe.rb
+++ b/lib/bcdice/game_system/Satasupe.rb
@@ -47,7 +47,7 @@ module BCDice
         ・D66ダイスあり
       INFO_MESSAGE_TEXT
 
-      register_prefix(['(\d+R|SR\d+|TAGT|\w+IET|\w+IHT|F\w*T|F\w*T|A\w*T|G\w*A\w*T|A\w*T|R\w*FT|NPCT|KusaiMT|EnterT|BudTT|GetgT|GetzT|GetnT|GetkT|GETSST|PayT|TimeUT|\w+IT|ShaokinRET|MinamiRET|ChinatownRET|CivicCenterRET|DowntownRET|WarshipLandRET|LoveLoveRET|AjitoRET|JigokuSpaRET|JailHouseRET).*'])
+      register_prefix('(\d+R|SR\d+|TAGT|\w+IET|\w+IHT|F\w*T|F\w*T|A\w*T|G\w*A\w*T|A\w*T|R\w*FT|NPCT|KusaiMT|EnterT|BudTT|GetgT|GetzT|GetnT|GetkT|GETSST|PayT|TimeUT|\w+IT|ShaokinRET|MinamiRET|ChinatownRET|CivicCenterRET|DowntownRET|WarshipLandRET|LoveLoveRET|AjitoRET|JigokuSpaRET|JailHouseRET).*')
 
       def initialize(command)
         super(command)

--- a/lib/bcdice/game_system/ScreamHighSchool.rb
+++ b/lib/bcdice/game_system/ScreamHighSchool.rb
@@ -36,11 +36,11 @@ module BCDice
         　例）DCSL7　DCEL22
       INFO_MESSAGE_TEXT
 
-      register_prefix([
+      register_prefix(
         '(SH|SHS)(\-?\d+)(\/\d+)?(@\d+)?',
         '(EM|TR|FE)(\-?\d+)(@\d+)?',
         'DC(SL|BL|IM|BR|RF|EL).+'
-      ])
+      )
 
       def eval_game_system_specific_command(command)
         case command

--- a/lib/bcdice/game_system/SevenFortressMobius.rb
+++ b/lib/bcdice/game_system/SevenFortressMobius.rb
@@ -23,7 +23,7 @@ module BCDice
         　例）12SFM-5@7#2　　1SFM　　50SFM+5@7,10#2,5　50SFM-5+10@7,10#2,5+15+25
       INFO_MESSAGE_TEXT
 
-      register_prefix(['([-+]?\d+)?SFM.*', '2R6.*'])
+      register_prefix('([-+]?\d+)?SFM.*', '2R6.*')
 
       def initialize(command)
         super(command)

--- a/lib/bcdice/game_system/ShadowRun5.rb
+++ b/lib/bcdice/game_system/ShadowRun5.rb
@@ -21,7 +21,7 @@ module BCDice
         BコマンドとRコマンド時に、グリッチの表示を行います。
       INFO_MESSAGE_TEXT
 
-      register_prefix(['(\d+)B6@(\d+)'])
+      register_prefix('(\d+)B6@(\d+)')
 
       def initialize(command)
         super(command)

--- a/lib/bcdice/game_system/SharedFantasia.rb
+++ b/lib/bcdice/game_system/SharedFantasia.rb
@@ -21,7 +21,7 @@ module BCDice
         例) SF+4>=9 : 2D6して4を足した値が9以上なら成功
       MESSAGETEXT
 
-      register_prefix(['SF.*', 'ST.*'])
+      register_prefix('SF.*', 'ST.*')
 
       def change_text(string)
         string.gsub(/SF/i, "2D6").gsub(/ST/i, "2D6")

--- a/lib/bcdice/game_system/ShinkuuGakuen.rb
+++ b/lib/bcdice/game_system/ShinkuuGakuen.rb
@@ -33,10 +33,10 @@ module BCDice
         　例）CSW10　CBX76
       MESSAGETEXT
 
-      register_prefix([
+      register_prefix(
         'CRL.*', 'CSW.*', 'CLS.*', 'CSS.*', 'CSP.*', 'CAX.*', 'CCL.*', 'CMA.*', 'CBX.*', 'CPR.*', 'CST.*',
         'RL.*', 'SW.*', 'LS.*', 'SS.*', 'SP.*', 'AX.*', 'CL.*', 'BW.*', 'MA.*', 'BX.*', 'PR.*', 'ST.*'
-      ])
+      )
 
       def eval_game_system_specific_command(command)
         m = /^([A-Z]+)([\+\-]?\d+)?(?:>=(\d+))?$/i.match(command)

--- a/lib/bcdice/game_system/ShinobiGami.rb
+++ b/lib/bcdice/game_system/ShinobiGami.rb
@@ -674,7 +674,7 @@ module BCDice
         }
       ].freeze
 
-      register_prefix(['MT', 'RTT'] + TABLES.keys)
+      register_prefix('MT', 'RTT', TABLES.keys)
     end
   end
 end

--- a/lib/bcdice/game_system/ShoujoTenrankai.rb
+++ b/lib/bcdice/game_system/ShoujoTenrankai.rb
@@ -33,7 +33,7 @@ module BCDice
         　RUIN  廃屋／SHORE  水のほとり
       MESSAGETEXT
 
-      register_prefix(["SPRING", "SUMMER", "AUTUMN", "WINTER", "MORNING", "NOON", "AFTERNOON", "TWILIGHT", "NIGHT", "MIDNIGHT", "NORBLE", "MARCHEN", "COLONIAL", "SHELF", "LITTLE", "ELDER", "ATERIEL", "OPEN", "HAUNTED", "SIMPLE", "LARGE", "CORRIDOR", "STAIRS", "COSY", "TERRACE", "GARRET", "KITCHEN", "BATH", "REST", "CELLER", "LUMBER", "GARDEN", "WASTED", "RUIN", "SHORE"])
+      register_prefix("SPRING", "SUMMER", "AUTUMN", "WINTER", "MORNING", "NOON", "AFTERNOON", "TWILIGHT", "NIGHT", "MIDNIGHT", "NORBLE", "MARCHEN", "COLONIAL", "SHELF", "LITTLE", "ELDER", "ATERIEL", "OPEN", "HAUNTED", "SIMPLE", "LARGE", "CORRIDOR", "STAIRS", "COSY", "TERRACE", "GARRET", "KITCHEN", "BATH", "REST", "CELLER", "LUMBER", "GARDEN", "WASTED", "RUIN", "SHORE")
 
       def eval_game_system_specific_command(command)
         info = EVENT_TABLES[command.upcase]

--- a/lib/bcdice/game_system/Skynauts.rb
+++ b/lib/bcdice/game_system/Skynauts.rb
@@ -32,7 +32,7 @@ module BCDice
         　AVO9@8[縦1,横4],[縦2,横6],[縦3,横8]　AVO@2[縦6,横4],[縦2,横6]
       MESSAGETEXT
 
-      register_prefix(['D.*', '2[Dd]6<=.*', 'SN.*', 'NV.*', 'AVO.*', 'BOM.*'])
+      register_prefix('D.*', '2[Dd]6<=.*', 'SN.*', 'NV.*', 'AVO.*', 'BOM.*')
 
       def initialize(command)
         super(command)

--- a/lib/bcdice/game_system/SteamPunkers.rb
+++ b/lib/bcdice/game_system/SteamPunkers.rb
@@ -479,7 +479,7 @@ module BCDice
         )
       }.freeze
 
-      register_prefix(['SP.*'] + TABLES.keys)
+      register_prefix('SP.*', TABLES.keys)
     end
   end
 end

--- a/lib/bcdice/game_system/StellarKnights.rb
+++ b/lib/bcdice/game_system/StellarKnights.rb
@@ -850,7 +850,7 @@ module BCDice
         ),
       }.freeze
 
-      register_prefix(['\d+SK\d?(,\d>\d)*', 'STB2', 'ALLS', 'PET', 'FT\d*'] + TABLES.keys)
+      register_prefix('\d+SK\d?(,\d>\d)*', 'STB2', 'ALLS', 'PET', 'FT\d*', TABLES.keys)
     end
   end
 end

--- a/lib/bcdice/game_system/SterileLife.rb
+++ b/lib/bcdice/game_system/SterileLife.rb
@@ -37,7 +37,7 @@ module BCDice
         　・超未来の宇宙船内　INT
       MESSAGETEXT
 
-      register_prefix(['(\d+)*DA.*\[(\d+),(\d+)(,(\d+))?\]', 'VPFT', 'VNFT', 'VNRT', 'AAFT', 'AST', 'RNST', 'RET', 'TRST', 'TRAT', 'TRMT', 'TROT', 'TET', 'ENT', 'CUT', 'NAT', 'INT']) # '(\d+)*DA.*\[.*\]'
+      register_prefix('(\d+)*DA.*\[(\d+),(\d+)(,(\d+))?\]', 'VPFT', 'VNFT', 'VNRT', 'AAFT', 'AST', 'RNST', 'RET', 'TRST', 'TRAT', 'TRMT', 'TROT', 'TET', 'ENT', 'CUT', 'NAT', 'INT') # '(\d+)*DA.*\[.*\]'
 
       def eval_game_system_specific_command(command) # ダイスロールコマンド
         # 通常判定部分をgetJudgeResultコマンドに切り分け

--- a/lib/bcdice/game_system/StrangerOfSwordCity.rb
+++ b/lib/bcdice/game_system/StrangerOfSwordCity.rb
@@ -21,7 +21,7 @@ module BCDice
         ・D66ダイスあり
       INFO_MESSAGE_TEXT
 
-      register_prefix(['\d+SR.*'])
+      register_prefix('\d+SR.*')
 
       def initialize(command)
         super(command)

--- a/lib/bcdice/game_system/Strave.rb
+++ b/lib/bcdice/game_system/Strave.rb
@@ -32,10 +32,10 @@ module BCDice
         ※アイデンティティ表はエラッタ適用済です。
       MESSAGETEXT
 
-      register_prefix([
+      register_prefix(
         'MP\d+', '\d+ST\d+(x|\*)\d+',
         'AFF', 'IDT', 'AFV', 'IDV'
-      ])
+      )
 
       def initialize(command)
         super(command)

--- a/lib/bcdice/game_system/SwordWorld.rb
+++ b/lib/bcdice/game_system/SwordWorld.rb
@@ -15,7 +15,7 @@ module BCDice
       # ダイスボットの使い方
       HELP_MESSAGE = "・SW　レーティング表　(Kx[c]+m$f) (x:キー, c:クリティカル値, m:ボーナス, f:出目修正)\n"
 
-      register_prefix(['H?K\d+.*'])
+      register_prefix('H?K\d+.*')
 
       def initialize(command)
         super(command)

--- a/lib/bcdice/game_system/SwordWorld2_0.rb
+++ b/lib/bcdice/game_system/SwordWorld2_0.rb
@@ -65,7 +65,7 @@ module BCDice
         　絡み効果表を出すことができます。
       INFO_MESSAGE_TEXT
 
-      register_prefix(['H?K\d+.*', 'Gr(\d+)?', '2D6?@\d+.*', 'FT', 'TT'])
+      register_prefix('H?K\d+.*', 'Gr(\d+)?', '2D6?@\d+.*', 'FT', 'TT')
 
       # 超越判定のノード
       class TranscendentTest

--- a/lib/bcdice/game_system/SwordWorld2_5.rb
+++ b/lib/bcdice/game_system/SwordWorld2_5.rb
@@ -68,7 +68,7 @@ module BCDice
         　絡み効果表を出すことができます。
       INFO_MESSAGE_TEXT
 
-      register_prefix(['H?K\d+.*', 'Gr(\d+)?', '2D6?@\d+.*', 'FT', 'TT'])
+      register_prefix('H?K\d+.*', 'Gr(\d+)?', '2D6?@\d+.*', 'FT', 'TT')
 
       # コマンド実行前にメッセージを置換する
       # @param [String] string 受信したメッセージ

--- a/lib/bcdice/game_system/TherapieSein.rb
+++ b/lib/bcdice/game_system/TherapieSein.rb
@@ -30,7 +30,7 @@ module BCDice
         ・OP3@12 → ダイス合計+3の達成値＆クリティカル、判定の成否を表示。
       MESSAGETEXT
 
-      register_prefix(['(TS|OP)(\d+)?([\+\-]\d)*(\@\d+)?'])
+      register_prefix('(TS|OP)(\d+)?([\+\-]\d)*(\@\d+)?')
 
       def eval_game_system_specific_command(command)
         output =

--- a/lib/bcdice/game_system/TokumeiTenkousei.rb
+++ b/lib/bcdice/game_system/TokumeiTenkousei.rb
@@ -26,7 +26,7 @@ module BCDice
         @sort_add_dice = true
       end
 
-      register_prefix(['\d+D6.*'])
+      register_prefix('\d+D6.*')
 
       def eval_game_system_specific_command(command)
         parser = CommandParser.new(/^\d+D6$/)

--- a/lib/bcdice/game_system/TokyoGhostResearch.rb
+++ b/lib/bcdice/game_system/TokyoGhostResearch.rb
@@ -24,9 +24,9 @@ module BCDice
       MESSAGETEXT
 
       # ダイスボットで使用するコマンドを配列で列挙する
-      register_prefix([
+      register_prefix(
         'OP', 'TB', 'TK?\(\d+\)'
-      ])
+      )
 
       def eval_game_system_specific_command(command)
         output =

--- a/lib/bcdice/game_system/Torg.rb
+++ b/lib/bcdice/game_system/Torg.rb
@@ -28,7 +28,7 @@ module BCDice
         　・ボーナス表「BTx+y or BONUSx+y or TOTALx+y」 xは数値, yは技能基本値
       INFO_MESSAGE_TEXT
 
-      register_prefix(['TG.*', '1R20.*', 'RT.*', 'Result.*', 'IT.*', 'Initimidate.*', 'TT.*', 'Taunt.*', 'Trick.*', 'CT.*', 'MT.*', 'Maneuver.*', 'ODT.*', 'ords.*', 'odamage.*', 'DT.*', 'damage.*', 'BT.*', 'bonus.*', 'total.*'])
+      register_prefix('TG.*', '1R20.*', 'RT.*', 'Result.*', 'IT.*', 'Initimidate.*', 'TT.*', 'Taunt.*', 'Trick.*', 'CT.*', 'MT.*', 'Maneuver.*', 'ODT.*', 'ords.*', 'odamage.*', 'DT.*', 'damage.*', 'BT.*', 'bonus.*', 'total.*')
 
       def replace_text(string)
         string = string.gsub(/Result/i, 'RT')

--- a/lib/bcdice/game_system/TorgEternity.rb
+++ b/lib/bcdice/game_system/TorgEternity.rb
@@ -41,7 +41,7 @@ module BCDice
         　・ダメージ結果表「DTx or DAMAGEx」
         　・ロールボーナス表「BTx+y or BONUSx+y or TOTALx+y」 xは数値, yは技能基本値
       INFO_MESSAGE_TEXT
-      register_prefix(['TE.*', 'UP.*', 'POS.*', '\d+BD.*', 'TG.*', 'RT.*', 'Result.*', 'DT.*', 'damage.*', 'BT.*', 'bonus.*', 'total.*', '1R20.*'])
+      register_prefix('TE.*', 'UP.*', 'POS.*', '\d+BD.*', 'TG.*', 'RT.*', 'Result.*', 'DT.*', 'damage.*', 'BT.*', 'bonus.*', 'total.*', '1R20.*')
       def initialize(command)
         super(command)
       end

--- a/lib/bcdice/game_system/TrinitySeven.rb
+++ b/lib/bcdice/game_system/TrinitySeven.rb
@@ -33,7 +33,7 @@ module BCDice
 
       MESSAGETEXT
 
-      register_prefix(['(\d+)DM\d+(\+|\-)?\d*', '(\d+)DM(\+|\-)?\d*', 'TR(\d+)<=(\d+)(\+|\-)?\d*', 'TR<=(\d+)(\+|\-)?\d*', 'TR(\+|\-)?(\d+)<=(\d+)(\+|\-)?\d*', 'TRNAME'])
+      register_prefix('(\d+)DM\d+(\+|\-)?\d*', '(\d+)DM(\+|\-)?\d*', 'TR(\d+)<=(\d+)(\+|\-)?\d*', 'TR<=(\d+)(\+|\-)?\d*', 'TR(\+|\-)?(\d+)<=(\d+)(\+|\-)?\d*', 'TRNAME')
 
       def eval_game_system_specific_command(command) # スパゲッティなコードだけど許して！！！ → 絶対に許さない。全力でリファクタリングした。
         debug("eval_game_system_specific_command command", command)

--- a/lib/bcdice/game_system/TunnelsAndTrolls.rb
+++ b/lib/bcdice/game_system/TunnelsAndTrolls.rb
@@ -30,7 +30,7 @@ module BCDice
         　下から２番目の出目をずらした分だけ合計にマイナス修正を追加して表示します。
       INFO_MESSAGE_TEXT
 
-      register_prefix(['\d+H?BS.*', '\d+R6.*', '\d+D\d+.+', '\dD6.*'])
+      register_prefix('\d+H?BS.*', '\d+R6.*', '\d+D\d+.+', '\dD6.*')
 
       def initialize(command)
         super(command)

--- a/lib/bcdice/game_system/TwilightGunsmoke.rb
+++ b/lib/bcdice/game_system/TwilightGunsmoke.rb
@@ -521,7 +521,7 @@ module BCDice
         )
       }.freeze
 
-      register_prefix(['2D6.*'] + TABLES.keys)
+      register_prefix('2D6.*', TABLES.keys)
     end
   end
 end

--- a/lib/bcdice/game_system/Utakaze.rb
+++ b/lib/bcdice/game_system/Utakaze.rb
@@ -25,7 +25,7 @@ module BCDice
           例）3UK@5 ：龍のダイス「月」でクリティカルコール宣言したサイコロ3個の行為判定
       MESSAGETEXT
 
-      register_prefix(['\d*UK[@\d]*.*'])
+      register_prefix('\d*UK[@\d]*.*')
 
       def initialize(command)
         super(command)

--- a/lib/bcdice/game_system/VampireTheMasquerade5th.rb
+++ b/lib/bcdice/game_system/VampireTheMasquerade5th.rb
@@ -41,7 +41,7 @@ module BCDice
       NOT_CHECK_SUCCESS = -1 # 判定成功にかかわるチェックを行わない(判定失敗に関わるチェックは行う)
 
       # ダイスボットで使用するコマンドを配列で列挙する
-      register_prefix(['\d*VMF.*'])
+      register_prefix('\d*VMF.*')
 
       def eval_game_system_specific_command(command)
         m = /\A(\d+)?(VMF)(\d+)(\+(\d+))?/.match(command)

--- a/lib/bcdice/game_system/Villaciel.rb
+++ b/lib/bcdice/game_system/Villaciel.rb
@@ -47,7 +47,7 @@ module BCDice
         ・改良種表　　　　　　IS
       MESSAGETEXT
 
-      register_prefix(['\\d+VBS(>=\\d+)?', '\\d+VF', '\\d+VM', '\\d+VG', 'PJ[VA]?', 'PQ[VA]?', 'AC', 'MM([IAD]|V[VA]?)', 'F[LRWGBCS]', 'IP[VA]?', 'EP[VA]?\\d?', 'MP', 'IS'])
+      register_prefix('\\d+VBS(>=\\d+)?', '\\d+VF', '\\d+VM', '\\d+VG', 'PJ[VA]?', 'PQ[VA]?', 'AC', 'MM([IAD]|V[VA]?)', 'F[LRWGBCS]', 'IP[VA]?', 'EP[VA]?\\d?', 'MP', 'IS')
 
       def initialize(command)
         super(command)

--- a/lib/bcdice/game_system/Warhammer.rb
+++ b/lib/bcdice/game_system/Warhammer.rb
@@ -26,7 +26,7 @@ module BCDice
         　例）wh60　　wh43@4W　　WH65@
       INFO_MESSAGE_TEXT
 
-      register_prefix(['WH.*'])
+      register_prefix('WH.*')
 
       def initialize(command)
         super(command)

--- a/lib/bcdice/game_system/WitchQuest.rb
+++ b/lib/bcdice/game_system/WitchQuest.rb
@@ -22,7 +22,7 @@ module BCDice
         　例）SET1　SET48
       MESSAGETEXT
 
-      register_prefix(['WQ\d+', 'SET\d+'])
+      register_prefix('WQ\d+', 'SET\d+')
 
       def eval_game_system_specific_command(command)
         case command

--- a/lib/bcdice/game_system/WorldOfDarkness.rb
+++ b/lib/bcdice/game_system/WorldOfDarkness.rb
@@ -23,7 +23,7 @@ module BCDice
         　自動成功=省略時0
       INFO_MESSAGE_TEXT
 
-      register_prefix(['\d+ST.*'])
+      register_prefix('\d+ST.*')
 
       def initialize(command)
         super(command)

--- a/lib/bcdice/game_system/YearZeroEngine.rb
+++ b/lib/bcdice/game_system/YearZeroEngine.rb
@@ -29,7 +29,7 @@ module BCDice
       SKILL_INDEX        = 5 # 技能値ダイスのインデックス
       MODIFIED_INDEX     = 7 # 修正ダイスのインデックス
 
-      register_prefix(['(\d+)?(YZE|MYZ).*'])
+      register_prefix('(\d+)?(YZE|MYZ).*')
 
       def dice_info_init()
         @total_success_dice = 0

--- a/lib/bcdice/game_system/ZettaiReido.rb
+++ b/lib/bcdice/game_system/ZettaiReido.rb
@@ -20,7 +20,7 @@ module BCDice
         DPの取得の有無も表示されます。
       INFO_MESSAGE_TEXT
 
-      register_prefix(['\d+\-2DR.*'])
+      register_prefix('\d+\-2DR.*')
 
       def eval_game_system_specific_command(command)
         return nil unless command =~ /^(\d+)-2DR([\+\-\d]*)(>=(\d+))?$/i


### PR DESCRIPTION
`Base#register_prefix` は可変長引数でprefixを登録できるので、全てのゲームシステムで可変長引数を使って渡すようにする。