### PR TITLE
SW2.5のモンストラスロアで追加された森羅魔法のダメージ算出ダイスに対応

### DIFF
--- a/lib/bcdice/game_system/SwordWorld2_5.rb
+++ b/lib/bcdice/game_system/SwordWorld2_5.rb
@@ -120,7 +120,7 @@ module BCDice
         total = power + command.modify_number
         sequence = [
           "(#{command.command.capitalize}#{Format.modifier(command.modify_number)})",
-          "2D[#{dice_list.join(',')}]=#{power}",
+          "2D[#{dice_list.join(',')}]=#{dice_total}",
           "#{power}#{Format.modifier(command.modify_number)}",
           total
         ]

--- a/lib/bcdice/game_system/SwordWorld2_5.rb
+++ b/lib/bcdice/game_system/SwordWorld2_5.rb
@@ -77,7 +77,7 @@ module BCDice
         case command
         when /^dru\[(\d+),(\d+),(\d+)\]/i
           power_list = Regexp.last_match.captures.map(&:to_i)
-          druid_parser = Command::Parser.new(/dru\[(\d+),(\d+),(\d+)\]/i, round_type: BCDice::RoundType::CEIL)
+          druid_parser = Command::Parser.new(/dru\[\d+,\d+,\d+\]/i, round_type: BCDice::RoundType::CEIL)
 
           cmd = druid_parser.parse(command)
           unless cmd

--- a/lib/bcdice/game_system/SwordWorld2_5.rb
+++ b/lib/bcdice/game_system/SwordWorld2_5.rb
@@ -76,7 +76,7 @@ module BCDice
       def eval_game_system_specific_command(command)
         case command
         when /dru\[(\d+),(\d+),(\d+)\].*/i
-          power_list = (1..3).map{ |i|  Regexp.last_match(i).to_i }
+          power_list = (1..3).map { |i| Regexp.last_match(i).to_i }
           druid_parser = Command::Parser.new(/dru\[\d+,\d+,\d+\]/i, round_type: BCDice::RoundType::CEIL)
 
           cmd = druid_parser.parse(command)
@@ -117,7 +117,7 @@ module BCDice
         power = power_list[offset]
         total = power + command.modify_number
         sequence = [
-          "2D[#{dice_list.join(",")}]=#{power}",
+          "2D[#{dice_list.join(',')}]=#{power}",
           "#{power}#{Format.modifier(command.modify_number)}",
           total
         ].compact

--- a/lib/bcdice/game_system/SwordWorld2_5.rb
+++ b/lib/bcdice/game_system/SwordWorld2_5.rb
@@ -77,14 +77,14 @@ module BCDice
         case command
         when /dru\[(\d+),(\d+),(\d+)\].*/i
           power_list = (1..3).map{ |i|  Regexp.last_match(i).to_i }
-          doruid_parser = Command::Parser.new(/dru\[\d+,\d+,\d+\]/i, round_type: BCDice::RoundType::CEIL)
+          druid_parser = Command::Parser.new(/dru\[\d+,\d+,\d+\]/i, round_type: BCDice::RoundType::CEIL)
 
-          cmd = doruid_parser.parse(command)
+          cmd = druid_parser.parse(command)
           unless cmd
             return nil
           end
 
-          doruid_dice(cmd, power_list)
+          druid_dice(cmd, power_list)
         else
           super(command)
         end
@@ -102,7 +102,7 @@ module BCDice
         end
       end
 
-      def doruid_dice(command, power_list)
+      def druid_dice(command, power_list)
         dice_list = @randomizer.roll_barabara(2, 6)
         dice_total = dice_list.sum()
         offset =

--- a/lib/bcdice/game_system/SwordWorld2_5.rb
+++ b/lib/bcdice/game_system/SwordWorld2_5.rb
@@ -71,11 +71,11 @@ module BCDice
         　例）Dru[0,3,6]+10-3
       INFO_MESSAGE_TEXT
 
-      register_prefix('H?K\d+.*', 'Gr(\d+)?', '2D6?@\d+.*', 'FT', 'TT', '^Dru\[\d+,\d+,\d+\]')
+      register_prefix('H?K\d+.*', 'Gr(\d+)?', '2D6?@\d+.*', 'FT', 'TT', 'Dru\[\d+,\d+,\d+\].*')
 
       def eval_game_system_specific_command(command)
         case command
