### PR TITLE
`set-env` command is disabled

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
         ruby-version: ${{ matrix.ruby }}
         bundler-cache: true
     - name: "Set CHECK_COVERAGE=true on Ruby 2.7"
-      run: echo '::set-env name=CHECK_COVERAGE::true'
+      run: echo "CHECK_COVERAGE=true" >> $GITHUB_ENV
       if: matrix.ruby == '2.7'
     - run: bundle install
     - run: bundle exec rake test


### PR DESCRIPTION
脆弱性があったらしく `set-env` が消えたので、新しい手法に切り替える