### PR TITLE
Choiceで半角スペースを扱えるようにする

### DIFF
--- a/lib/bcdice/common_command/choice.rb
+++ b/lib/bcdice/common_command/choice.rb
@@ -105,6 +105,9 @@ module BCDice
           items.push(last_item.delete_suffix(SUFFIX[type]))
 
           items = items.map(&:strip).reject(&:empty?)
+          if items.empty?
+            return nil
+          end
 
           new(
             secret: secret,

--- a/lib/bcdice/common_command/choice.rb
+++ b/lib/bcdice/common_command/choice.rb
@@ -1,7 +1,60 @@
+# frozen_string_literal: true
+
+require "strscan"
+
 module BCDice
   module CommonCommand
+    # チョイスコマンド
+    #
+    # 列挙された項目の中から一つを選んで出力する。
+    #
+    # フォーマットは以下の通り
+    # choice[A,B,C,D]
+    # choice(A,B,C,D)
+    # choice A B C D
+    # choice(新クトゥルフ神話TRPG, ソード・ワールド2.5, Dungeons & Dragons)
+    #
+    # "choice"の次の文字によって区切り文字が変化する
+    #   "[" -> "," で区切る
+    #   "(" -> "," で区切る
+    #   " " -> /\s+/ にマッチする文字列で区切る
+    #
+    # 各項目の前後に空白文字があった場合は除去される
+    #   choice[A, B,  C , D   ] は choice[A,B,C,D] と等価
+    #
+    # 項目が空文字列である場合、その項目は無視する
+    #   choice[A,,C] は choice[A,C] と等価
+    #
+    # フォーマットを選ぶことで、項目の文字列に()や,を含めることができる
+    #   choice A,B X,Y -> "A,B" と "X,Y" から選ぶ
+    #   choice(A[], B[], C[]) -> "A[]", "B[]", "C[]" から選ぶ
+    #   choice[A(), B(), C()] -> "A()", "B()", "C()" から選ぶ
     class Choice
       PREFIX_PATTERN = /choice/.freeze
+
+      module BlockDelimiter
+        BRACKET = :bracket # "["
+        PAREN = :paren # "("
+        SPACE = :space # /\s/
+      end
+
+      DELIMITER = {
+        bracket: /,/,
+        paren: /,/,
+        space: /\s+/,
+      }.freeze
+
+      TERMINATION = {
+        bracket: /\]/,
+        paren: /\)/,
+        space: /$/,
+      }.freeze
+
+      SUFFIX = {
+        bracket: "]",
+        paren: ")",
+        space: "",
+      }.freeze
 
       class << self
         # @param command [String]
@@ -16,20 +69,57 @@ module BCDice
         private
 
         def parse(command)