-        when /dru\[(\d+),(\d+),(\d+)\].*/i
+        when /^dru\[(\d+),(\d+),(\d+)\]/i
           power_list = Regexp.last_match.captures.map(&:to_i)
           druid_parser = Command::Parser.new(/dru\[\d+,\d+,\d+\]/i, round_type: BCDice::RoundType::CEIL)
 

--- a/lib/bcdice/game_system/SwordWorld2_5.rb
+++ b/lib/bcdice/game_system/SwordWorld2_5.rb
@@ -73,11 +73,13 @@ module BCDice
 
       register_prefix('H?K\d+.*', 'Gr(\d+)?', '2D6?@\d+.*', 'FT', 'TT', 'Dru\[\d+,\d+,\d+\].*')
 
+      DRUID_DICE_RE = /^dru\[(\d+),(\d+),(\d+)\]/i.freeze
+
       def eval_game_system_specific_command(command)
         case command
-        when /^dru\[(\d+),(\d+),(\d+)\]/i
+        when DRUID_DICE_RE
           power_list = Regexp.last_match.captures.map(&:to_i)
-          druid_parser = Command::Parser.new(/dru\[\d+,\d+,\d+\]/i, round_type: BCDice::RoundType::CEIL)
+          druid_parser = Command::Parser.new(DRUID_DICE_RE, round_type: BCDice::RoundType::CEIL)
 
           cmd = druid_parser.parse(command)
           unless cmd

--- a/lib/bcdice/game_system/SwordWorld2_5.rb
+++ b/lib/bcdice/game_system/SwordWorld2_5.rb
@@ -73,13 +73,11 @@ module BCDice
 
       register_prefix('H?K\d+.*', 'Gr(\d+)?', '2D6?@\d+.*', 'FT', 'TT', 'Dru\[\d+,\d+,\d+\].*')
 
-      DRUID_DICE_RE = /^dru\[(\d+),(\d+),(\d+)\]/i.freeze
-
       def eval_game_system_specific_command(command)
         case command
-        when DRUID_DICE_RE
+        when /^dru\[(\d+),(\d+),(\d+)\]/i
           power_list = Regexp.last_match.captures.map(&:to_i)
-          druid_parser = Command::Parser.new(DRUID_DICE_RE, round_type: BCDice::RoundType::CEIL)
+          druid_parser = Command::Parser.new(/dru\[(\d+),(\d+),(\d+)\]/i, round_type: BCDice::RoundType::CEIL)
 
           cmd = druid_parser.parse(command)
           unless cmd

--- a/lib/bcdice/game_system/SwordWorld2_5.rb
+++ b/lib/bcdice/game_system/SwordWorld2_5.rb
@@ -71,12 +71,12 @@ module BCDice
         　例）Dru[0,3,6]+10-3
       INFO_MESSAGE_TEXT
 
-      register_prefix('H?K\d+.*', 'Gr(\d+)?', '2D6?@\d+.*', 'FT', 'TT', 'Dru\[\d+,\d+,\d+\].*')
+      register_prefix('H?K\d+.*', 'Gr(\d+)?', '2D6?@\d+.*', 'FT', 'TT', '^Dru\[\d+,\d+,\d+\]')
 
       def eval_game_system_specific_command(command)
         case command
         when /dru\[(\d+),(\d+),(\d+)\].*/i
-          power_list = (1..3).map { |i| Regexp.last_match(i).to_i }
+          power_list = Regexp.last_match.captures.map(&:to_i)
           druid_parser = Command::Parser.new(/dru\[\d+,\d+,\d+\]/i, round_type: BCDice::RoundType::CEIL)
 
           cmd = druid_parser.parse(command)
@@ -120,7 +120,7 @@ module BCDice
           "2D[#{dice_list.join(',')}]=#{power}",
           "#{power}#{Format.modifier(command.modify_number)}",
           total
-        ].compact
+        ]
 
         return sequence.join(" ＞ ")
       end

--- a/lib/bcdice/game_system/SwordWorld2_5.rb
+++ b/lib/bcdice/game_system/SwordWorld2_5.rb
@@ -71,7 +71,7 @@ module BCDice
         　例）Dru[0,3,6]+10-3
       INFO_MESSAGE_TEXT
 
-      register_prefix('H?K\d+.*', 'Gr(\d+)?', '2D6?@\d+.*', 'FT', 'TT', 'Dru\[\d+,\d+,\d+\]')
+      register_prefix('H?K\d+.*', 'Gr(\d+)?', '2D6?@\d+.*', 'FT', 'TT', 'Dru\[\d+,\d+,\d+\].*')
 
       def eval_game_system_specific_command(command)
         case command

