### PR TITLE
[Preprocessor] 四則演算の誤った展開を直す

### DIFF
--- a/lib/bcdice/preprocessor.rb
+++ b/lib/bcdice/preprocessor.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module BCDice
   # 入力文字列に対して前処理を行う
   #
@@ -41,8 +43,14 @@ module BCDice
 
     # カッコ書きの数式を事前計算する
     def replace_parentheses
-      @text = @text.gsub(%r{\([\d/\+\*\-\(\)]+\)}) do |expr|
-        ArithmeticEvaluator.eval(expr, round_type: @game_system.round_type)
+      loop do
+        prev = @text
+        @text = @text.gsub(%r{\([\d/\+\*\-]+\)}) do |expr|
+          ae = ArithmeticEvaluator.new(expr, round_type: @game_system.round_type)
+          val = ae.eval
+          ae.error? ? expr : val
+        end
+        break if prev == @text
       end
     end
 

--- a/test/data/DoubleCross.toml
+++ b/test/data/DoubleCross.toml
@@ -2322,6 +2322,21 @@ rands = [
 
 [[ test ]]
 game_system = "DoubleCross"
+input = "5DX(8-1)-(2-1)"
+output = "(5DX7-1) ＞ 10[5,6,6,7,8]+10[1,9]+5[5]-1 ＞ 24"
+rands = [
+  { sides = 10, value = 6 },
+  { sides = 10, value = 6 },
+  { sides = 10, value = 8 },
+  { sides = 10, value = 5 },
+  { sides = 10, value = 7 },
+  { sides = 10, value = 9 },
+  { sides = 10, value = 1 },
+  { sides = 10, value = 5 },
+]
+
+[[ test ]]
+game_system = "DoubleCross"
 input = "2D10>=? 目標値?でバグらない"
 output = "(2D10>=?) ＞ 10[5,5] ＞ 10"
 rands = [

--- a/test/test_preprocessor.rb
+++ b/test/test_preprocessor.rb
@@ -1,0 +1,44 @@
+require "test/unit"
+require "bcdice/preprocessor"
+
+class TestPreprocessor < Test::Unit::TestCase
+  class Mock < BCDice::Base; end
+
+  def setup
+    @game_system = Mock.new("")
+  end
+
+  # カッコが個別に展開される
+  def test_replace_parentheses
+    text = BCDice::Preprocessor.process("10dx(8-1)+(5+5)", @game_system)
+    assert_equal("10dx7+10", text)
+  end
+
+  # カッコがネストされていても展開される
+  def test_replace_parentheses_nested
+    text = BCDice::Preprocessor.process("1D(100+10*(20+30))", @game_system)
+    assert_equal("1D600", text)
+  end
+
+  # 不正な式はそのまま
+  def test_invalid_expr
+    text = BCDice::Preprocessor.process("(10**2*(3+4))D6", @game_system)
+    assert_equal("(10**2*7)D6", text)
+  end
+
+  # ネストが深くても展開される
+  def test_replace_parentheses_nested_nested
+    text = BCDice::Preprocessor.process("1D((((((((((((((((((10))))))))))))))))))", @game_system)
+    assert_equal("1D10", text)
+  end
+
+  def test_implicit_d
+    text = BCDice::Preprocessor.process("1D+3", @game_system)
+    assert_equal("1D6+3", text)
+  end
+
+  def test_no_implicit_d
+    text = BCDice::Preprocessor.process("1Dhoge", @game_system)
+    assert_equal("1Dhoge", text)
+  end
+end


### PR DESCRIPTION
- `(8-1)+(5+5)` が `17` になってしまう問題を修正 (Fix #318)
- 不正な式だった時には `0` にぜすにそのままにしておく