### PR TITLE
より意図の明確なメソッド（Ruby 2.4以降で使用可能、Array#count）を使う

### DIFF
--- a/lib/bcdice/game_system/CthulhuTech.rb
+++ b/lib/bcdice/game_system/CthulhuTech.rb
@@ -124,25 +124,19 @@ module BCDice
         def calculate_roll_result(sorted_dice_values)
           highest_single_roll = sorted_dice_values.last
 
+          sum_of_highest_set_of_multiples = sorted_dice_values
+                                            .group_by(&:itself)
+                                            .values
+                                            .map(&:sum)
+                                            .max
+
           candidates = [
             highest_single_roll,
-            sum_of_highest_set_of_multiples(sorted_dice_values),
+            sum_of_highest_set_of_multiples,
             sum_of_largest_straight(sorted_dice_values)
           ]
 
           return candidates.max
-        end
-
-        # ゾロ目の和の最大値を求める
-        # @param [Array<Integer>] dice_values 出目の配列
-        # @return [Integer]
-        def sum_of_highest_set_of_multiples(dice_values)
-          dice_values.
-            # TODO: Ruby 2.2以降では group_by(&:itself) が使える
-            group_by { |i| i }.
-            # TODO: Ruby 2.4以降では value_group.sum が使える
-            map { |_, value_group| value_group.reduce(0, &:+) }
-                     .max
         end
 
         # ストレートの和の最大値を求める

--- a/lib/bcdice/game_system/DoubleCross.rb
+++ b/lib/bcdice/game_system/DoubleCross.rb
@@ -103,8 +103,7 @@ module BCDice
         # @return [String]
         def result_str(value_groups)
           fumble = value_groups[0].values.all? { |value| value == 1 }
-          # TODO: Ruby 2.4以降では Array#sum が使える
-          sum = value_groups.map(&:max).reduce(0, &:+)
+          sum = value_groups.map(&:max).sum
           achieved_value = fumble ? 0 : (sum + @modifier)
 
           parts = [

--- a/lib/bcdice/game_system/DoubleCross.rb
+++ b/lib/bcdice/game_system/DoubleCross.rb
@@ -176,9 +176,7 @@ module BCDice
         # クリティカルの発生数を返す
         # @return [Integer]
         def num_of_critical_occurrences
-          @values
-            .select { |value| critical?(value) }
-            .length
+          @values.count { |value| critical?(value) }
         end
 
         private

--- a/lib/bcdice/game_system/NinjaSlayer.rb
+++ b/lib/bcdice/game_system/NinjaSlayer.rb
@@ -196,7 +196,7 @@ module BCDice
         m = /＞ (\d+(?:,\d+)*)/.match(rollResult)
         values = m[1].split(',').map(&:to_i)
 
-        numOfMaxValues = values.select { |v| v == 6 }.length
+        numOfMaxValues = values.count(6)
 
         return numOfMaxValues >= 2 ? "#{rollResult} ＞ サツバツ!!" : rollResult
       end
@@ -213,9 +213,9 @@ module BCDice
         m = /＞ (\d+(?:,\d+)*)/.match(rollResult)
         values = m[1].split(',').map(&:to_i)
 
-        numOfMaxValues = values.select { |v| v == 6 }.length
+        numOfMaxValues = values.count(6)
 
-        sumOfTrueValues = values.select { |v| v >= el.difficulty }.length
+        sumOfTrueValues = values.count { |v| v >= el.difficulty }
 
         return numOfMaxValues >= 1 ? "#{rollResult} + #{numOfMaxValues} ＞ #{sumOfTrueValues + numOfMaxValues}" : rollResult
       end

--- a/lib/bcdice/game_system/SwordWorld.rb
+++ b/lib/bcdice/game_system/SwordWorld.rb
@@ -31,8 +31,7 @@ module BCDice
       # @param [String] string 受信したメッセージ
       # @return [String]
       def replace_text(string)
-        # TODO: Ruby 2.4以降では Regexp#match? を使うこと
-        return string unless RATING_TABLE_RE_FOR_CHANGE_TEXT.match(string)
+        return string unless RATING_TABLE_RE_FOR_CHANGE_TEXT.match?(string)
 
         string
           .gsub(/\[(\d+)\]/) { "c[#{Regexp.last_match(1)}]" }

--- a/lib/bcdice/game_system/SwordWorld2_0.rb
+++ b/lib/bcdice/game_system/SwordWorld2_0.rb
@@ -131,8 +131,7 @@ module BCDice
         #   出目のグループまたはその配列
         # @return [Integer]
         def sum_of_dice(value_groups)
-          # TODO: Ruby 2.4以降では Array#sum が使える
-          value_groups.flatten.reduce(0, &:+)
+          value_groups.flatten.sum
         end
 
         # ダイス部分の文字列を返す

--- a/lib/bcdice/game_system/SwordWorld2_5.rb
+++ b/lib/bcdice/game_system/SwordWorld2_5.rb
@@ -74,8 +74,7 @@ module BCDice
       # @param [String] string 受信したメッセージ
       # @return [String]
       def replace_text(string)
-        # TODO: Ruby 2.4以降では Regexp#match? を使うこと
-        return string unless RATING_TABLE_RE_FOR_CHANGE_TEXT.match(string)
+        return string unless RATING_TABLE_RE_FOR_CHANGE_TEXT.match?(string)
 
         super(string).gsub(/#([-+]?\d+)/) do
           modifier = Regexp.last_match(1).to_i


### PR DESCRIPTION
Ruby 2.4以降で使える意図の明確なメソッドを活用して、各ゲームシステムに含まれていたTODOの一部を除去しました。また、条件を満たす要素の個数カウントに `array.select.length` という冗長な記述があったので、`Array#count` を使うように変えました。