--- a/lib/bcdice/game_system/SwordWorld2_5.rb
+++ b/lib/bcdice/game_system/SwordWorld2_5.rb
@@ -117,6 +117,7 @@ module BCDice
         power = power_list[offset]
         total = power + command.modify_number
         sequence = [
+          "(#{command.command.capitalize}#{Format.modifier(command.modify_number)})",
           "2D[#{dice_list.join(',')}]=#{power}",
           "#{power}#{Format.modifier(command.modify_number)}",
           total

--- a/test/data/SwordWorld2_5.toml
+++ b/test/data/SwordWorld2_5.toml
@@ -735,7 +735,7 @@ rands = [
 [[ test ]]
 game_system = "SwordWorld2.5"
 input = "Dru[4,7,13]+10"
-output = "2D[6,5]=13 ＞ 13+10 ＞ 23"
+output = "(Dru[4,7,13]+10) ＞ 2D[6,5]=13 ＞ 13+10 ＞ 23"
 rands = [
   { sides = 6, value = 6 },
   { sides = 6, value = 5 },
@@ -744,7 +744,7 @@ rands = [
 [[ test ]]
 game_system = "SwordWorld2.5"
 input = "Dru[4,7,13]+10"
-output = "2D[6,6]=13 ＞ 13+10 ＞ 23"
+output = "(Dru[4,7,13]+10) ＞ 2D[6,6]=13 ＞ 13+10 ＞ 23"
 rands = [
   { sides = 6, value = 6 },
   { sides = 6, value = 6 },
@@ -753,7 +753,7 @@ rands = [
 [[ test ]]
 game_system = "SwordWorld2.5"
 input = "Dru[4,7,13]+10"
-output = "2D[4,6]=13 ＞ 13+10 ＞ 23"
+output = "(Dru[4,7,13]+10) ＞ 2D[4,6]=13 ＞ 13+10 ＞ 23"
 rands = [
   { sides = 6, value = 4 },
   { sides = 6, value = 6 },
@@ -762,7 +762,7 @@ rands = [
 [[ test ]]
 game_system = "SwordWorld2.5"
 input = "Dru[4,7,13]+10"
-output = "2D[4,5]=7 ＞ 7+10 ＞ 17"
+output = "(Dru[4,7,13]+10) ＞ 2D[4,5]=7 ＞ 7+10 ＞ 17"
 rands = [
   { sides = 6, value = 4 },
   { sides = 6, value = 5 },
@@ -770,8 +770,8 @@ rands = [
 
 [[ test ]]
 game_system = "SwordWorld2.5"
-input = "Dru[0,3,6]+10+4-5"
-output = "2D[2,3]=0 ＞ 0+9 ＞ 9"
+input = "dru[0,3,6]+10+4-5"
+output = "(Dru[0,3,6]+9) ＞ 2D[2,3]=0 ＞ 0+9 ＞ 9"
 rands = [
   { sides = 6, value = 2 },
   { sides = 6, value = 3 },
@@ -779,8 +779,8 @@ rands = [
 
 [[ test ]]
 game_system = "SwordWorld2.5"
-input = "Dru[0,3,6]+10+4-5"
-output = "2D[3,3]=0 ＞ 0+9 ＞ 9"
+input = "dru[0,3,6]+10+4-5"
+output = "(Dru[0,3,6]+9) ＞ 2D[3,3]=0 ＞ 0+9 ＞ 9"
 rands = [
   { sides = 6, value = 3 },
   { sides = 6, value = 3 },
@@ -788,26 +788,26 @@ rands = [
 
 [[ test ]]
 game_system = "SwordWorld2.5"
-input = "Dru[0,3,6]+10+4-5"
-output = "2D[4,3]=3 ＞ 3+9 ＞ 12"
+input = "dru[0,3,6]+10+4-5"
+output = "(Dru[0,3,6]+9) ＞ 2D[4,3]=3 ＞ 3+9 ＞ 12"
 rands = [
   { sides = 6, value = 4 },
   { sides = 6, value = 3 },
-]
-
-[[ test ]]
-game_system = "SwordWorld2.5"
-input = "Dru[13,16,19]+12+8-10"
-output = "2D[4,4]=16 ＞ 16+10 ＞ 26"
-rands = [
-  { sides = 6, value = 4 },
-  { sides = 6, value = 4 },
 ]
 
 [[ test ]]
 game_system = "SwordWorld2.5"
 input = "Dru[13,16,19]+12+8-10"
-output = "2D[4,5]=16 ＞ 16+10 ＞ 26"
+output = "(Dru[13,16,19]+10) ＞ 2D[4,4]=16 ＞ 16+10 ＞ 26"
+rands = [
+  { sides = 6, value = 4 },
+  { sides = 6, value = 4 },
+]
+
+[[ test ]]
+game_system = "SwordWorld2.5"
+input = "Dru[13,16,19]+12+8-10"
+output = "(Dru[13,16,19]+10) ＞ 2D[4,5]=16 ＞ 16+10 ＞ 26"
 rands = [
   { sides = 6, value = 4 },
   { sides = 6, value = 5 },

--- a/test/data/SwordWorld2_5.toml
+++ b/test/data/SwordWorld2_5.toml
@@ -731,3 +731,84 @@ output = "絡み効果表(6) → 特殊：尻尾や翼などに命中。絡め�
 rands = [
   { sides = 6, value = 6 },
 ]
+
+[[ test ]]
+game_system = "SwordWorld2.5"
+input = "Dru[4,7,13]+10"
+output = "2D[6,5]=13 ＞ 13+10 ＞ 23"
+rands = [
+  { sides = 6, value = 6 },
+  { sides = 6, value = 5 },
+]
+
+[[ test ]]
+game_system = "SwordWorld2.5"
+input = "Dru[4,7,13]+10"
+output = "2D[6,6]=13 ＞ 13+10 ＞ 23"
+rands = [
+  { sides = 6, value = 6 },
+  { sides = 6, value = 6 },
+]
+
+[[ test ]]
+game_system = "SwordWorld2.5"
+input = "Dru[4,7,13]+10"
+output = "2D[4,6]=13 ＞ 13+10 ＞ 23"
+rands = [
+  { sides = 6, value = 4 },
+  { sides = 6, value = 6 },
+]
+
+[[ test ]]
+game_system = "SwordWorld2.5"
+input = "Dru[4,7,13]+10"
+output = "2D[4,5]=7 ＞ 7+10 ＞ 17"
+rands = [
+  { sides = 6, value = 4 },
+  { sides = 6, value = 5 },
+]
+
+[[ test ]]
+game_system = "SwordWorld2.5"
+input = "Dru[0,3,6]+10+4-5"
+output = "2D[2,3]=0 ＞ 0+9 ＞ 9"
+rands = [
+  { sides = 6, value = 2 },
+  { sides = 6, value = 3 },
+]
+
+[[ test ]]
+game_system = "SwordWorld2.5"
+input = "Dru[0,3,6]+10+4-5"
+output = "2D[3,3]=0 ＞ 0+9 ＞ 9"
+rands = [
+  { sides = 6, value = 3 },
+  { sides = 6, value = 3 },
+]
+
+[[ test ]]
+game_system = "SwordWorld2.5"
+input = "Dru[0,3,6]+10+4-5"
+output = "2D[4,3]=3 ＞ 3+9 ＞ 12"
+rands = [
+  { sides = 6, value = 4 },
+  { sides = 6, value = 3 },
+]
+
+[[ test ]]
+game_system = "SwordWorld2.5"
+input = "Dru[13,16,19]+12+8-10"
+output = "2D[4,4]=16 ＞ 16+10 ＞ 26"
+rands = [
+  { sides = 6, value = 4 },
+  { sides = 6, value = 4 },
+]
+
+[[ test ]]
+game_system = "SwordWorld2.5"
+input = "Dru[13,16,19]+12+8-10"
+output = "2D[4,5]=16 ＞ 16+10 ＞ 26"
+rands = [
+  { sides = 6, value = 4 },
+  { sides = 6, value = 5 },
+]

--- a/test/data/SwordWorld2_5.toml
+++ b/test/data/SwordWorld2_5.toml
@@ -735,7 +735,7 @@ rands = [
 [[ test ]]
 game_system = "SwordWorld2.5"
 input = "Dru[4,7,13]+10"
-output = "(Dru[4,7,13]+10) ＞ 2D[6,5]=13 ＞ 13+10 ＞ 23"
+output = "(Dru[4,7,13]+10) ＞ 2D[6,5]=11 ＞ 13+10 ＞ 23"
 rands = [
   { sides = 6, value = 6 },
   { sides = 6, value = 5 },
@@ -744,7 +744,7 @@ rands = [
 [[ test ]]
 game_system = "SwordWorld2.5"
 input = "Dru[4,7,13]+10"
-output = "(Dru[4,7,13]+10) ＞ 2D[6,6]=13 ＞ 13+10 ＞ 23"
+output = "(Dru[4,7,13]+10) ＞ 2D[6,6]=12 ＞ 13+10 ＞ 23"
 rands = [
   { sides = 6, value = 6 },
   { sides = 6, value = 6 },
@@ -753,7 +753,7 @@ rands = [
 [[ test ]]
 game_system = "SwordWorld2.5"
 input = "Dru[4,7,13]+10"
-output = "(Dru[4,7,13]+10) ＞ 2D[4,6]=13 ＞ 13+10 ＞ 23"
+output = "(Dru[4,7,13]+10) ＞ 2D[4,6]=10 ＞ 13+10 ＞ 23"
 rands = [
   { sides = 6, value = 4 },
   { sides = 6, value = 6 },
@@ -762,7 +762,7 @@ rands = [
 [[ test ]]
 game_system = "SwordWorld2.5"
 input = "Dru[4,7,13]+10"
-output = "(Dru[4,7,13]+10) ＞ 2D[4,5]=7 ＞ 7+10 ＞ 17"
+output = "(Dru[4,7,13]+10) ＞ 2D[4,5]=9 ＞ 7+10 ＞ 17"
 rands = [
   { sides = 6, value = 4 },
   { sides = 6, value = 5 },
@@ -771,7 +771,7 @@ rands = [
 [[ test ]]
 game_system = "SwordWorld2.5"
 input = "dru[0,3,6]+10+4-5"
-output = "(Dru[0,3,6]+9) ＞ 2D[2,3]=0 ＞ 0+9 ＞ 9"
+output = "(Dru[0,3,6]+9) ＞ 2D[2,3]=5 ＞ 0+9 ＞ 9"
 rands = [
   { sides = 6, value = 2 },
   { sides = 6, value = 3 },
@@ -780,7 +780,7 @@ rands = [
 [[ test ]]
 game_system = "SwordWorld2.5"
 input = "dru[0,3,6]+10+4-5"
-output = "(Dru[0,3,6]+9) ＞ 2D[3,3]=0 ＞ 0+9 ＞ 9"
+output = "(Dru[0,3,6]+9) ＞ 2D[3,3]=6 ＞ 0+9 ＞ 9"
 rands = [
   { sides = 6, value = 3 },
   { sides = 6, value = 3 },
@@ -789,7 +789,7 @@ rands = [
 [[ test ]]
 game_system = "SwordWorld2.5"
 input = "dru[0,3,6]+10+4-5"
-output = "(Dru[0,3,6]+9) ＞ 2D[4,3]=3 ＞ 3+9 ＞ 12"
+output = "(Dru[0,3,6]+9) ＞ 2D[4,3]=7 ＞ 3+9 ＞ 12"
 rands = [
   { sides = 6, value = 4 },
   { sides = 6, value = 3 },
@@ -798,7 +798,7 @@ rands = [
 [[ test ]]
 game_system = "SwordWorld2.5"
 input = "Dru[13,16,19]+12+8-10"
-output = "(Dru[13,16,19]+10) ＞ 2D[4,4]=16 ＞ 16+10 ＞ 26"
+output = "(Dru[13,16,19]+10) ＞ 2D[4,4]=8 ＞ 16+10 ＞ 26"
 rands = [
   { sides = 6, value = 4 },
   { sides = 6, value = 4 },
@@ -807,7 +807,7 @@ rands = [
 [[ test ]]
 game_system = "SwordWorld2.5"
 input = "Dru[13,16,19]+12+8-10"
-output = "(Dru[13,16,19]+10) ＞ 2D[4,5]=16 ＞ 16+10 ＞ 26"
+output = "(Dru[13,16,19]+10) ＞ 2D[4,5]=9 ＞ 16+10 ＞ 26"
 rands = [
   { sides = 6, value = 4 },
   { sides = 6, value = 5 },


### PR DESCRIPTION
SW2.5のモンストラスロアで追加されたドルイド技能（森羅魔法）において、
一部魔法で特異なダメージ算出方法が追加されました。

威力決定の際に威力表を参照せず、2d6の出目の範囲に応じて

- 出目が2-6の時は「A+魔力」点のダメージ
- 出目が7-9の時は「B+魔力」点のダメージ
- 出目が10-12の時は「C+魔力」点のダメージ

という形でダメージを算出しています。このA、B、Cの値は、使用する魔法によって異なっています。

「ダメージ算出」であるという性質上加減算などが必要になり、 単純なダイス表で表現するのも難しいため、専用のダイスコマンドを実装いたしました。