### PR TITLE
オプション enabled_d66 を廃止する

### DIFF
--- a/lib/bcdice/base.rb
+++ b/lib/bcdice/base.rb
@@ -77,7 +77,6 @@ module BCDice
       @sort_add_dice = false # 加算ダイスでダイス目をソートするかどうか
       @sort_barabara_dice = false # バラバラダイスでダイス目をソートするかどうか
 
-      @enabled_d66 = true # D66ダイスを利用するかどうか
       @d66_sort_type = D66SortType::NO_SORT # 入れ替えの種類 詳しくはBCDice::D66SortTypeを参照すること
 
       @enabled_d9 = false # D9ダイスを有効にするか（ガンドッグ）で使用
@@ -142,13 +141,6 @@ module BCDice
     # @return [Boolean]
     def sort_barabara_dice?
       @sort_barabara_dice
-    end
-
-    # D66ダイスが有効か
-    #
-    # @return [Boolean]
-    def enabled_d66?
-      @enabled_d66
     end
 
     # D9ダイスが有効か

--- a/lib/bcdice/common_command/add_dice/randomizer.rb
+++ b/lib/bcdice/common_command/add_dice/randomizer.rb
@@ -20,7 +20,7 @@ module BCDice
         # @return [Array<Integer>] 出目の配列
         def roll(times, sides)
           dice_list =
-            if sides == 66 && @game_system.enabled_d66?
+            if sides == 66
               Array.new(times) { @rand_source.roll_d66(@game_system.d66_sort_type) }
             elsif sides == 9 && @game_system.enabled_d9?
               Array.new(times) { @rand_source.roll_d9() }

--- a/lib/bcdice/common_command/d66_dice.rb
+++ b/lib/bcdice/common_command/d66_dice.rb
@@ -16,8 +16,6 @@ module BCDice
         private
 
         def parse(command, game_system)
-          return nil unless game_system.enabled_d66?
-
           command = command.split(" ", 2).first
 
           m = /^(S)?D66([ANS])?$/i.match(command)

--- a/lib/bcdice/game_system/Arianrhod.rb
+++ b/lib/bcdice/game_system/Arianrhod.rb
@@ -22,7 +22,6 @@ module BCDice
         super(command)
 
         @sort_add_dice = true
-        @enabled_d66 = true
         @d66_sort_type = D66SortType::NO_SORT
       end
 

--- a/lib/bcdice/game_system/BeastBindTrinity.rb
+++ b/lib/bcdice/game_system/BeastBindTrinity.rb
@@ -63,7 +63,6 @@ module BCDice
       def initialize(command)
         super(command)
 
-        @enabled_d66 = true
         @d66_sort_type = D66SortType::ASC
       end
 

--- a/lib/bcdice/game_system/BeginningIdol.rb
+++ b/lib/bcdice/game_system/BeginningIdol.rb
@@ -148,7 +148,6 @@ module BCDice
         super(command)
 
         @sort_add_dice = true
-        @enabled_d66 = true
         @d66_sort_type = D66SortType::ASC
       end
 

--- a/lib/bcdice/game_system/BeginningIdol_Korean.rb
+++ b/lib/bcdice/game_system/BeginningIdol_Korean.rb
@@ -143,7 +143,6 @@ module BCDice
         super(command)
 
         @sort_add_dice = true
-        @enabled_d66 = true
         @d66_sort_type = D66SortType::ASC
       end
 

--- a/lib/bcdice/game_system/BloodCrusade.rb
+++ b/lib/bcdice/game_system/BloodCrusade.rb
@@ -40,7 +40,6 @@ module BCDice
         super(command)
 
         @sort_add_dice = true
-        @enabled_d66 = true
         @d66_sort_type = D66SortType::ASC
         @round_type = RoundType::CEIL # 端数切り上げに設定
       end

--- a/lib/bcdice/game_system/BloodMoon.rb
+++ b/lib/bcdice/game_system/BloodMoon.rb
@@ -38,7 +38,6 @@ module BCDice
         super(command)
 
         @sort_add_dice = true
-        @enabled_d66 = true
         @d66_sort_type = D66SortType::ASC
         @round_type = RoundType::CEIL # 端数切り上げに設定
       end

--- a/lib/bcdice/game_system/CardRanker.rb
+++ b/lib/bcdice/game_system/CardRanker.rb
@@ -32,7 +32,6 @@ module BCDice
         super(command)
 
         @sort_add_dice = true
-        @enabled_d66 = true
         @d66_sort_type = D66SortType::ASC
       end
 

