### PR TITLE
テスト：複数のゲームシステムを指定可能にする

### DIFF
--- a/test/test_game_system_commands.rb
+++ b/test/test_game_system_commands.rb
@@ -11,30 +11,35 @@ require_relative "randomizer_mock"
 class TestGameSystemCommands < Test::Unit::TestCase
   class << self
     def target_files
-      target = ENV["target"]
-      unless target
+      env_target = ENV["target"]
+      unless env_target
         return Dir.glob("test/data/*.toml")
       end
 
-      if File.exist?(target)
-        return [target]
+      files = env_target.split(",").map do |target|
+        target_with_extension = target.end_with?(".toml") ? target : "#{target}.toml"
+        path = "test/data/#{target_with_extension}"
+
+        unless File.exist?(path)
+          warn("Unknown target: #{path}")
+          next nil
+        end
+
+        path
       end
 
-      target += ".toml" unless target.end_with?(".toml")
-      target = File.join("test/data", target)
-
-      unless File.exist?(target)
-        warn "unknown target: #{target}"
-        exit(1)
-      end
-
-      return [target]
+      return files.compact
     end
   end
 
   data do
     data_set = {}
+
     files = target_files()
+    if files.empty?
+      warn("No target found!")
+      exit(1)
+    end
 
     files.each do |filename|
       filename_base = File.basename(filename, ".toml")


### PR DESCRIPTION
Rakeタスク `test:dicebots` で、複数のゲームシステムを指定できるようにしました。例えば、SwordWorld・SwordWorld2\_0・SwordWorld2\_5のような、クラス継承によって動作が引き継がれる複数のゲームシステムのテストをまとめて実行できるようになり、動作確認の効率向上が期待できます。

# 使い方・動作

`rake test:dicebots` で環境変数 `target` を用いる際、カンマ区切りでテストデータファイル名を並べます。

```
bundle exec rake test:dicebots target=SwordWorld,SwordWorld2_0,SwordWorld2_5
```

このように記述して実行すると、並べた順にテストケースが追加されて、テストが実行されます。

存在しないテストデータファイル名を指定すると、そのファイルが無視されて、残りのテストが実行されます。

```
$ bundle exec rake test:dicebots target=SwordWorld,SwordWorld2
Unknown target: test/data/SwordWorld2.toml
Loaded suite ...
Started
...
```

すべてのファイルが無視された（＝テストケースがない）場合はエラーとなり、終了コード1で終了します。

```
$ bundle exec rake test:dicebots target=SwordWorld2
Unknown target: test/data/SwordWorld2.toml
No target found!
rake aborted!
Command failed with status (1)
```