### PR TITLE
でたとこサーガの誤植修正、通常判定の拡張。

### DIFF
--- a/i18n/DetatokoSaga/ja_jp.yml
+++ b/i18n/DetatokoSaga/ja_jp.yml
@@ -2,6 +2,7 @@ ja_jp:
   DetatokoSaga:
     DS:
       input_options: "判定！　スキルランク：%{skill}　フラグ：%{flag}　目標値：%{target}"
+      modifier: "　修正値：%{modifier}"
       success: 目標値以上！【成功】
       failure: 目標値未満…【失敗】
     JD:

--- a/i18n/DetatokoSaga/ja_jp.yml
+++ b/i18n/DetatokoSaga/ja_jp.yml
@@ -1,11 +1,11 @@
 ja_jp:
   DetatokoSaga:
     DS:
-      input_options: "判定！　スキルレベル：%{skill}　フラグ：%{flag}　目標値：%{target}"
+      input_options: "判定！　スキルランク：%{skill}　フラグ：%{flag}　目標値：%{target}"
       success: 目標値以上！【成功】
       failure: 目標値未満…【失敗】
     JD:
-      input_options: "判定！　スキルレベル：%{skill}　フラグ：%{flag}"
+      input_options: "判定！　スキルランク：%{skill}　フラグ：%{flag}"
       modifier: "　修正値：%{modifier}"
     total_value: "判定値：%{total}"
     less_than_flag: "、フラグ以下！【気力%{will}点減少】【判定値変更不可】"

--- a/i18n/DetatokoSaga/ko_kr.yml
+++ b/i18n/DetatokoSaga/ko_kr.yml
@@ -2,6 +2,7 @@ ko_kr:
   DetatokoSaga:
     DS:
       input_options: "판정！　스킬레벨：%{skill}　플래그：%{flag}　목표치：%{target}"
+      modifier: "　수정치：%{modifier}"
       success: 목표치 이상！【성공】
       failure: 목표치 미달… 【실패】
     JD:

--- a/lib/bcdice/game_system/DetatokoSaga.rb
+++ b/lib/bcdice/game_system/DetatokoSaga.rb
@@ -15,10 +15,10 @@ module BCDice
       # ダイスボットの使い方
       HELP_MESSAGE = <<~INFO_MESSAGE_TEXT
         ・通常判定　xDS or xDSy or xDS>=z or xDSy>=z
-        　(x＝スキルレベル、y＝現在フラグ値(省略時0)、z＝目標値(省略時８))
+        　(x＝スキルランク、y＝現在フラグ値(省略時0)、z＝目標値(省略時８))
         　例）3DS　2DS5　0DS　3DS>=10　3DS7>=12
         ・判定値　xJD or xJDy or xJDy+z or xJDy-z or xJDy/z
-        　(x＝スキルレベル、y＝現在フラグ値(省略時0)、z＝修正値(省略時０))
+        　(x＝スキルランク、y＝現在フラグ値(省略時0)、z＝修正値(省略時０))
         　例）3JD　2JD5　3JD7+1　4JD/3
         ・体力烙印表　SST (StrengthStigmaTable)
         ・気力烙印表　WST (WillStigmaTable)

--- a/lib/bcdice/game_system/DetatokoSaga_Korean.rb
+++ b/lib/bcdice/game_system/DetatokoSaga_Korean.rb
@@ -16,9 +16,9 @@ module BCDice
 
       # ダイスボットの使い方
       HELP_MESSAGE = <<~INFO_MESSAGE_TEXT
-        ・통상판정　xDS or xDSy or xDS>=z or xDSy>=z
-        　(x＝스킬레벨, y＝현재 플래그(생략=0), z＝목표치(생략=８))
-        　예）3DS　2DS5　0DS　3DS>=10　3DS7>=12
+        ・통상판정　xDS or xDSy or xDS>=t or xDSy>=t or xDS+z>=t or xDSy+z>=t
+        　(x＝스킬레벨, y＝현재 플래그(생략=0), z＝수정치(생략=０), t＝목표치(생략=８))
+        　예）3DS　2DS5　0DS　3DS>=10　3DS7>=12 2DS3+1 3DS2+1>=10
         ・판정치　xJD or xJDy or xJDy+z or xJDy-z or xJDy/z
         　(x＝스킬레벨, y＝현재 플래그(생략=0), z＝수정치(생략=０))
         　예）3JD　2JD5　3JD7+1　4JD/3