--- a/lib/bcdice/game_system/ColossalHunter.rb
+++ b/lib/bcdice/game_system/ColossalHunter.rb
@@ -32,7 +32,6 @@ module BCDice
 
       def initialize(command)
         super(command)
-        @enabled_d66 = true
         @d66_sort_type = D66SortType::NO_SORT
       end
 

--- a/lib/bcdice/game_system/DarkDaysDrive.rb
+++ b/lib/bcdice/game_system/DarkDaysDrive.rb
@@ -47,7 +47,6 @@ module BCDice
 
       def initialize(command)
         super(command)
-        @enabled_d66 = true
         @d66_sort_type = D66SortType::ASC
       end
 

--- a/lib/bcdice/game_system/DemonParasite.rb
+++ b/lib/bcdice/game_system/DemonParasite.rb
@@ -34,7 +34,6 @@ module BCDice
         super(command)
 
         @sort_add_dice = true
-        @enabled_d66 = true
         @d66_sort_type = D66SortType::NO_SORT
       end
 

--- a/lib/bcdice/game_system/DetatokoSaga.rb
+++ b/lib/bcdice/game_system/DetatokoSaga.rb
@@ -32,7 +32,6 @@ module BCDice
         super(command)
 
         @sort_add_dice = true
-        @enabled_d66 = true
         @d66_sort_type = D66SortType::ASC
       end
 

--- a/lib/bcdice/game_system/DiceOfTheDead.rb
+++ b/lib/bcdice/game_system/DiceOfTheDead.rb
@@ -27,7 +27,6 @@ module BCDice
         super(command)
 
         @sort_add_dice = true
-        @enabled_d66 = true
         @d66_sort_type = D66SortType::ASC
       end
 

--- a/lib/bcdice/game_system/Dracurouge.rb
+++ b/lib/bcdice/game_system/Dracurouge.rb
@@ -44,7 +44,6 @@ module BCDice
 
       def initialize(command)
         super(command)
-        @enabled_d66 = true
         @d66_sort_type = D66SortType::NO_SORT
       end
 

--- a/lib/bcdice/game_system/Elysion.rb
+++ b/lib/bcdice/game_system/Elysion.rb
@@ -50,7 +50,6 @@ module BCDice
 
       def initialize(command)
         super(command)
-        @enabled_d66 = true
         @d66_sort_type = D66SortType::ASC
 
         @enabled_upcase_input = false

--- a/lib/bcdice/game_system/EndBreaker.rb
+++ b/lib/bcdice/game_system/EndBreaker.rb
@@ -25,7 +25,6 @@ module BCDice
       def initialize(command)
         super(command)
 
-        @enabled_d66 = true
         @d66_sort_type = D66SortType::NO_SORT
       end
 

--- a/lib/bcdice/game_system/FilledWith.rb
+++ b/lib/bcdice/game_system/FilledWith.rb
@@ -48,7 +48,6 @@ module BCDice
 
       def initialize(command)
         super(command)
-        @enabled_d66 = true
         @d66_sort_type = D66SortType::NO_SORT; # d66の差し替え
       end
 

--- a/lib/bcdice/game_system/FutariSousa.rb
+++ b/lib/bcdice/game_system/FutariSousa.rb
@@ -40,7 +40,6 @@ module BCDice
       def initialize(command)
         super(command)
 
-        @enabled_d66 = true
         @d66_sort_type = D66SortType::ASC
       end
 

--- a/lib/bcdice/game_system/GURPS.rb
+++ b/lib/bcdice/game_system/GURPS.rb
@@ -37,7 +37,6 @@ module BCDice
       def initialize(command)
         super(command)
 
-        @enabled_d66 = true
         @d66_sort_type = D66SortType::NO_SORT
       end
 

--- a/lib/bcdice/game_system/GranCrest.rb
+++ b/lib/bcdice/game_system/GranCrest.rb
@@ -41,7 +41,6 @@ module BCDice
         super(command)
 
         @sort_add_dice = true
-        @enabled_d66 = true
         @d66_sort_type = D66SortType::NO_SORT
         @round_type = RoundType::FLOOR
       end

--- a/lib/bcdice/game_system/GurpsFW.rb
+++ b/lib/bcdice/game_system/GurpsFW.rb
@@ -75,7 +75,6 @@ module BCDice
       def initialize(command)
         super(command)
 
-        @enabled_d66 = true
         @d66_sort_type = D66SortType::NO_SORT
       end
 

--- a/lib/bcdice/game_system/HatsuneMiku.rb
+++ b/lib/bcdice/game_system/HatsuneMiku.rb
@@ -40,7 +40,6 @@ module BCDice
       def initialize(command)
         super(command)
 
