### PR TITLE
[ShinobiGami] 行為判定ではクリティカルよりもファンブルが優先される

### DIFF
--- a/lib/bcdice/game_system/ShinobiGami.rb
+++ b/lib/bcdice/game_system/ShinobiGami.rb
@@ -109,10 +109,10 @@ module BCDice
         total = dice_total + cmd.modify_number
 
         result =
-          if dice_total >= cmd.critical
-            Result.critical(SPECIAL)
-          elsif dice_total <= cmd.fumble
+          if dice_total <= cmd.fumble
             Result.fumble("ファンブル")
+          elsif dice_total >= cmd.critical
+            Result.critical(SPECIAL)
           elsif cmd.cmp_op.nil?
             Result.new
           elsif total >= cmd.target_number

--- a/test/data/ShinobiGami.toml
+++ b/test/data/ShinobiGami.toml
@@ -114,6 +114,17 @@ rands = [
 
 [[ test ]]
 game_system = "ShinobiGami"
+input = "SG@5#7 ファンブルが優先"
+output = "(SG@5#7) ＞ 5[1,4] ＞ 5 ＞ ファンブル"
+failure = true
+fumble = true
+rands = [
+  { sides = 6, value = 1 },
+  { sides = 6, value = 4 },
+]
+
+[[ test ]]
+game_system = "ShinobiGami"
 input = "SG+1 修正値がファンブルに影響しない"
 output = "(SG+1@12#2) ＞ 2[1,1]+1 ＞ 3 ＞ ファンブル"
 failure = true


### PR DESCRIPTION
Discordにこのバグが報告された

```
p.p.今日 17:40
お世話になっております。
1. ココフォリア
2. シノビガミ
3. SG@5#7
4. SG (SG@5#7) ＞ 5[1,4] ＞ 5 ＞ スペシャル(【生命力】1点か変調一つを回復)
5. シノビガミのシステムではファンブル値とスペシャル値が競合した場合ファンブル値が適用されます。なので上記の入力の場合ダイスによる達成値が5の場合ファンブルと出力されるのが正しいです。
BCDice/lib/bcdice/game_system/ShinobiGami.rbを読んだかぎり112行目から115行目のif、elseifの処理順を逆にすれば修正できるかなと。
```