### PR TITLE
ガラコの判定の目標値を省略可能に

### DIFF
--- a/lib/bcdice/game_system/Garako.rb
+++ b/lib/bcdice/game_system/Garako.rb
@@ -18,7 +18,7 @@ module BCDice
 
       # ダイスボットの使い方
       HELP_MESSAGE = <<~MESSAGETEXT
-        ・判定 GR+n#f>=X （+n：判定値、#f：不安定による自動失敗基準値、X：目標値）
+        ・判定 GR+n#f>=X （+n：判定値、#f：不安定による自動失敗基準値、X：目標値、それぞれ省略可能）
         ・部位決定チャート：HIT
         ・ダメージ+部位決定：GAHn（n：火力）
         ・ダメージチャート：xDCy（CDC/EDC/FDC/ADC/LDC )
@@ -63,7 +63,7 @@ module BCDice
       def roll_gr(command)
         parser = Command::Parser.new("GR", round_type: round_type)
                                 .enable_fumble
-                                .restrict_cmp_op_to(:>=)
+                                .restrict_cmp_op_to(nil, :>=)
         cmd = parser.parse(command)
         return nil unless cmd
 

--- a/test/data/Garako.toml
+++ b/test/data/Garako.toml
@@ -152,6 +152,30 @@ rands = [
 
 [[ test ]]
 game_system = "Garako"
+input = "GR+1"
+output = "(1D10+1) ＞ 10[10]+1 ＞ 11 ＞ クリティカル"
+rands = [
+  { sides = 10, value = 10 },
+]
+
+[[ test ]]
+game_system = "Garako"
+input = "GR+1"
+output = "(1D10+1) ＞ 9[9]+1 ＞ 10"
+rands = [
+  { sides = 10, value = 9 },
+]
+
+[[ test ]]
+game_system = "Garako"
+input = "GR+1"
+output = "(1D10+1) ＞ 1[1]+1 ＞ 2 ＞ ファンブル"
+rands = [
+  { sides = 10, value = 1 },
+]
+
+[[ test ]]
+game_system = "Garako"
 input = "IDI"
 output = "個性表(1) ＞ 〈近接武器熟練〉 近接攻撃の火力+1。"
 rands = [


### PR DESCRIPTION
`GR`や`GR+5#2`のように、目標値が無くても振れるように