-        @enabled_d66 = true
         @d66_sort_type = D66SortType::ASC
       end
 

--- a/lib/bcdice/game_system/HuntersMoon.rb
+++ b/lib/bcdice/game_system/HuntersMoon.rb
@@ -46,7 +46,6 @@ module BCDice
         super(command)
 
         @sort_add_dice = true
-        @enabled_d66 = true
         @d66_sort_type = D66SortType::ASC
         @round_type = RoundType::CEIL # 端数切り上げに設定
       end

--- a/lib/bcdice/game_system/Insane.rb
+++ b/lib/bcdice/game_system/Insane.rb
@@ -42,7 +42,6 @@ module BCDice
 
         @sort_add_dice = true
         @sort_barabara_dice = true
-        @enabled_d66 = true
         @d66_sort_type = D66SortType::ASC
       end
 

--- a/lib/bcdice/game_system/Kamigakari.rb
+++ b/lib/bcdice/game_system/Kamigakari.rb
@@ -28,7 +28,6 @@ module BCDice
         super(command)
 
         @sort_add_dice = true
-        @enabled_d66 = true
         @d66_sort_type = D66SortType::NO_SORT
       end
 

--- a/lib/bcdice/game_system/KanColle.rb
+++ b/lib/bcdice/game_system/KanColle.rb
@@ -49,7 +49,6 @@ module BCDice
 
         @sort_add_dice = true
         @sort_barabara_dice = true
-        @enabled_d66 = true
         @d66_sort_type = D66SortType::ASC
       end
 

--- a/lib/bcdice/game_system/KillDeathBusiness.rb
+++ b/lib/bcdice/game_system/KillDeathBusiness.rb
@@ -45,7 +45,6 @@ module BCDice
         super(command)
 
         @sort_add_dice = true
-        @enabled_d66 = true
         @d66_sort_type = D66SortType::ASC
       end
 

--- a/lib/bcdice/game_system/LogHorizon.rb
+++ b/lib/bcdice/game_system/LogHorizon.rb
@@ -94,7 +94,6 @@ module BCDice
 
       def initialize(command)
         super(command)
-        @enabled_d66 = true
         @d66_sort_type = D66SortType::NO_SORT
       end
 

--- a/lib/bcdice/game_system/LostRecord.rb
+++ b/lib/bcdice/game_system/LostRecord.rb
@@ -22,7 +22,6 @@ module BCDice
         super(command)
 
         # D66は昇順に
-        @enabled_d66 = true
         @d66_sort_type = D66SortType::ASC
       end
     end

--- a/lib/bcdice/game_system/LostRoyal.rb
+++ b/lib/bcdice/game_system/LostRoyal.rb
@@ -41,7 +41,6 @@ module BCDice
         super(command)
 
         @sort_add_dice = true
-        @enabled_d66 = true
         @d66_sort_type = D66SortType::NO_SORT
       end
 

--- a/lib/bcdice/game_system/MagicaLogia.rb
+++ b/lib/bcdice/game_system/MagicaLogia.rb
@@ -56,7 +56,6 @@ module BCDice
 
         @sort_add_dice = true
         @sort_barabara_dice = true
-        @enabled_d66 = true
         @d66_sort_type = D66SortType::ASC
       end
 

--- a/lib/bcdice/game_system/MeikyuDays.rb
+++ b/lib/bcdice/game_system/MeikyuDays.rb
@@ -35,7 +35,6 @@ module BCDice
         super(command)
 
         @sort_add_dice = true
-        @enabled_d66 = true
         @d66_sort_type = D66SortType::ASC
       end
 

--- a/lib/bcdice/game_system/MeikyuKingdom.rb
+++ b/lib/bcdice/game_system/MeikyuKingdom.rb
@@ -63,7 +63,6 @@ module BCDice
         super(command)
 
         @sort_add_dice = true
-        @enabled_d66 = true
         @d66_sort_type = D66SortType::ASC
       end
 

--- a/lib/bcdice/game_system/MeikyuKingdomBasic.rb
+++ b/lib/bcdice/game_system/MeikyuKingdomBasic.rb
@@ -79,7 +79,6 @@ module BCDice
         super(command)
 
         @sort_add_dice = true
-        @enabled_d66 = true
         @d66_sort_type = D66SortType::ASC
       end
 

--- a/lib/bcdice/game_system/MonotoneMuseum.rb
+++ b/lib/bcdice/game_system/MonotoneMuseum.rb
@@ -40,7 +40,6 @@ module BCDice
         # 式、出目ともに送信する
 
         # D66ダイスあり（出目をソートしない）
