### PR TITLE
[Cthulhu7th] 技能判定のボーナスダイス数を100まで緩和する

### DIFF
--- a/lib/bcdice/game_system/Cthulhu7th.rb
+++ b/lib/bcdice/game_system/Cthulhu7th.rb
@@ -154,8 +154,8 @@ module BCDice
           return "1D100 ＞ #{dice}"
         end
 
-        unless BONUS_DICE_RANGE.include?(bonus_dice)
-          return "エラー。ボーナス・ペナルティダイスの値は#{BONUS_DICE_RANGE.min}～#{BONUS_DICE_RANGE.max}です。"
+        if bonus_dice.abs > 100
+          return "ボーナス・ペナルティダイスの値は-100以上、100以下としてください"
         end
 
         total, total_list = roll_with_bonus(bonus_dice)

--- a/test/data/Cthulhu7th.toml
+++ b/test/data/Cthulhu7th.toml
@@ -328,14 +328,14 @@ rands = [
 
 [[ test ]]
 game_system = "Cthulhu7th"
-input = "CC(-3)<=80"
-output = "エラー。ボーナス・ペナルティダイスの値は-2～2です。"
+input = "CC(-101)<=80"
+output = "ボーナス・ペナルティダイスの値は-100以上、100以下としてください"
 rands = []
 
 [[ test ]]
 game_system = "Cthulhu7th"
-input = "CC(3)<=80"
-output = "エラー。ボーナス・ペナルティダイスの値は-2～2です。"
+input = "CC(101)<=80"
+output = "ボーナス・ペナルティダイスの値は-100以上、100以下としてください"
 rands = []
 
 [[ test ]]
@@ -377,6 +377,30 @@ rands = [
   { sides = 10, value = 6 },
   { sides = 10, value = 3 },
   { sides = 10, value = 7 },
+]
+
+[[ test ]]
+game_system = "Cthulhu7th"
+input = "CC(3) ボーナスダイス数緩和"
+output = "(1D100) ボーナス・ペナルティダイス[3] ＞ 20, 100, 50, 30 ＞ 20"
+rands = [
+  { sides = 10, value = 2 },
+  { sides = 10, value = 10 },
+  { sides = 10, value = 5 },
+  { sides = 10, value = 3 },
+  { sides = 10, value = 10 },
+]
+
+[[ test ]]
+game_system = "Cthulhu7th"
+input = "CC(-3) ペナルティダイス数緩和"
+output = "(1D100) ボーナス・ペナルティダイス[-3] ＞ 20, 100, 50, 30 ＞ 100"
+rands = [
+  { sides = 10, value = 2 },
+  { sides = 10, value = 10 },
+  { sides = 10, value = 5 },
+  { sides = 10, value = 3 },
+  { sides = 10, value = 10 },
 ]
 
 [[ test ]]


### PR DESCRIPTION
ボーナス・ペナルティダイス数は英語原文だと明言されているが、日本語訳に意味が抜け落ちている。
ボーナスダイスに影響を与える呪文が未翻訳の英語版に複数あることや、上限についてはKPの裁量によるところが大きいため上限を緩和する。

Close #342