### PR TITLE
バラバラロール（xBn）の結果に出目と成功数を加える

### DIFF
--- a/lib/bcdice/common_command/barabara_dice/node.rb
+++ b/lib/bcdice/common_command/barabara_dice/node.rb
@@ -1,4 +1,5 @@
 require "bcdice/format"
+require "bcdice/common_command/barabara_dice/result"
 
 module BCDice
   module CommonCommand
@@ -12,7 +13,9 @@ module BCDice
             @target_number = target_number
           end
 
-          # @return [String, nil]
+          # @param game_system [Base] ゲームシステム
+          # @param randomizer [Randomizer] ランダマイザ
+          # @return [Result]
           def eval(game_system, randomizer)
             round_type = game_system.round_type
             notations = @notations.map { |n| n.to_dice(round_type) }
@@ -38,6 +41,9 @@ module BCDice
             Result.new.tap do |r|
               r.secret = @secret
               r.text = sequence.join(" ＞ ")
+              r.rands = randomizer.rand_results
+              r.detailed_rands = randomizer.detailed_rand_results
+              r.success_num = success_num
             end
           end
         end

--- a/lib/bcdice/common_command/barabara_dice/result.rb
+++ b/lib/bcdice/common_command/barabara_dice/result.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require "bcdice/result"
+
+module BCDice
+  module CommonCommand
+    module BarabaraDice
+      # バラバラロールの結果を表すクラス
+      class Result < ::BCDice::Result
+        # @return [Integer] 成功数
+        attr_accessor :success_num
+
+        # @param text [String, nil] 結果の文章
+        def initialize(text = nil)
+          super(text)
+
+          @success_num = 0
+        end
+      end
+    end
+  end
+end

--- a/lib/bcdice/result.rb
+++ b/lib/bcdice/result.rb
@@ -38,6 +38,8 @@ module BCDice
 
     def initialize(text = nil)
       @text = text
+      @rands = nil
+      @detailed_rands = nil
       @secret = false
       @success = false
       @failure = false


### PR DESCRIPTION
バラバラロール（`xBn`）の結果を表すクラスを作り、通常の結果に加えて出目と成功数を記録するようにしました。

目的は、BarabaraDiceの結果オブジェクトから必要な項目を直接取得できるようにすることです。これまでは結果が文字列でしか得られなかったため、ニンジャスレイヤーTRPG等では結果の文字列から必要な部分を抽出して判断していました。この方法はバラバラロールの出力書式に依存するため、書式の変更に弱いです（i18nを行う場合は、さらに言語数分だけ修正作業が多くなります）。結果オブジェクトから必要な項目を直接取得できれば、書式を考慮する必要がなくなります。

実装では `BCDice::Result` を継承するクラス `BCDice::CommonCommand::BarabaraDice::Result` を作りました。追加したのは成功数（`success_num`）のみです。出目の記録には、`BCDice::Base#eval` の最後で設定される `#rands` と `#detailed_rands` を使用しましたが、これでも大丈夫でしょうか？

作った仕組みを使って、ひとまずニンジャスレイヤーTRPGのTODO整理を行いました。他にはシャドウラン5th Editionに適用できそうです（ただ、シャドウラン5th EditionではニンジャスレイヤーTRPGよりもアドホックな処理が多かったため、今回は適用を見送りました）。