### PR TITLE
ダイスの面数が省略された場合の面数をゲームシステムごとに指定できるようにする

### DIFF
--- a/lib/bcdice/base.rb
+++ b/lib/bcdice/base.rb
@@ -83,6 +83,8 @@ module BCDice
 
       @round_type = RoundType::FLOOR # 割り算をした時の端数の扱い (FLOOR: 切り捨て, CEIL: 切り上げ, ROUND: 四捨五入)
 
+      @sides_implicit_d = 6 # 1D のようにダイスの面数が指定されていない場合に何面ダイスにするか
+
       @upper_dice_reroll_threshold = nil # UpperDiceで振り足しをする出目の閾値 nilの場合デフォルト設定なし
       @reroll_dice_reroll_threshold = nil # RerollDiceで振り足しをする出目の閾値 nilの場合デフォルト設定なし
 
@@ -108,6 +110,11 @@ module BCDice
     #
     # @return [Symbol]
     attr_reader :round_type
+
+    # ダイスの面数が指定されていない場合に何面ダイスにするか
+    #
+    # @return [Integer]
+    attr_reader :sides_implicit_d
 
     # UpperDiceで振り足しをする出目の閾値
     #

--- a/lib/bcdice/common_command/add_dice/node.rb
+++ b/lib/bcdice/common_command/add_dice/node.rb
@@ -391,7 +391,7 @@ module BCDice
           # @return [Integer] 評価結果（出目の合計値）
           def eval(game_system, randomizer)
             times = @times.eval(game_system, nil)
-            sides = @sides.eval(game_system, nil)
+            sides = eval_sides(game_system)
 
             dice_list = randomizer.roll(times, sides)
 
@@ -410,7 +410,7 @@ module BCDice
           # @return [String]
           def expr(game_system)
             times = @times.eval(game_system, nil)
-            sides = @sides.eval(game_system, nil)
+            sides = eval_sides(game_system)
 
             "#{times}D#{sides}"
           end
@@ -425,6 +425,31 @@ module BCDice
           # @return [String]
           def s_exp
             "(DiceRoll #{@times.s_exp} #{@sides.s_exp})"
+          end
+
+          private
+
+          def eval_sides(game_system)
+            @sides.eval(game_system, nil)
+          end
+        end
+
+        class ImplicitSidesDiceRoll < DiceRoll
+          # @param [Number] times ダイスを振る回数のノード
+          def initialize(times)
+            @times = times
+            @text = nil
+          end
+
+          # @return [String]
+          def s_exp
+            "(ImplicitSidesDiceRoll #{@times.s_exp})"
+          end
+
+          private
+
+          def eval_sides(game_system)
+            game_system.sides_implicit_d
           end
         end
 

--- a/lib/bcdice/common_command/add_dice/parser.rb
+++ b/lib/bcdice/common_command/add_dice/parser.rb
@@ -338,10 +338,9 @@ end
 
 def _reduce_22(val, _values, result)
         times = val[0]
-        sides = Node::Number.new(6)
         raise ParseError if times.include_dice?
 
-        result = Node::DiceRoll.new(times, sides)
+        result = Node::ImplicitSidesDiceRoll.new(times)
 
     result
 end