-          m = /^(S)?choice\[([^,]+(?:,[^,]+)+)\]$/i.match(command)
-          return nil unless m
+          scanner = StringScanner.new(command)
+          scanner.skip(/\s+/)
+
+          secret = !scanner.scan(/S/i).nil?
+          unless scanner.scan(/choice/i)
+            return nil
+          end
+
+          type =
+            case scanner.scan(/\(|\[|\s+/)
+            when "["
+              BlockDelimiter::BRACKET
+            when "("
+              BlockDelimiter::PAREN
+            when String
+              BlockDelimiter::SPACE
+            else
+              return nil
+            end
+
+          delimiter = DELIMITER[type]
+          termination = TERMINATION[type]
+
+          items = []
+          while (item = scanner.scan_until(delimiter))
+            items.push(item.delete_suffix(","))
+          end
+
+          last_item = scanner.scan_until(termination)
+          unless last_item
+            return nil
+          end
+
+          items.push(last_item.delete_suffix(SUFFIX[type]))
+
+          items = items.map(&:strip).reject(&:empty?)
 
           new(
-            secret: !m[1].nil?,
-            items: m[2].split(",").map(&:strip)
+            secret: secret,
+            block_delimiter: type,
+            items: items
           )
         end
       end
 
       # @param secret [Boolean]
+      # @param block_delimiter [BlockDelimiter::BRACKET, BlockDelimiter::PAREN, BlockDelimiter::SPACE]
       # @param items [Array<String>]
-      def initialize(secret:, items:)
+      def initialize(secret:, block_delimiter:, items:)
         @secret = secret
+        @block_delimiter = block_delimiter
         @items = items
       end
 
@@ -41,7 +131,18 @@ module BCDice
 
         Result.new.tap do |r|
           r.secret = @secret
-          r.text = "(choice[#{@items.join(',')}]) ＞ #{chosen}"
+          r.text = "(#{expr()}) ＞ #{chosen}"
+        end
+      end
+
+      def expr
+        case @block_delimiter
+        when BlockDelimiter::SPACE
+          "choice #{@items.join(' ')}"
+        when BlockDelimiter::BRACKET
+          "choice[#{@items.join(',')}]"
+        when BlockDelimiter::PAREN
+          "choice(#{@items.join(',')})"
         end
       end
     end

--- a/test/data/None.toml
+++ b/test/data/None.toml
@@ -1356,23 +1356,6 @@ rands = [
 
 [[ test ]]
 game_system = "DiceBot"
-input = "choice[abc,def]"
-output = "(choice[abc,def]) ＞ abc"
-rands = [
-  { sides = 2, value = 1 },
-]
-
-[[ test ]]
-game_system = "DiceBot"
-input = "Schoice[abc2,def3]"
-output = "(choice[abc2,def3]) ＞ def3"
-secret = true
-rands = [
-  { sides = 2, value = 2 },
-]
-
-[[ test ]]
-game_system = "DiceBot"
 input = "C(10/2)"
 output = "計算結果 ＞ 5"
 rands = []

--- a/test/data/choice.toml
+++ b/test/data/choice.toml
@@ -1,0 +1,82 @@
+[[ test ]]
+game_system = "DiceBot"
+input = "choice[abc,def]"
+output = "(choice[abc,def]) ＞ abc"
+rands = [
+  { sides = 2, value = 1 },
+]
+
+[[ test ]]
+game_system = "DiceBot"
+input = "CHOICE[abc,def] 大文字"
+output = "(choice[abc,def]) ＞ abc"
+rands = [
+  { sides = 2, value = 1 },
+]
+
+[[ test ]]
+game_system = "DiceBot"
+input = "Schoice[abc2,def3]"
+output = "(choice[abc2,def3]) ＞ def3"
+secret = true
+rands = [
+  { sides = 2, value = 2 },
+]
+
+[[ test ]]
+game_system = "DiceBot"
+input = "sChoice[abc2,def3] 混合"
+output = "(choice[abc2,def3]) ＞ def3"
+secret = true
+rands = [
+  { sides = 2, value = 2 },
+]
+
+[[ test ]]
+game_system = "DiceBot"
+input = "choice[The Call of Cthulhu, The Shadow Over Innsmouth, The Shadow Out of Time]"
+output = "(choice[The Call of Cthulhu,The Shadow Over Innsmouth,The Shadow Out of Time]) ＞ The Call of Cthulhu"
+rands = [
+  { sides = 3, value = 1 },
+]
+
+[[ test ]]
+game_system = "DiceBot"
+input = "choice[A(), B(), C()] カッコが終端として認識されない"
+output = "(choice[A(),B(),C()]) ＞ A()"
+rands = [
+  { sides = 3, value = 1 },
+]
+
+[[ test ]]
+game_system = "DiceBot"
+input = "choice(The Call of Cthulhu, The Shadow Over Innsmouth, The Shadow Out of Time)"
+output = "(choice(The Call of Cthulhu,The Shadow Over Innsmouth,The Shadow Out of Time)) ＞ The Call of Cthulhu"
+rands = [
+  { sides = 3, value = 1 },
+]
+
+[[ test ]]
+game_system = "DiceBot"
+input = "choice(A[], B[], C[]) ブラケットが終端として認識されない"
+output = "(choice(A[],B[],C[])) ＞ A[]"
+rands = [
+  { sides = 3, value = 1 },
+]
+
+[[ test ]]
+game_system = "DiceBot"
+input = "choice The Call of Cthulhu"
+output = "(choice The Call of Cthulhu) ＞ Cthulhu"
+rands = [
+  { sides = 4, value = 4 },
+]
+
+# カンマが終端として認識されない
+[[ test ]]
+game_system = "DiceBot"
+input = "choice A,B P,J Z,Y"
+output = "(choice A,B P,J Z,Y) ＞ A,B"
+rands = [
+  { sides = 3, value = 1 },
+]

--- a/test/data/choice.toml
+++ b/test/data/choice.toml
@@ -86,3 +86,15 @@ game_system = "DiceBot"
 input = "choice{A,B,C,D} 不正な範囲開始文字"
 output = ""
 rands = []
+
+[[ test ]]
+game_system = "DiceBot"
+input = "choice[] 要素数ゼロ"
+output = ""
+rands = []
+
+[[ test ]]
+game_system = "DiceBot"
+input = "choice[, ,,  ,, ,] 要素数ゼロ"
+output = ""
+rands = []

--- a/test/data/choice.toml
+++ b/test/data/choice.toml
@@ -80,3 +80,9 @@ output = "(choice A,B P,J Z,Y) ＞ A,B"
 rands = [
   { sides = 3, value = 1 },
 ]
+
+[[ test ]]
+game_system = "DiceBot"
+input = "choice{A,B,C,D} 不正な範囲開始文字"
+output = ""
+rands = []

--- a/test/data/choice.toml
+++ b/test/data/choice.toml
@@ -83,6 +83,30 @@ rands = [
 
 [[ test ]]
 game_system = "DiceBot"
+input = "choice[A,B,C,D) 終端記号が違う"
+output = ""
+rands = []
+
+[[ test ]]
+game_system = "DiceBot"
+input = "choice[A,B,C,D 終端記号がない"
+output = ""
+rands = []
+
+[[ test ]]
+game_system = "DiceBot"
+input = "choice(A,B,C,D] 終端記号が違う"
+output = ""
+rands = []
+
+[[ test ]]
+game_system = "DiceBot"
+input = "choice(A,B,C,D 終端記号がない"
+output = ""
+rands = []
+
+[[ test ]]
+game_system = "DiceBot"
 input = "choice{A,B,C,D} 不正な範囲開始文字"
 output = ""
 rands = []


### PR DESCRIPTION
## 入力例
```
choice[A,B,C,D]
choice(A,B,C,D)
choice A B C D
choice(新クトゥルフ神話TRPG, ソード・ワールド2.5, Dungeons & Dragons)
```

## 仕様
### 区切り文字
`"choice"`の次の文字によって区切り文字が変化する
- `"["` -> `","` で区切る
- `"("` -> `","` で区切る
- 空白文字 -> `/\s+/` にマッチする文字列で区切る

### 空白の扱い
各項目の前後に空白文字があった場合は除去される
- `choice[A, B,  C , D   ]` は `choice[A,B,C,D]` と等価

項目が空文字列である場合、その項目は無視する
- `choice[A,,C]` は `choice[A,C]` と等価

### 利用できる文字を増やす
フォーマットを選ぶことで、項目の文字列に`()`や`,`を含めることができる
- `choice A,B X,Y` -> `"A,B"` と `"X,Y"` から選ぶ
- `choice(A[], B[], C[])` -> `"A[]"`, `"B[]"`, `"C[]"` から選ぶ
- `choice[A(), B(), C()]` -> `"A()"`, `"B()"`, `"C()"` から選ぶ