### PR TITLE
[DoubleCross] DXの修正値で `1+-4` となったときに動くように

### DIFF
--- a/lib/bcdice/game_system/DoubleCross.rb
+++ b/lib/bcdice/game_system/DoubleCross.rb
@@ -247,7 +247,7 @@ module BCDice
         parsed = parser.parse(command)
         return nil unless parsed
 
-        num, critical_value = parsed.command.split("DX", 2).map {|x| x&.to_i }
+        num, critical_value = parsed.command.split("DX", 2).map { |x| x&.to_i }
         critical_value ||= 10
 
         self.class::DX.new(num, critical_value, parsed.modify_number, parsed.target_number)

--- a/test/data/DoubleCross.toml
+++ b/test/data/DoubleCross.toml
@@ -1689,6 +1689,34 @@ rands = []
 
 [[ test ]]
 game_system = "DoubleCross"
+input = "(1+1+1)DX(8-0)+4+-4 埋め込み対応"
+output = "(3DX8) ＞ 10[2,4,9]+4[4] ＞ 14"
+rands = [
+    { sides = 10, value = 4 },
+    { sides = 10, value = 9 },
+    { sides = 10, value = 2 },
+    { sides = 10, value = 4 },
+]
+
+[[ test ]]
+game_system = "DoubleCross"
+input = "(1+1+1)DX@(8-0)+4+-4 埋め込み対応"
+output = "(3DX8) ＞ 10[2,4,9]+4[4] ＞ 14"
+rands = [
+    { sides = 10, value = 4 },
+    { sides = 10, value = 9 },
+    { sides = 10, value = 2 },
+    { sides = 10, value = 4 },
+]
+
+[[ test ]]
+game_system = "DoubleCross"
+input = "10DX10@10 クリティカル値が両方書いてあるのはパースエラー"
+output = ""
+rands = []
+
+[[ test ]]
+game_system = "DoubleCross"
 input = "ET"
 output = "感情表(69-7) ＞ 信頼(しんらい) - ○脅威(きょうい)"
 rands = [


### PR DESCRIPTION
オンセツールの機能を使って負の数を埋め込みしようとするとこのような現象が起こる。
`Command::Parser` を使ってパースする。


Ref. https://twitter.com/A_zondag/status/1305838316584009730
> システムはダブルクロスです
ステータスにw,xを設定しています
>
>使用している式です
({精神}+{DB}+{x})DX(8-{z})+{白兵}+{w}　命中判定
wに-の値が入ると判定がうまくいきません
