### PR TITLE
コマンドあたりの乱数生成の上限回数を10000回にする

### DIFF
--- a/lib/bcdice/randomizer.rb
+++ b/lib/bcdice/randomizer.rb
@@ -4,6 +4,8 @@ module BCDice
     UPPER_LIMIT_DICE_TIMES = 200
     UPPER_LIMIT_DICE_SIDES = 1000
 
+    UPPER_LIMIT_RANDS = 10000
+
     def initialize
       @rand_results = []
       @detailed_rand_results = []
@@ -30,6 +32,10 @@ module BCDice
     # @param sides [Integer] ダイスの面数
     # @return [Array<Integer>] ダイスの出目一覧
     def roll_barabara(times, sides)
+      if @rand_results.size + times > UPPER_LIMIT_RANDS
+        raise TooManyRandsError
+      end
+
       if times <= 0 || times > UPPER_LIMIT_DICE_TIMES
         return []
       end
@@ -113,6 +119,10 @@ module BCDice
     # @param sides [Integer]
     # @return [Integer] 1以上sides以下の整数
     def rand_inner(sides)
+      if @rand_results.size >= UPPER_LIMIT_RANDS
+        raise TooManyRandsError
+      end
+
       dice = random(sides)
 
       @rand_results << [dice, sides]
@@ -134,4 +144,6 @@ module BCDice
       @detailed_rand_results.push(detail)
     end
   end
+
+  class TooManyRandsError < StandardError; end
 end

--- a/test/test_randomizer.rb
+++ b/test/test_randomizer.rb
@@ -72,4 +72,68 @@ class TestRandomizer < Test::Unit::TestCase
   def test_roll_sum_minus_d
     assert_equal(0, @randomizer.roll_sum(-10, 100))
   end
+
+  def test_no_raise_rands_limit_with_barabara
+    assert_nothing_raised do
+      @randomizer.roll_barabara(10000, 100)
+    end
+  end
+
+  def test_raise_rands_limit_with_barabara
+    assert_raise_kind_of(BCDice::TooManyRandsError) do
+      @randomizer.roll_barabara(10001, 100)
+    end
+  end
+
+  def test_raise_rands_limit_with_sum
+    assert_raise_kind_of(BCDice::TooManyRandsError) do
+      @randomizer.roll_sum(10001, 100)
+    end
+  end
+
+  def test_no_raise_rands_limit_with_ones
+    assert_nothing_raised do
+      10000.times do
+        @randomizer.roll_once(6)
+      end
+    end
+  end
+
+  def test_raise_rands_limit_with_ones
+    assert_raise_kind_of(BCDice::TooManyRandsError) do
+      10001.times do
+        @randomizer.roll_once(6)
+      end
+    end
+  end
+
+  def test_raise_rands_limit_with_roll_tens_d10
+    assert_raise_kind_of(BCDice::TooManyRandsError) do
+      10001.times do
+        @randomizer.roll_tens_d10()
+      end
+    end
+  end
+
+  def test_raise_rands_limit_with_d9
+    assert_raise_kind_of(BCDice::TooManyRandsError) do
+      10001.times do
+        @randomizer.roll_d9()
+      end
+    end
+  end
+
+  def test_raise_rands_limit_with_d66
+    assert_raise_kind_of(BCDice::TooManyRandsError) do
+      10001.times do
+        @randomizer.roll_d66(BCDice::D66SortType::ASC)
+      end
+    end
+  end
+
+  def test_raise_rands_limit_with_eval
+    assert_raise_kind_of(BCDice::TooManyRandsError) do
+      BCDice::GameSystem::DiceBot.eval("x100 101D6")
+    end
+  end
 end


### PR DESCRIPTION
繰り返しコマンドを実装したことで悪意のあるコマンドを注入しやすくなったため、
コマンドにおける乱数生成に上限を設ける。

上限に達した場合、例外を発生させる。
BCDiceではこの例外をキャッチせず、ハンドリングはライブラリ利用者に委ねる。


## 検討事項
この例外をBCDiceでキャッチしてエラーメッセージに変換した方が良いかどうか