--- a/test/data/DetatokoSaga.toml
+++ b/test/data/DetatokoSaga.toml
@@ -1,7 +1,7 @@
 [[ test ]]
 game_system = "DetatokoSaga"
 input = "3JD"
-output = "判定！　スキルレベル：3　フラグ：0 ＞ 7[1,3,2,4] ＞ 判定値：7"
+output = "判定！　スキルランク：3　フラグ：0 ＞ 7[1,3,2,4] ＞ 判定値：7"
 rands = [
   { sides = 6, value = 1 },
   { sides = 6, value = 3 },
@@ -12,7 +12,7 @@ rands = [
 [[ test ]]
 game_system = "DetatokoSaga"
 input = "1JD"
-output = "判定！　スキルレベル：1　フラグ：0 ＞ 7[4,3] ＞ 判定値：7"
+output = "判定！　スキルランク：1　フラグ：0 ＞ 7[4,3] ＞ 判定値：7"
 rands = [
   { sides = 6, value = 4 },
   { sides = 6, value = 3 },
@@ -21,7 +21,7 @@ rands = [
 [[ test ]]
 game_system = "DetatokoSaga"
 input = "0JD"
-output = "判定！　スキルレベル：0　フラグ：0 ＞ 7[6,3,4] ＞ 判定値：7"
+output = "判定！　スキルランク：0　フラグ：0 ＞ 7[6,3,4] ＞ 判定値：7"
 rands = [
   { sides = 6, value = 6 },
   { sides = 6, value = 3 },
@@ -31,7 +31,7 @@ rands = [
 [[ test ]]
 game_system = "DetatokoSaga"
 input = "3JD"
-output = "判定！　スキルレベル：3　フラグ：0 ＞ 8[1,3,2,5] ＞ 判定値：8"
+output = "判定！　スキルランク：3　フラグ：0 ＞ 8[1,3,2,5] ＞ 判定値：8"
 rands = [
   { sides = 6, value = 1 },
   { sides = 6, value = 3 },
@@ -42,7 +42,7 @@ rands = [
 [[ test ]]
 game_system = "DetatokoSaga"
 input = "2JD5"
-output = "判定！　スキルレベル：2　フラグ：5 ＞ 7[5,2,1] ＞ 判定値：7"
+output = "判定！　スキルランク：2　フラグ：5 ＞ 7[5,2,1] ＞ 判定値：7"
 rands = [
   { sides = 6, value = 5 },
   { sides = 6, value = 2 },
@@ -52,7 +52,7 @@ rands = [
 [[ test ]]
 game_system = "DetatokoSaga"
 input = "3JD7"
-output = "判定！　スキルレベル：3　フラグ：7 ＞ 7[5,2,1,1] ＞ 判定値：7、フラグ以下！【気力1D6->3点減少】【判定値変更不可】"
+output = "判定！　スキルランク：3　フラグ：7 ＞ 7[5,2,1,1] ＞ 判定値：7、フラグ以下！【気力1D6->3点減少】【判定値変更不可】"
 rands = [
   { sides = 6, value = 5 },
   { sides = 6, value = 2 },
@@ -64,7 +64,7 @@ rands = [
 [[ test ]]
 game_system = "DetatokoSaga"
 input = "3JD7+1"
-output = "判定！　スキルレベル：3　フラグ：7　修正値：＋1 ＞ 7[5,2,1,1]＋1 ＞ 7+1 ＞ 判定値：8、フラグ以下！【気力1D6->3点減少】【判定値変更不可】"
+output = "判定！　スキルランク：3　フラグ：7　修正値：＋1 ＞ 7[5,2,1,1]＋1 ＞ 7+1 ＞ 判定値：8、フラグ以下！【気力1D6->3点減少】【判定値変更不可】"
 rands = [
   { sides = 6, value = 5 },
   { sides = 6, value = 2 },
@@ -76,7 +76,7 @@ rands = [
 [[ test ]]
 game_system = "DetatokoSaga"
 input = "3JD7-1"
-output = "判定！　スキルレベル：3　フラグ：7　修正値：－1 ＞ 7[5,2,1,1]－1 ＞ 7-1 ＞ 判定値：6、フラグ以下！【気力1D6->3点減少】【判定値変更不可】"
+output = "判定！　スキルランク：3　フラグ：7　修正値：－1 ＞ 7[5,2,1,1]－1 ＞ 7-1 ＞ 判定値：6、フラグ以下！【気力1D6->3点減少】【判定値変更不可】"
 rands = [
   { sides = 6, value = 5 },
   { sides = 6, value = 2 },
@@ -88,7 +88,7 @@ rands = [
 [[ test ]]
 game_system = "DetatokoSaga"
 input = "3JD7/3"
-output = "判定！　スキルレベル：3　フラグ：7　修正値：÷3 ＞ 8[5,3,1,2]÷3 ＞ 8÷3 ＞ 判定値：3"
+output = "判定！　スキルランク：3　フラグ：7　修正値：÷3 ＞ 8[5,3,1,2]÷3 ＞ 8÷3 ＞ 判定値：3"
 rands = [
   { sides = 6, value = 5 },
   { sides = 6, value = 3 },
@@ -99,7 +99,7 @@ rands = [
 [[ test ]]
 game_system = "DetatokoSaga"
 input = "3JD7/3"
-output = "判定！　スキルレベル：3　フラグ：7　修正値：÷3 ＞ 9[6,3,1,2]÷3 ＞ 9÷3 ＞ 判定値：3"
+output = "判定！　スキルランク：3　フラグ：7　修正値：÷3 ＞ 9[6,3,1,2]÷3 ＞ 9÷3 ＞ 判定値：3"
 rands = [
   { sides = 6, value = 6 },
   { sides = 6, value = 3 },
@@ -110,7 +110,7 @@ rands = [
 [[ test ]]
 game_system = "DetatokoSaga"
 input = "3JD7/3"
-output = "判定！　スキルレベル：3　フラグ：7　修正値：÷3 ＞ 10[6,4,1,2]÷3 ＞ 10÷3 ＞ 判定値：4"
+output = "判定！　スキルランク：3　フラグ：7　修正値：÷3 ＞ 10[6,4,1,2]÷3 ＞ 10÷3 ＞ 判定値：4"
 rands = [
   { sides = 6, value = 6 },
   { sides = 6, value = 4 },
@@ -121,7 +121,7 @@ rands = [
 [[ test ]]
 game_system = "DetatokoSaga"
 input = "3JD7/3"
-output = "判定！　スキルレベル：3　フラグ：7　修正値：÷3 ＞ 11[6,5,1,2]÷3 ＞ 11÷3 ＞ 判定値：4"
+output = "判定！　スキルランク：3　フラグ：7　修正値：÷3 ＞ 11[6,5,1,2]÷3 ＞ 11÷3 ＞ 判定値：4"
 rands = [
   { sides = 6, value = 6 },
   { sides = 6, value = 5 },
@@ -132,7 +132,7 @@ rands = [
 [[ test ]]
 game_system = "DetatokoSaga"
 input = "3JD7/3"
-output = "判定！　スキルレベル：3　フラグ：7　修正値：÷3 ＞ 12[6,6,1,2]÷3 ＞ 12÷3 ＞ 判定値：4"
+output = "判定！　スキルランク：3　フラグ：7　修正値：÷3 ＞ 12[6,6,1,2]÷3 ＞ 12÷3 ＞ 判定値：4"
 rands = [
   { sides = 6, value = 6 },
   { sides = 6, value = 6 },
@@ -143,7 +143,7 @@ rands = [
 [[ test ]]
 game_system = "DetatokoSaga"
 input = "3JD7/1"
-output = "判定！　スキルレベル：3　フラグ：7　修正値：÷1 ＞ 12[6,6,1,2]÷1 ＞ 12÷1 ＞ 判定値：12"
+output = "判定！　スキルランク：3　フラグ：7　修正値：÷1 ＞ 12[6,6,1,2]÷1 ＞ 12÷1 ＞ 判定値：12"
 rands = [
   { sides = 6, value = 6 },
   { sides = 6, value = 6 },
@@ -154,7 +154,7 @@ rands = [
 [[ test ]]
 game_system = "DetatokoSaga"
 input = "3JD7/0 ゼロ除算"
-output = "判定！　スキルレベル：3　フラグ：7 ＞ 12[6,6,1,2] ＞ 0では割れません"
+output = "判定！　スキルランク：3　フラグ：7 ＞ 12[6,6,1,2] ＞ 0では割れません"
 rands = [
   { sides = 6, value = 6 },
   { sides = 6, value = 6 },
@@ -165,7 +165,7 @@ rands = [
 [[ test ]]
 game_system = "DetatokoSaga"
 input = "3JD9"
-output = "判定！　スキルレベル：3　フラグ：9 ＞ 8[1,3,2,5] ＞ 判定値：8、フラグ以下！【気力1D6->3点減少】【判定値変更不可】"
+output = "判定！　スキルランク：3　フラグ：9 ＞ 8[1,3,2,5] ＞ 判定値：8、フラグ以下！【気力1D6->3点減少】【判定値変更不可】"
 rands = [
   { sides = 6, value = 1 },
   { sides = 6, value = 3 },
@@ -177,7 +177,7 @@ rands = [
 [[ test ]]
 game_system = "DetatokoSaga"
 input = "3JD10"
-output = "判定！　スキルレベル：3　フラグ：10 ＞ 8[1,3,2,5] ＞ 判定値：8、フラグ以下！【気力6点減少】【判定値変更不可】"
+output = "判定！　スキルランク：3　フラグ：10 ＞ 8[1,3,2,5] ＞ 判定値：8、フラグ以下！【気力6点減少】【判定値変更不可】"
 rands = [
   { sides = 6, value = 1 },
   { sides = 6, value = 3 },
@@ -188,7 +188,7 @@ rands = [
 [[ test ]]
 game_system = "DetatokoSaga"
 input = "3DS"
-output = "判定！　スキルレベル：3　フラグ：0　目標値：8 ＞ 7[1,3,2,4] ＞ 判定値：7 ＞ 目標値未満…【失敗】"
+output = "判定！　スキルランク：3　フラグ：0　目標値：8 ＞ 7[1,3,2,4] ＞ 判定値：7 ＞ 目標値未満…【失敗】"
 rands = [
   { sides = 6, value = 1 },
   { sides = 6, value = 3 },
@@ -199,7 +199,7 @@ rands = [
 [[ test ]]
 game_system = "DetatokoSaga"
 input = "1DS"
-output = "判定！　スキルレベル：1　フラグ：0　目標値：8 ＞ 7[4,3] ＞ 判定値：7 ＞ 目標値未満…【失敗】"
+output = "判定！　スキルランク：1　フラグ：0　目標値：8 ＞ 7[4,3] ＞ 判定値：7 ＞ 目標値未満…【失敗】"
 rands = [
   { sides = 6, value = 4 },
   { sides = 6, value = 3 },
@@ -208,7 +208,7 @@ rands = [
 [[ test ]]
 game_system = "DetatokoSaga"
 input = "0DS"
-output = "判定！　スキルレベル：0　フラグ：0　目標値：8 ＞ 7[6,3,4] ＞ 判定値：7 ＞ 目標値未満…【失敗】"
+output = "判定！　スキルランク：0　フラグ：0　目標値：8 ＞ 7[6,3,4] ＞ 判定値：7 ＞ 目標値未満…【失敗】"
 rands = [
   { sides = 6, value = 6 },
   { sides = 6, value = 3 },
@@ -218,7 +218,7 @@ rands = [
 [[ test ]]
 game_system = "DetatokoSaga"
 input = "3DS"
-output = "判定！　スキルレベル：3　フラグ：0　目標値：8 ＞ 8[1,3,2,5] ＞ 判定値：8 ＞ 目標値以上！【成功】"
+output = "判定！　スキルランク：3　フラグ：0　目標値：8 ＞ 8[1,3,2,5] ＞ 判定値：8 ＞ 目標値以上！【成功】"
 rands = [
   { sides = 6, value = 1 },
   { sides = 6, value = 3 },
@@ -229,7 +229,7 @@ rands = [
 [[ test ]]
 game_system = "DetatokoSaga"
 input = "3DS7"
-output = "判定！　スキルレベル：3　フラグ：7　目標値：8 ＞ 7[5,2,1,1] ＞ 判定値：7 ＞ 目標値未満…【失敗】、フラグ以下！【気力1D6->3点減少】【判定値変更不可】"
+output = "判定！　スキルランク：3　フラグ：7　目標値：8 ＞ 7[5,2,1,1] ＞ 判定値：7 ＞ 目標値未満…【失敗】、フラグ以下！【気力1D6->3点減少】【判定値変更不可】"
 rands = [
   { sides = 6, value = 5 },
   { sides = 6, value = 2 },
@@ -241,7 +241,7 @@ rands = [
 [[ test ]]
 game_system = "DetatokoSaga"
 input = "3DS9"
-output = "判定！　スキルレベル：3　フラグ：9　目標値：8 ＞ 8[1,3,2,5] ＞ 判定値：8 ＞ 目標値以上！【成功】、フラグ以下！【気力1D6->3点減少】【判定値変更不可】"
+output = "判定！　スキルランク：3　フラグ：9　目標値：8 ＞ 8[1,3,2,5] ＞ 判定値：8 ＞ 目標値以上！【成功】、フラグ以下！【気力1D6->3点減少】【判定値変更不可】"
 rands = [
   { sides = 6, value = 1 },
   { sides = 6, value = 3 },
@@ -253,7 +253,7 @@ rands = [
 [[ test ]]
 game_system = "DetatokoSaga"
 input = "3DS10"
-output = "判定！　スキルレベル：3　フラグ：10　目標値：8 ＞ 8[1,3,2,5] ＞ 判定値：8 ＞ 目標値以上！【成功】、フラグ以下！【気力6点減少】【判定値変更不可】"
+output = "判定！　スキルランク：3　フラグ：10　目標値：8 ＞ 8[1,3,2,5] ＞ 判定値：8 ＞ 目標値以上！【成功】、フラグ以下！【気力6点減少】【判定値変更不可】"
 rands = [
   { sides = 6, value = 1 },
   { sides = 6, value = 3 },
@@ -264,7 +264,7 @@ rands = [
 [[ test ]]
 game_system = "DetatokoSaga"
 input = "3DS>=10"
-output = "判定！　スキルレベル：3　フラグ：0　目標値：10 ＞ 9[5,2,4,1] ＞ 判定値：9 ＞ 目標値未満…【失敗】"
+output = "判定！　スキルランク：3　フラグ：0　目標値：10 ＞ 9[5,2,4,1] ＞ 判定値：9 ＞ 目標値未満…【失敗】"
 rands = [
   { sides = 6, value = 5 },
   { sides = 6, value = 2 },
@@ -275,7 +275,7 @@ rands = [
 [[ test ]]
 game_system = "DetatokoSaga"
 input = "3DS>=10"
-output = "判定！　スキルレベル：3　フラグ：0　目標値：10 ＞ 10[4,2,4,6] ＞ 判定値：10 ＞ 目標値以上！【成功】"
+output = "判定！　スキルランク：3　フラグ：0　目標値：10 ＞ 10[4,2,4,6] ＞ 判定値：10 ＞ 目標値以上！【成功】"
 rands = [
   { sides = 6, value = 4 },
   { sides = 6, value = 2 },
@@ -286,7 +286,7 @@ rands = [
 [[ test ]]
 game_system = "DetatokoSaga"
 input = "3DS9>=10"
-output = "判定！　スキルレベル：3　フラグ：9　目標値：10 ＞ 9[5,2,4,1] ＞ 判定値：9 ＞ 目標値未満…【失敗】、フラグ以下！【気力1D6->3点減少】【判定値変更不可】"
+output = "判定！　スキルランク：3　フラグ：9　目標値：10 ＞ 9[5,2,4,1] ＞ 判定値：9 ＞ 目標値未満…【失敗】、フラグ以下！【気力1D6->3点減少】【判定値変更不可】"
 rands = [
   { sides = 6, value = 5 },
   { sides = 6, value = 2 },

--- a/test/data/DetatokoSaga.toml
+++ b/test/data/DetatokoSaga.toml
@@ -297,6 +297,78 @@ rands = [
 
 [[ test ]]
 game_system = "DetatokoSaga"
+input = "1DS+1"
+output = "判定！　スキルランク：1　フラグ：0　目標値：8　修正値：＋1 ＞ 4[2,2]＋1 ＞ 4+1 ＞ 判定値：5 ＞ 目標値未満…【失敗】"
+rands = [
+  { sides = 6, value = 2 },
+  { sides = 6, value = 2 }
+]
+
+[[ test ]]
+game_system = "DetatokoSaga"
+input = "2DS2+2"
+output = "判定！　スキルランク：2　フラグ：2　目標値：8　修正値：＋2 ＞ 7[4,2,3]＋2 ＞ 7+2 ＞ 判定値：9 ＞ 目標値以上！【成功】"
+rands = [
+  { sides = 6, value = 4 },
+  { sides = 6, value = 2 },
+  { sides = 6, value = 3 }
+]
+
+[[ test ]]
+game_system = "DetatokoSaga"
+input = "3DS+1>=11"
+output = "判定！　スキルランク：3　フラグ：0　目標値：11　修正値：＋1 ＞ 6[1,4,2,2]＋1 ＞ 6+1 ＞ 判定値：7 ＞ 目標値未満…【失敗】"
+rands = [
+  { sides = 6, value = 1 },
+  { sides = 6, value = 4 },
+  { sides = 6, value = 2 },
+  { sides = 6, value = 2 }
+]
+
+[[ test ]]
+game_system = "DetatokoSaga"
+input = "2DS3+1>=10"
+output = "判定！　スキルランク：2　フラグ：3　目標値：10　修正値：＋1 ＞ 9[4,5,3]＋1 ＞ 9+1 ＞ 判定値：10 ＞ 目標値以上！【成功】"
+rands = [
+  { sides = 6, value = 4 },
+  { sides = 6, value = 5 },
+  { sides = 6, value = 3 }
+]
+
+[[ test ]]
+game_system = "DetatokoSaga"
+input = "1DS5+1"
+output = "判定！　スキルランク：1　フラグ：5　目標値：8　修正値：＋1 ＞ 3[1,2]＋1 ＞ 3+1 ＞ 判定値：4 ＞ 目標値未満…【失敗】、フラグ以下！【気力1D6->5点減少】【判定値変更不可】"
+rands = [
+  { sides = 6, value = 1 },
+  { sides = 6, value = 2 },
+  { sides = 6, value = 5 }
+]
+
+[[ test ]]
+game_system = "DetatokoSaga"
+input = "2DS9+1"
+output = "判定！　スキルランク：2　フラグ：9　目標値：8　修正値：＋1 ＞ 7[3,4,3]＋1 ＞ 7+1 ＞ 判定値：8 ＞ 目標値以上！【成功】、フラグ以下！【気力1D6->2点減少】【判定値変更不可】"
+rands = [
+  { sides = 6, value = 3 },
+  { sides = 6, value = 4 },
+  { sides = 6, value = 3 },
+  { sides = 6, value = 2 }
+]
+
+[[ test ]]
+game_system = "DetatokoSaga"
+input = "3DS11+2>=9"
+output = "判定！　スキルランク：3　フラグ：11　目標値：9　修正値：＋2 ＞ 9[1,2,5,4]＋2 ＞ 9+2 ＞ 判定値：11 ＞ 目標値以上！【成功】、フラグ以下！【気力6点減少】【判定値変更不可】"
+rands = [
+  { sides = 6, value = 1 },
+  { sides = 6, value = 2 },
+  { sides = 6, value = 5 },
+  { sides = 6, value = 4 }
+]
+
+[[ test ]]
+game_system = "DetatokoSaga"
 input = "SST"
 output = "体力烙印表(2) ＞ あなたは【烙印】を２つ受ける。この表をさらに２回振って受ける【烙印】を決める（その結果、再びこの出目が出ても【烙印】は増えない）。"
 rands = [

--- a/test/data/DetatokoSaga_Korean.toml
+++ b/test/data/DetatokoSaga_Korean.toml
@@ -297,6 +297,78 @@ rands = [
 
 [[ test ]]
 game_system = "DetatokoSaga:Korean"
+input = "1DS+1"
+output = "판정！　스킬레벨：1　플래그：0　목표치：8　수정치：＋1 ＞ 4[2,2]＋1 ＞ 4+1 ＞ 판정치：5 ＞ 목표치 미달… 【실패】"
+rands = [
+  { sides = 6, value = 2 },
+  { sides = 6, value = 2 }
+]
+
+[[ test ]]
+game_system = "DetatokoSaga:Korean"
+input = "2DS2+2"
+output = "판정！　스킬레벨：2　플래그：2　목표치：8　수정치：＋2 ＞ 7[4,2,3]＋2 ＞ 7+2 ＞ 판정치：9 ＞ 목표치 이상！【성공】"
+rands = [
+  { sides = 6, value = 4 },
+  { sides = 6, value = 2 },
+  { sides = 6, value = 3 }
+]
+
+[[ test ]]
+game_system = "DetatokoSaga:Korean"
+input = "3DS+1>=11"
+output = "판정！　스킬레벨：3　플래그：0　목표치：11　수정치：＋1 ＞ 6[1,4,2,2]＋1 ＞ 6+1 ＞ 판정치：7 ＞ 목표치 미달… 【실패】"
+rands = [
+  { sides = 6, value = 1 },
+  { sides = 6, value = 4 },
+  { sides = 6, value = 2 },
+  { sides = 6, value = 2 }
+]
+
+[[ test ]]
+game_system = "DetatokoSaga:Korean"
+input = "2DS3+1>=10"
+output = "판정！　스킬레벨：2　플래그：3　목표치：10　수정치：＋1 ＞ 9[4,5,3]＋1 ＞ 9+1 ＞ 판정치：10 ＞ 목표치 이상！【성공】"
+rands = [
+  { sides = 6, value = 4 },
+  { sides = 6, value = 5 },
+  { sides = 6, value = 3 }
+]
+
+[[ test ]]
+game_system = "DetatokoSaga:Korean"
+input = "1DS5+1"
+output = "판정！　스킬레벨：1　플래그：5　목표치：8　수정치：＋1 ＞ 3[1,2]＋1 ＞ 3+1 ＞ 판정치：4 ＞ 목표치 미달… 【실패】, 플래그 이하！ 【기력1D6->5점 감소】 【판정치 변경 불가】"
+rands = [
+  { sides = 6, value = 1 },
+  { sides = 6, value = 2 },
+  { sides = 6, value = 5 }
+]
+
+[[ test ]]
+game_system = "DetatokoSaga:Korean"
+input = "2DS9+1"
+output = "판정！　스킬레벨：2　플래그：9　목표치：8　수정치：＋1 ＞ 7[3,4,3]＋1 ＞ 7+1 ＞ 판정치：8 ＞ 목표치 이상！【성공】, 플래그 이하！ 【기력1D6->2점 감소】 【판정치 변경 불가】"
+rands = [
+  { sides = 6, value = 3 },
+  { sides = 6, value = 4 },
+  { sides = 6, value = 3 },
+  { sides = 6, value = 2 }
+]
+
+[[ test ]]
+game_system = "DetatokoSaga:Korean"
+input = "3DS11+2>=9"
+output = "판정！　스킬레벨：3　플래그：11　목표치：9　수정치：＋2 ＞ 9[1,2,5,4]＋2 ＞ 9+2 ＞ 판정치：11 ＞ 목표치 이상！【성공】, 플래그 이하！ 【기력6점 감소】 【판정치 변경 불가】"
+rands = [
+  { sides = 6, value = 1 },
+  { sides = 6, value = 2 },
+  { sides = 6, value = 5 },
+  { sides = 6, value = 4 }
+]
+
+[[ test ]]
+game_system = "DetatokoSaga:Korean"
 input = "SST"
 output = "체력 낙인표(2) ＞ 당신은 【낙인】을 2개 받는다. 이 표를 다시 2번 굴려 받을 【낙인】을 정한다(그 경우, 다시 이 눈이 나와도 【낙인】은 늘어나지 않는다)."
 rands = [


### PR DESCRIPTION
でたとこサーガのダイスボットについての2つの修正です。

修正1) ダイスボットの誤植修正
　ダイスボットでは「スキルレベル」と出力されているが、ルールブックの記述では「スキルランク」となっている。
ルールブックの記述に合わせた誤植の修正を行ったものです。

修正2) 通常判定 xDS の機能拡張
　通常判定コマンド xDS では、現在の挙動では修正値を受け付けません。
ルールに記載されたスキル効果などで、修正値を加えることがあります。
現状の挙動のままでは、ユーザは 2DS3 と入力し、出力を受けてから
手作業で修正値の分を計算する形になります。
　利便性を向上させるため、 xDS コマンドも +- の修正値に対応するよう
拡張したものが修正2になります。

付記
　修正2では、修正内容が多言語化ファイルへも影響するため
韓国語版についても変更を加えています。

確認よろしくお願いします。