-        @enabled_d66 = true
         @d66_sort_type = D66SortType::NO_SORT
         # バラバラロール（Bコマンド）でソートする
         @sort_add_dice = true

--- a/lib/bcdice/game_system/OneWayHeroics.rb
+++ b/lib/bcdice/game_system/OneWayHeroics.rb
@@ -45,7 +45,6 @@ module BCDice
 
       def initialize(command)
         super(command)
-        @enabled_d66 = true
         @d66_sort_type = D66SortType::ASC
       end
 

--- a/lib/bcdice/game_system/Peekaboo.rb
+++ b/lib/bcdice/game_system/Peekaboo.rb
@@ -40,7 +40,6 @@ module BCDice
         super(command)
 
         @sort_add_dice = true
-        @enabled_d66 = true
         @d66_sort_type = D66SortType::ASC
         @round_type = RoundType::CEIL # 端数切り上げに設定
       end

--- a/lib/bcdice/game_system/SRS.rb
+++ b/lib/bcdice/game_system/SRS.rb
@@ -183,7 +183,6 @@ module BCDice
         # バラバラロール（Bコマンド）でソートする
         @sort_add_dice = true
         # D66ダイスあり（出目をソートしない）
-        @enabled_d66 = true
         @d66_sort_type = D66SortType::NO_SORT
       end
 

--- a/lib/bcdice/game_system/Satasupe.rb
+++ b/lib/bcdice/game_system/Satasupe.rb
@@ -53,7 +53,6 @@ module BCDice
         super(command)
 
         @sort_add_dice = true
-        @enabled_d66 = true
         @d66_sort_type = D66SortType::ASC
       end
 

--- a/lib/bcdice/game_system/ShinobiGami.rb
+++ b/lib/bcdice/game_system/ShinobiGami.rb
@@ -38,7 +38,6 @@ module BCDice
         super(command)
 
         @sort_add_dice = true
-        @enabled_d66 = true
         @d66_sort_type = D66SortType::ASC
       end
 

--- a/lib/bcdice/game_system/StellarKnights.rb
+++ b/lib/bcdice/game_system/StellarKnights.rb
@@ -67,7 +67,6 @@ module BCDice
         super(command)
 
         @sort_barabara_dice = true # バラバラロール（Bコマンド）でソート有
-        @enabled_d66 = true
         @d66_sort_type = D66SortType::NO_SORT
       end
 

--- a/lib/bcdice/game_system/StrangerOfSwordCity.rb
+++ b/lib/bcdice/game_system/StrangerOfSwordCity.rb
@@ -27,7 +27,6 @@ module BCDice
         super(command)
 
         @sort_add_dice = true
-        @enabled_d66 = true
         @d66_sort_type = D66SortType::NO_SORT
         @round_type = RoundType::FLOOR
       end

--- a/lib/bcdice/game_system/StratoShout.rb
+++ b/lib/bcdice/game_system/StratoShout.rb
@@ -30,7 +30,6 @@ module BCDice
         super(command)
 
         @sort_add_dice = true
-        @enabled_d66 = true
         @d66_sort_type = D66SortType::ASC
       end
 

--- a/lib/bcdice/game_system/TwilightGunsmoke.rb
+++ b/lib/bcdice/game_system/TwilightGunsmoke.rb
@@ -43,7 +43,6 @@ module BCDice
       def initialize(command)
         super(command)
 
-        @enabled_d66 = true
         @d66_sort_type = D66SortType::NO_SORT
         @sort_add_dice = true
       end

--- a/lib/bcdice/game_system/Villaciel.rb
+++ b/lib/bcdice/game_system/Villaciel.rb
@@ -52,7 +52,6 @@ module BCDice
       def initialize(command)
         super(command)
 
-        @enabled_d66 = true
         @d66_sort_type = D66SortType::NO_SORT # D66あり。ただし、現行ルールにある6x6の表については別のコマンドを用意
         @round_type = RoundType::CEIL # 端数は切り上げ
       end

--- a/lib/bcdice/game_system/YankeeYogSothoth.rb
+++ b/lib/bcdice/game_system/YankeeYogSothoth.rb
@@ -45,7 +45,6 @@ module BCDice
 
       def initialize(command)
         super(command)
-        @enabled_d66 = true
         @d66_sort_type = D66SortType::ASC
       end
 


### PR DESCRIPTION
全てのゲームシステムでオンになっており、OFFなシステムがないため廃止する