--- a/lib/bcdice/common_command/add_dice/parser.y
+++ b/lib/bcdice/common_command/add_dice/parser.y
@@ -86,10 +86,9 @@ rule
       | term D
       {
         times = val[0]
-        sides = Node::Number.new(6)
         raise ParseError if times.include_dice?
 
-        result = Node::DiceRoll.new(times, sides)
+        result = Node::ImplicitSidesDiceRoll.new(times)
       }
       | term D term filter_type term
       {

--- a/lib/bcdice/preprocessor.rb
+++ b/lib/bcdice/preprocessor.rb
@@ -29,7 +29,7 @@ module BCDice
 
       @text = @game_system.change_text(@text)
 
-      replace_implicit_d6()
+      replace_implicit_d()
 
       return @text
     end
@@ -54,9 +54,15 @@ module BCDice
       end
     end
 
-    # nDをnD6に置き換える
-    def replace_implicit_d6
-      @text = @text.gsub(/(\d+)D([^\w]|$)/i) { "#{Regexp.last_match(1)}D6#{Regexp.last_match(2)}" }
+    # nDをゲームシステムに応じて置き換える
+    def replace_implicit_d
+      @text = @text.gsub(/(\d+)D([^\w]|$)/i) do
+        times = Regexp.last_match(1)
+        sides = @game_system.sides_implicit_d
+        trailer = Regexp.last_match(2)
+
+        "#{times}D#{sides}#{trailer}"
+      end
     end
   end
 end

--- a/test/test_add_dice.rb
+++ b/test/test_add_dice.rb
@@ -3,6 +3,8 @@
 require "test/unit"
 require "bcdice"
 
+require_relative "randomizer_mock"
+
 class AddDiceTest < Test::Unit::TestCase
   class DefaultRound < BCDice::Base
     def initialize(command)
@@ -25,6 +27,13 @@ class AddDiceTest < Test::Unit::TestCase
     end
   end
 
+  class ImplicitD10 < BCDice::Base
+    def initialize(command)
+      super(command)
+      @sides_implicit_d = 10
+    end
+  end
+
   def test_default_round
     assert_equal("(1D1+3/2) ＞ 1[1]+3/2 ＞ 2", BCDice::Base.eval("1D1+3/2").text) # 1 + 1.5
     assert_equal("(1D1+4/3) ＞ 1[1]+4/3 ＞ 2", BCDice::Base.eval("1D1+4/3").text) # 1 + 1.33
@@ -43,5 +52,19 @@ class AddDiceTest < Test::Unit::TestCase
   def test_floor
     assert_equal("(1D1+3/2) ＞ 1[1]+3/2 ＞ 2", DefaultFloor.eval("1D1+3/2").text) # 1 + 1.5
     assert_equal("(1D1+4/3) ＞ 1[1]+4/3 ＞ 2", DefaultFloor.eval("1D1+4/3").text) # 1 + 1.33
+  end
+
+  def test_implicit_d10
+    game_system = ImplicitD10.new("1D+4")
+    game_system.randomizer = RandomizerMock.new([[10, 10]])
+
+    assert_equal("(1D10+4) ＞ 10[10]+4 ＞ 14", game_system.eval.text)
+  end
+
+  def test_implicit_d_default
+    game_system = BCDice::Base.new("1D+4")
+    game_system.randomizer = RandomizerMock.new([[6, 6]])
+
+    assert_equal("(1D6+4) ＞ 6[6]+4 ＞ 10", game_system.eval.text)
   end
 end

--- a/test/test_add_dice_parser.rb
+++ b/test/test_add_dice_parser.rb
@@ -30,8 +30,8 @@ class AddDiceParserTest < Test::Unit::TestCase
 
   # 面数の省略
   def test_parse_implicit_d
-    test_parse("2D", "(Command (DiceRoll 2 6))")
-    test_parse("2D+3", "(Command (+ (DiceRoll 2 6) 3))")
+    test_parse("2D", "(Command (ImplicitSidesDiceRoll 2))")
+    test_parse("2D+3", "(Command (+ (ImplicitSidesDiceRoll 2) 3))")
   end
 
   # 最初の空白までがパース対象となる

--- a/test/test_preprocessor.rb
+++ b/test/test_preprocessor.rb
@@ -4,6 +4,13 @@ require "bcdice/preprocessor"
 class TestPreprocessor < Test::Unit::TestCase
   class Mock < BCDice::Base; end
 
+  class ImplicitD10 < BCDice::Base
+    def initialize(command)
+      super(command)
+      @sides_implicit_d = 10
+    end
+  end
+
   def setup
     @game_system = Mock.new("")
   end
@@ -40,5 +47,11 @@ class TestPreprocessor < Test::Unit::TestCase
   def test_no_implicit_d
     text = BCDice::Preprocessor.process("1Dhoge", @game_system)
     assert_equal("1Dhoge", text)
+  end
+
+  def test_implicit_d10
+    game_system = ImplicitD10.new("")
+    text = BCDice::Preprocessor.process("1D+3", game_system)
+    assert_equal("1D10+3", text)
   end
 end


### PR DESCRIPTION
`1D+4` と入力された場合、今までは6面ダイス扱いとし `1D6+4` と解釈するようになっていた。

しかし、ゲームシステムによっては`1D`で期待される暗黙の面数は異なる。そこで、`BCDice::Base`に設定項目`@sides_implicit_d`を追加し、ゲームシステムごとに`1D`の解釈を変えられるようにする。

## 変更点
- 設定`@sides_implicit_d`の追加
- AddDiceで`@sides_implicit_d`を参照する
- Preprocessorで`@sides_implicit_d`を参照する