### PR TITLE
register_prefixで設定されている末尾の `.*` を消す

### DIFF
--- a/lib/bcdice/game_system/Alshard.rb
+++ b/lib/bcdice/game_system/Alshard.rb
@@ -15,7 +15,7 @@ module BCDice
       ID = 'Alshard'
 
       # 固有のコマンドの接頭辞を設定する
-      register_prefix('2D6.*', 'AL.*')
+      register_prefix('2D6', 'AL')
 
       # 成功判定のエイリアスコマンドを設定する
       set_aliases_for_srs_roll('AL')

--- a/lib/bcdice/game_system/ArsMagica.rb
+++ b/lib/bcdice/game_system/ArsMagica.rb
@@ -26,7 +26,7 @@ module BCDice
         　　最初の0が判断基準で、その右側5つがボッチダイスです。1*2,8*2,0*1なので1botchという訳です。
       INFO_MESSAGE_TEXT
 
-      register_prefix('ArS.*', '1R10.*')
+      register_prefix('ArS', '1R10')
 
       def eval_game_system_specific_command(string)
         unless parse_ars(string) || parse_1r10(string)

--- a/lib/bcdice/game_system/BBN.rb
+++ b/lib/bcdice/game_system/BBN.rb
@@ -4,7 +4,7 @@ module BCDice
   module GameSystem
     class BBN < Base
       # ダイスボットで使用するコマンドを配列で列挙する
-      register_prefix('\d+BN.*')
+      register_prefix('\d+BN')
 
       ID = 'BBN'
 

--- a/lib/bcdice/game_system/BadLife.rb
+++ b/lib/bcdice/game_system/BadLife.rb
@@ -41,7 +41,7 @@ module BCDice
         ・スキル表：SKL
       MESSAGETEXT
 
-      register_prefix('\d?(BAD|BL|GL).*', '[TDGKSB]RN', 'SKL')
+      register_prefix('\d?(BAD|BL|GL)', '[TDGKSB]RN', 'SKL')
 
       def eval_game_system_specific_command(command)
         command = command.upcase

--- a/lib/bcdice/game_system/BarnaKronika.rb
+++ b/lib/bcdice/game_system/BarnaKronika.rb
@@ -26,7 +26,7 @@ module BCDice
         　セット数が1以上の時はセット数も表示し、攻撃判定の場合は命中部位も表示します。
       INFO_MESSAGE_TEXT
 
-      register_prefix('\d+BK.*', '\d+BA.*', '\d+BKC\d+.*', '\d+BAC\d+.*', '\d+R6.*')
+      register_prefix('\d+BK', '\d+BA', '\d+BKC\d+', '\d+BAC\d+', '\d+R6')
 
       def initialize(command)
         super(command)

--- a/lib/bcdice/game_system/BeastBindTrinity.rb
+++ b/lib/bcdice/game_system/BeastBindTrinity.rb
@@ -332,7 +332,7 @@ module BCDice
         ),
       }.freeze
 
-      register_prefix('\d+BB.*', '\d+R6.*', TABLES.keys)
+      register_prefix('\d+BB', '\d+R6', TABLES.keys)
     end
   end
 end

--- a/lib/bcdice/game_system/BlindMythos.rb
+++ b/lib/bcdice/game_system/BlindMythos.rb
@@ -456,7 +456,7 @@ module BCDice
         ),
       }.freeze
 
-      register_prefix('BM.*', 'ReRoll\d+.*', 'RP\d+', 'DT', TABLES.keys)
+      register_prefix('BM', 'ReRoll\d+', 'RP\d+', 'DT', TABLES.keys)
     end
   end
 end

--- a/lib/bcdice/game_system/CardRanker.rb
+++ b/lib/bcdice/game_system/CardRanker.rb
@@ -202,7 +202,7 @@ module BCDice
           ]
         ),
       }.freeze
-      register_prefix(RTT.prefixes, 'CM.*', TABLES.keys)
+      register_prefix(RTT.prefixes, 'CM', TABLES.keys)
     end
   end
 end

--- a/lib/bcdice/game_system/ChaosFlare.rb
+++ b/lib/bcdice/game_system/ChaosFlare.rb
@@ -39,7 +39,7 @@ module BCDice
           - FT7
       INFO_MESSAGE_TEXT
 
-      register_prefix('\d*CF.*', 'FT\d*')
+      register_prefix('\d*CF', 'FT\d*')
 
       # ゲーム別成功度判定(2D6)。以前の処理をそのまま残しています。
       def check_2D6(total, dice_total, _dice_list, cmp_op, target)

--- a/lib/bcdice/game_system/Chill.rb
+++ b/lib/bcdice/game_system/Chill.rb
@@ -22,7 +22,7 @@ module BCDice
         　例）SR7　　　sr13　　　SR(7+4)　　　Ssr10
       INFO_MESSAGE_TEXT
 
-      register_prefix('SR\d+.*')
+      register_prefix('SR\d+')
 
       def check_1D100(total, _dice_total, cmp_op, target)
         return '' if target == '?'

--- a/lib/bcdice/game_system/CodeLayerd.rb
+++ b/lib/bcdice/game_system/CodeLayerd.rb
@@ -30,7 +30,7 @@ module BCDice
           デフォルトダイス：10面
       MESSAGETEXT
 
-      register_prefix('[+-]?\d*CL([+-]\d+)?[@\d]*.*')
+      register_prefix('[+-]?\d*CL([+-]\d+)?[@\d]*')
 
       def initialize(command)
         super(command)

--- a/lib/bcdice/game_system/Cthulhu.rb
+++ b/lib/bcdice/game_system/Cthulhu.rb
@@ -48,7 +48,7 @@ module BCDice
 
       INFO_MESSAGE_TEXT
 
-      register_prefix('CC(B)?\(\d+\)', 'CC(B)?.*', 'RES(B)?.*', 'CBR(B)?\(\d+,\d+\)')
+      register_prefix('CC(B)?\(\d+\)', 'CC(B)?', 'RES(B)?', 'CBR(B)?\(\d+,\d+\)')
 
       def initialize(command)
         super(command)

--- a/lib/bcdice/game_system/Cthulhu7th_ChineseTraditional.rb
+++ b/lib/bcdice/game_system/Cthulhu7th_ChineseTraditional.rb
@@ -35,7 +35,7 @@ module BCDice
         ・實時型　Short／總結型　Longer
       INFO_MESSAGE_TEXT
 
-      register_prefix('CC\(\d+\)', 'CC.*', 'CBR\(\d+,\d+\)', 'FAR\(\d+\)', 'FAR.*')
+      register_prefix('CC\(\d+\)', 'CC', 'CBR\(\d+,\d+\)', 'FAR\(\d+\)', 'FAR')
 
       def initialize(command)
         super(command)

--- a/lib/bcdice/game_system/Cthulhu7th_Korean.rb
+++ b/lib/bcdice/game_system/Cthulhu7th_Korean.rb
@@ -32,7 +32,7 @@ module BCDice
         예）FAR(25,70,98)　FAR(50,80,98,-1)
       INFO_MESSAGE_TEXT
 
-      register_prefix('CC\(\d+\)', 'CC.*', 'CBR\(\d+,\d+\)', 'FAR\(\d+\)', 'FAR.*')
+      register_prefix('CC\(\d+\)', 'CC', 'CBR\(\d+,\d+\)', 'FAR\(\d+\)', 'FAR')
 
       def initialize(command)
         super(command)

--- a/lib/bcdice/game_system/CthulhuTech.rb
+++ b/lib/bcdice/game_system/CthulhuTech.rb
@@ -5,7 +5,7 @@ require 'bcdice/arithmetic_evaluator'
 module BCDice
   module GameSystem
     class CthulhuTech < Base
-      register_prefix('\d+D10.*')
+      register_prefix('\d+D10')
 
       # ゲームシステムの識別子
       ID = 'CthulhuTech'

--- a/lib/bcdice/game_system/DarkBlaze.rb
+++ b/lib/bcdice/game_system/DarkBlaze.rb
@@ -29,7 +29,7 @@ module BCDice
         　例）BT1　　　BT2　　　BT[1...3]
       INFO_MESSAGE_TEXT
 
-      register_prefix('DB.*', 'BT.*', '3R6.*')
+      register_prefix('DB', 'BT', '3R6')
 
       def replace_text(string)
         return string unless string =~ /DB/i

--- a/lib/bcdice/game_system/DiceOfTheDead.rb
+++ b/lib/bcdice/game_system/DiceOfTheDead.rb
@@ -21,7 +21,7 @@ module BCDice
         （上記二つは最初からシークレットダイスで行われます）
       INFO_MESSAGE_TEXT
 
-      register_prefix('(ZMB|BIO).*')
+      register_prefix('ZMB', 'BIO')
 
       def initialize(command)
         super(command)

--- a/lib/bcdice/game_system/DoubleCross.rb
+++ b/lib/bcdice/game_system/DoubleCross.rb
@@ -30,7 +30,7 @@ module BCDice
         ・D66ダイスあり
       INFO_MESSAGE_TEXT
 
-      register_prefix('\d+DX.*', 'ET')
+      register_prefix('\d+DX', 'ET')
 
       # 成功判定コマンドのノード
       class DX

--- a/lib/bcdice/game_system/EarthDawn.rb
+++ b/lib/bcdice/game_system/EarthDawn.rb
@@ -20,7 +20,7 @@ module BCDice
         例）9E　10E8　10E+D12
       INFO_MESSAGE_TEXT
 
-      register_prefix('\d+e.*')
+      register_prefix('\d+e')
 
       def initialize(command)
         super(command)

--- a/lib/bcdice/game_system/EarthDawn3.rb
+++ b/lib/bcdice/game_system/EarthDawn3.rb
@@ -24,7 +24,7 @@ module BCDice
         　　ステップ12、目標値8、カルマダイスD12：10E8+1D6
       INFO_MESSAGE_TEXT
 
-      register_prefix('\d+e.*')
+      register_prefix('\d+e')
 
       def initialize(command)
         super(command)

--- a/lib/bcdice/game_system/EarthDawn4.rb
+++ b/lib/bcdice/game_system/EarthDawn4.rb
@@ -24,7 +24,7 @@ module BCDice
         　　ステップ10、目標値8、カルマダイス：10E8K
       INFO_MESSAGE_TEXT
 
-      register_prefix('\d+e.*')
+      register_prefix('\d+e')
 
       def initialize(command)
         super(command)

--- a/lib/bcdice/game_system/Elysion.rb
+++ b/lib/bcdice/game_system/Elysion.rb
@@ -1200,8 +1200,8 @@ module BCDice
       }.freeze
 
       register_prefix(
-        'EL.*',
-        'DATE.*', 'FDATE.*', 'ODATE.*', 'MDATE.*',
+        'EL',
+        'DATE', 'FDATE', 'ODATE', 'MDATE',
         'RBT', 'SBT', 'BBT', 'CBT', 'DBT', 'IBT', 'FBT', 'LBT', 'PBT', 'NBT', 'ABT', 'VBT', 'GBT', 'HBT',
         'BFT', 'FWT', 'FT',
         'SRT', 'ORT', 'DRT', 'URT',

--- a/lib/bcdice/game_system/EmbryoMachine.rb
+++ b/lib/bcdice/game_system/EmbryoMachine.rb
@@ -24,7 +24,7 @@ module BCDice
         　・射撃攻撃ファンブル表　SFT
       INFO_MESSAGE_TEXT
 
-      register_prefix('EM\d+.*', 'HLT', 'MFT', 'SFT', '2R10.*')
+      register_prefix('EM\d+', 'HLT', 'MFT', 'SFT', '2R10')
 
       def initialize(command)
         super(command)

--- a/lib/bcdice/game_system/EtrianOdysseySRS.rb
+++ b/lib/bcdice/game_system/EtrianOdysseySRS.rb
@@ -15,7 +15,7 @@ module BCDice
       SORT_KEY = 'せかいしゆのめいきゆうSRS'
 
       # 固有のコマンドの接頭辞を設定する
-      register_prefix('2D6.*', 'EO.*', 'SQ.*')
+      register_prefix('2D6', 'EO', 'SQ')
 
       # 成功判定のエイリアスコマンドを設定する
       set_aliases_for_srs_roll('EO', 'SQ')

--- a/lib/bcdice/game_system/FullMetalPanic.rb
+++ b/lib/bcdice/game_system/FullMetalPanic.rb
@@ -15,7 +15,7 @@ module BCDice
       SORT_KEY = 'ふるめたるはにつくRPG'
 
       # 固有のコマンドの接頭辞を設定する
-      register_prefix('2D6.*', 'MG.*', 'FP.*')
+      register_prefix('2D6', 'MG', 'FP')
 
       # 成功判定のエイリアスコマンドを設定する
       set_aliases_for_srs_roll('MG', 'FP')

--- a/lib/bcdice/game_system/Garako.rb
+++ b/lib/bcdice/game_system/Garako.rb
@@ -654,7 +654,7 @@ module BCDice
         )
       }.freeze
 
-      register_prefix('GR.*', '[CEFAL]D[CT][-+\d]+', 'GHA[-+\d]+', TABLES.keys)
+      register_prefix('GR', '[CEFAL]D[CT][-+\d]+', 'GHA[-+\d]+', TABLES.keys)
     end
   end
 end

--- a/lib/bcdice/game_system/GehennaAn.rb
+++ b/lib/bcdice/game_system/GehennaAn.rb
@@ -23,7 +23,7 @@ module BCDice
         　幸運の助けを自動処理します。(連撃増加値、闘技チットを表示抑制します)
       INFO_MESSAGE_TEXT
 
-      register_prefix('\d+G\d+.*', '\d+GA\d+.*', '\d+R6.*')
+      register_prefix('\d+G\d+', '\d+GA\d+', '\d+R6')
 
       def initialize(command)
         super(command)

--- a/lib/bcdice/game_system/GoblinSlayer.rb
+++ b/lib/bcdice/game_system/GoblinSlayer.rb
@@ -41,7 +41,7 @@ module BCDice
       MESSAGETEXT
 
       # 因果点は共有リソースなのでMCPIはシークレットダイスを無効化
-      register_prefix('GS\(\d+\)', 'GS.*', '^MCPI.*\$\d+$', 'DB\d+')
+      register_prefix('GS\(\d+\)', 'GS', '^MCPI.*\$\d+$', 'DB\d+')
 
       def initialize(command)
         super(command)

--- a/lib/bcdice/game_system/Gorilla.rb
+++ b/lib/bcdice/game_system/Gorilla.rb
@@ -21,7 +21,7 @@ module BCDice
         例) G>=7 : 2D6して7以上なら成功
       MESSAGETEXT
 
-      register_prefix('G.*')
+      register_prefix('G')
 
       def change_text(string)
         string = string.gsub(/^(S)?G/i) { "#{Regexp.last_match(1)}2D6" }

--- a/lib/bcdice/game_system/HarnMaster.rb
+++ b/lib/bcdice/game_system/HarnMaster.rb
@@ -21,7 +21,7 @@ module BCDice
         ・人型用　中段命中部位表 (SLH)／上段命中部位 (SLHU)／上段命中部位 (SLHD)
       MESSAGETEXT
 
-      register_prefix('SHK\d+.*', 'SLH', 'SLHU', 'SLHD')
+      register_prefix('SHK\d+', 'SLH', 'SLHU', 'SLHD')
 
       def check_1D100(total, _dice_total, cmp_op, target)
         return '' if target == '?'

--- a/lib/bcdice/game_system/HatsuneMiku.rb
+++ b/lib/bcdice/game_system/HatsuneMiku.rb
@@ -699,7 +699,7 @@ module BCDice
         ),
       }.freeze
 
-      register_prefix('R([A-DS]|\d+).*', TABLES.keys)
+      register_prefix('R([A-DS]|\d+)', TABLES.keys)
     end
   end
 end

--- a/lib/bcdice/game_system/HouraiGakuen.rb
+++ b/lib/bcdice/game_system/HouraiGakuen.rb
@@ -31,7 +31,7 @@ module BCDice
           例）Hourai : 仁義八徳は、【義】(奇数、奇数、偶数)
       INFO_MESSAGE_TEXT
 
-      register_prefix('ROL.*', 'MED\(\d+,\d+\)', 'RES\(\d+,\d+\)', 'INY.*', 'HTK.*', 'GOG.*')
+      register_prefix('ROL', 'MED\(\d+,\d+\)', 'RES\(\d+,\d+\)', 'INY', 'HTK', 'GOG')
 
       # ゲームの名前
       # チャット欄表示名

--- a/lib/bcdice/game_system/MeikyuDays.rb
+++ b/lib/bcdice/game_system/MeikyuDays.rb
@@ -408,7 +408,7 @@ module BCDice
         ),
       }.freeze
 
-      register_prefix('\d+MD6?.*', '\d+R6.*', TABLES.keys)
+      register_prefix('\d+MD6?', '\d+R6', TABLES.keys)
     end
   end
 end

--- a/lib/bcdice/game_system/MeikyuKingdom.rb
+++ b/lib/bcdice/game_system/MeikyuKingdom.rb
@@ -42,7 +42,7 @@ module BCDice
       INFO_MESSAGE_TEXT
 
       register_prefix(
-        '\d+MK.*', '\d+R6.*',
+        '\d+MK', '\d+R6',
         'LRT', 'ORT', 'CRT', 'ART', 'FRT',
         'TBT', 'CBT', 'SBT', 'VBT', 'FBT', 'ABT', 'WBT', 'LBT',
         'THT', 'CHT', 'SHT', 'VHT',
@@ -50,7 +50,7 @@ module BCDice
         'CAT', 'FWT', 'CFT',
         'TT', 'NT', 'ET', 'MPT',
         'T1T', 'T2T', 'T3T', 'T4T', 'T5T',
-        'NAME.*',
+        'NAME',
         'DFT', 'IDT\d*',
         'WIT', 'LIT', 'RIT', 'SIT', 'RWIT', 'RUIT',
         'IFT',

--- a/lib/bcdice/game_system/MeikyuKingdomBasic.rb
+++ b/lib/bcdice/game_system/MeikyuKingdomBasic.rb
@@ -57,7 +57,7 @@ module BCDice
       INFO_MESSAGE_TEXT
 
       register_prefix(
-        '\d+MK.*', '\d+R6.*',
+        '\d+MK', '\d+R6',
         'IG', 'TT', 'NT', 'RMS',
         'CFT', 'FWT', 'CAT', 'KDT', 'KCT',
         'TBT', 'CBT', 'SBT', 'VBT', 'FBT', 'EBT', 'WBT', 'LBT',
@@ -65,7 +65,7 @@ module BCDice
         'BDT', 'TBO', 'CBO', 'SBO', 'VBO',
         'ET', 'FET', 'HET', 'SDT', 'IEQ', 'FRT',
         'T1T', 'T2T', 'T3T', 'T4T', 'T5T',
-        'MPT', 'KNT\d+', 'WORD\d+', 'NAME.*', 'NNAME.*', 'NM.*',
+        'MPT', 'KNT\d+', 'WORD\d+', 'NAME', 'NNAME', 'NM',
         'RT', 'CIR', 'RUIR', 'RWIR',
         'WIT', 'LIT', 'RIT', 'SIT', 'NRWT', 'NRUT', 'ARWT', 'ARUT',
         'KET', 'TET', 'NST', 'RET', 'FAT', 'HRT', 'BLT',

--- a/lib/bcdice/game_system/MetalHeadExtream.rb
+++ b/lib/bcdice/game_system/MetalHeadExtream.rb
@@ -51,7 +51,7 @@ module BCDice
       MESSAGETEXT
 
       register_prefix(
-        '[AS]R\d+.*',
+        '[AS]R\d+',
         '(HU|BK|WA|SC|BG|IN|PT|HT|TA|AC|HE|TR|VT|BO|CS|TH|AM|GD|HC|BI|BT|AI)HIT\d*',
         'SUV[A-Z]\d+', '[HTALMEBPD]DMG[LMHO]',
         'CRT\d*', '[GSME]AC\d*', '[ASL]MA\d*(\+\d+)?',

--- a/lib/bcdice/game_system/MetallicGuardian.rb
+++ b/lib/bcdice/game_system/MetallicGuardian.rb
@@ -6,7 +6,7 @@ module BCDice
   module GameSystem
     class MetallicGuardian < SRS
       # 固有のコマンドの接頭辞を設定する
-      register_prefix('2D6.*', 'MG.*')
+      register_prefix('2D6', 'MG')
 
       # 成功判定のエイリアスコマンドを設定する
       set_aliases_for_srs_roll('MG')

--- a/lib/bcdice/game_system/MonotoneMuseum.rb
+++ b/lib/bcdice/game_system/MonotoneMuseum.rb
@@ -148,7 +148,7 @@ module BCDice
 
       TABLES = translate_tables(:ja_jp).freeze
 
-      register_prefix('\d+D6.*', TABLES.keys)
+      register_prefix('\d+D6', TABLES.keys)
     end
   end
 end

--- a/lib/bcdice/game_system/NeverCloud.rb
+++ b/lib/bcdice/game_system/NeverCloud.rb
@@ -603,7 +603,7 @@ module BCDice
       }.freeze
 
       # ダイスボットで使用するコマンドを配列で列挙する
-      register_prefix('\d+NC.*', '\d+D6?([\+\-\d]*)>=\d+', TEXTS.keys, TABLES.keys)
+      register_prefix('\d+NC', '\d+D6?([\+\-\d]*)>=\d+', TEXTS.keys, TABLES.keys)
     end
   end
 end

--- a/lib/bcdice/game_system/NightWizard.rb
+++ b/lib/bcdice/game_system/NightWizard.rb
@@ -28,7 +28,7 @@ module BCDice
         　例）12NW-5@7#2$3 1NW 50nw+5@7,10#2,5 50nw-5+10@7,10#2,5+15+25
       INFO_MESSAGE_TEXT
 
-      register_prefix('([-+]?\d+)?NW.*', '2R6.*')
+      register_prefix('([-+]?\d+)?NW', '2R6')
 
       def initialize(command)
         super(command)

--- a/lib/bcdice/game_system/NightWizard3rd.rb
+++ b/lib/bcdice/game_system/NightWizard3rd.rb
@@ -14,7 +14,7 @@ module BCDice
       # ゲームシステムの識別子
       ID = 'NightWizard3rd'
 
-      register_prefix('([-+]?\d+)?NW.*', '2R6.*')
+      register_prefix('([-+]?\d+)?NW', '2R6')
 
       def fumble_base_number(parsed)
         parsed.passive_modify_number + parsed.active_modify_number

--- a/lib/bcdice/game_system/NinjaSlayer.rb
+++ b/lib/bcdice/game_system/NinjaSlayer.rb
@@ -40,15 +40,6 @@ module BCDice
         　KIDS=K,EASY=E,NORMAL=N,HARD=H,ULTRA HARD=UH 数字にも対応
       MESSAGETEXT
 
-      # ダイスボットで使用するコマンドを配列で列挙する
-      register_prefix(
-        'NJ\d+.*',
-        'EV\d+.*',
-        'AT\d+.*',
-        'EL\d+.*',
-        'SB'
-      )
-
       def initialize(command)
         super(command)
 
@@ -262,10 +253,10 @@ module BCDice
 
       # ダイスボットで使用するコマンドを配列で列挙する
       register_prefix(
-        'NJ\d+.*',
-        'EV\d+.*',
-        'AT\d+.*',
-        'EL\d+.*',
+        'NJ\d+',
+        'EV\d+',
+        'AT\d+',
+        'EL\d+',
         TABLES.keys
       )
     end

--- a/lib/bcdice/game_system/OneWayHeroics.rb
+++ b/lib/bcdice/game_system/OneWayHeroics.rb
@@ -127,7 +127,7 @@ module BCDice
         return "失敗"
       end
 
-      register_prefix('\d*JD.*', 'RETP?\d+', 'DNGNP?\d+', TABLES.keys)
+      register_prefix('\d*JD', 'RETP?\d+', 'DNGNP?\d+', TABLES.keys)
     end
   end
 end

--- a/lib/bcdice/game_system/OracleEngine.rb
+++ b/lib/bcdice/game_system/OracleEngine.rb
@@ -34,7 +34,7 @@ module BCDice
 MESSAGETEXT
 
       # ダイスボットで使用するコマンドを配列で列挙する
-      register_prefix('\d+CL.*', '\d+R6.*', '\d+D6.*\$[\+\-]?\d+.*')
+      register_prefix('\d+CL', '\d+R6', '\d+D6.*\$[\+\-]?\d+')
 
       def initialize(command)
         super(command)

--- a/lib/bcdice/game_system/Paradiso.rb
+++ b/lib/bcdice/game_system/Paradiso.rb
@@ -25,7 +25,7 @@ module BCDice
         　例）DC4:【攻撃力】4でダメージチェック　DC5[20]:【攻撃力】5でダメージチェック、うち1つは20mm機銃　DC5[20,30]:【攻撃力】5でダメージチェック、うち1つは20mm機銃、うち1つは30mmガンポッド
       MESSAGETEXT
 
-      register_prefix('(\d+)*D20<=.*', '(\d+)*CP.*', 'RMT', 'TOT', 'EXT', 'SUT', 'DC(\d+).*')
+      register_prefix('(\d+)*D20<=', '(\d+)*CP', 'RMT', 'TOT', 'EXT', 'SUT', 'DC(\d+)')
 
       def eval_game_system_specific_command(command) # ダイスロールコマンド
         # 通常判定部分をgetJudgeResultコマンドに切り分け

--- a/lib/bcdice/game_system/ParanoiaRebooted.rb
+++ b/lib/bcdice/game_system/ParanoiaRebooted.rb
@@ -26,7 +26,7 @@ module BCDice
         例）MP2
       INFO_MESSAGE_TEXT
 
-      register_prefix('ND.*', 'MP.*')
+      register_prefix('ND', 'MP')
 
       def eval_game_system_specific_command(command)
         case command

--- a/lib/bcdice/game_system/Postman.rb
+++ b/lib/bcdice/game_system/Postman.rb
@@ -39,7 +39,7 @@ module BCDice
 
       register_prefix(
         'WEA\d*',
-        '(\d+)?PO.*',
+        '(\d+)?PO',
         'FRE'
       )
 

--- a/lib/bcdice/game_system/PulpCthulhu.rb
+++ b/lib/bcdice/game_system/PulpCthulhu.rb
@@ -47,7 +47,7 @@ module BCDice
         　・プッシュ時のキャスティング・ロールの失敗（Failed Casting Effects）表　FCE
       INFO_MESSAGE_TEXT
 
-      register_prefix('CC\(\d+\)', 'CC.*', 'CBR\(\d+,\d+\)', 'FAR.*', 'BMR', 'BMS', 'FCE', 'PH', 'MA', 'IT')
+      register_prefix('CC\(\d+\)', 'CC', 'CBR\(\d+,\d+\)', 'FAR', 'BMR', 'BMS', 'FCE', 'PH', 'MA', 'IT')
 
       def eval_game_system_specific_command(command)
         case command

--- a/lib/bcdice/game_system/RecordOfLodossWar.rb
+++ b/lib/bcdice/game_system/RecordOfLodossWar.rb
@@ -19,7 +19,7 @@ module BCDice
         　判定と回避判定は、どちらもコマンドだけの場合、出目の表示と自動成功と自動失敗の判定のみを行います。
       INFO_MESSAGE_TEXT
 
-      register_prefix('LW.*')
+      register_prefix('LW')
 
       def eval_game_system_specific_command(command)
         parser = Command::Parser.new("LWD", "LW", round_type: round_type)

--- a/lib/bcdice/game_system/RecordOfSteam.rb
+++ b/lib/bcdice/game_system/RecordOfSteam.rb
@@ -21,7 +21,7 @@ module BCDice
         RecordOfSteam : (4S3@2) ＞ 2,1,2,4,4,4,2,3,4,5,6,6 ＞ 4回転 ＞ 成功数5
       MESSAGETEXT
 
-      register_prefix('\d+S\d+.*')
+      register_prefix('\d+S\d+')
 
       # サンプルのダイスコマンドは「nSt@c」で n=ダイス個数, t=目標値, c=クリティカル値。@cのみ省略可
 

--- a/lib/bcdice/game_system/RokumonSekai2.rb
+++ b/lib/bcdice/game_system/RokumonSekai2.rb
@@ -22,7 +22,7 @@ module BCDice
         　例) 3RS+1<=9　3R6+1<=9[3]
       INFO_MESSAGE_TEXT
 
-      register_prefix('\d+RS.*', '3R6.*')
+      register_prefix('\d+RS', '3R6')
 
       def initialize(command)
         super(command)

--- a/lib/bcdice/game_system/Ryutama.rb
+++ b/lib/bcdice/game_system/Ryutama.rb
@@ -21,7 +21,7 @@ module BCDice
         例）R8,6>=13
       INFO_MESSAGE_TEXT
 
-      register_prefix('R\d+.*')
+      register_prefix('R\d+')
 
       def initialize(command)
         super(command)

--- a/lib/bcdice/game_system/SRS.rb
+++ b/lib/bcdice/game_system/SRS.rb
@@ -167,7 +167,7 @@ module BCDice
       end
 
       # 固有のコマンドの接頭辞を設定する
-      register_prefix('2D6.*')
+      register_prefix('2D6')
 
       # ダイスボットを初期化する
       def initialize(command)

--- a/lib/bcdice/game_system/SamsaraBallad.rb
+++ b/lib/bcdice/game_system/SamsaraBallad.rb
@@ -31,7 +31,7 @@ module BCDice
       MESSAGETEXT
 
       # ダイスボットで使用するコマンドを配列で列挙する
-      register_prefix('SBS?.*')
+      register_prefix('SBS?')
 
       def eval_game_system_specific_command(command)
         debug("eval_game_system_specific_command Begin")

--- a/lib/bcdice/game_system/SevenFortressMobius.rb
+++ b/lib/bcdice/game_system/SevenFortressMobius.rb
@@ -23,7 +23,7 @@ module BCDice
         　例）12SFM-5@7#2　　1SFM　　50SFM+5@7,10#2,5　50SFM-5+10@7,10#2,5+15+25
       INFO_MESSAGE_TEXT
 
-      register_prefix('([-+]?\d+)?SFM.*', '2R6.*')
+      register_prefix('([-+]?\d+)?SFM', '2R6')
 
       def initialize(command)
         super(command)

--- a/lib/bcdice/game_system/SharedFantasia.rb
+++ b/lib/bcdice/game_system/SharedFantasia.rb
@@ -21,7 +21,7 @@ module BCDice
         例) SF+4>=9 : 2D6して4を足した値が9以上なら成功
       MESSAGETEXT
 
-      register_prefix('SF.*', 'ST.*')
+      register_prefix('SF', 'ST')
 
       def change_text(string)
         string.gsub(/SF/i, "2D6").gsub(/ST/i, "2D6")

--- a/lib/bcdice/game_system/ShinkuuGakuen.rb
+++ b/lib/bcdice/game_system/ShinkuuGakuen.rb
@@ -34,8 +34,8 @@ module BCDice
       MESSAGETEXT
 
       register_prefix(
-        'CRL.*', 'CSW.*', 'CLS.*', 'CSS.*', 'CSP.*', 'CAX.*', 'CCL.*', 'CMA.*', 'CBX.*', 'CPR.*', 'CST.*',
-        'RL.*', 'SW.*', 'LS.*', 'SS.*', 'SP.*', 'AX.*', 'CL.*', 'BW.*', 'MA.*', 'BX.*', 'PR.*', 'ST.*'
+        'CRL', 'CSW', 'CLS', 'CSS', 'CSP', 'CAX', 'CCL', 'CMA', 'CBX', 'CPR', 'CST',
+        'RL', 'SW', 'LS', 'SS', 'SP', 'AX', 'CL', 'BW', 'MA', 'BX', 'PR', 'ST'
       )
 
       def eval_game_system_specific_command(command)

--- a/lib/bcdice/game_system/Skynauts.rb
+++ b/lib/bcdice/game_system/Skynauts.rb
@@ -32,7 +32,7 @@ module BCDice
         　AVO9@8[縦1,横4],[縦2,横6],[縦3,横8]　AVO@2[縦6,横4],[縦2,横6]
       MESSAGETEXT
 
-      register_prefix('D.*', '2[Dd]6<=.*', 'SN.*', 'NV.*', 'AVO.*', 'BOM.*')
+      register_prefix('D', '2D6<=', 'SN', 'NV', 'AVO', 'BOM')
 
       def initialize(command)
         super(command)

--- a/lib/bcdice/game_system/SteamPunkers.rb
+++ b/lib/bcdice/game_system/SteamPunkers.rb
@@ -481,7 +481,7 @@ module BCDice
         )
       }.freeze
 
-      register_prefix('SP.*', TABLES.keys)
+      register_prefix('SP', TABLES.keys)
     end
   end
 end

--- a/lib/bcdice/game_system/StrangerOfSwordCity.rb
+++ b/lib/bcdice/game_system/StrangerOfSwordCity.rb
@@ -21,7 +21,7 @@ module BCDice
         ・D66ダイスあり
       INFO_MESSAGE_TEXT
 
-      register_prefix('\d+SR.*')
+      register_prefix('\d+SR')
 
       def initialize(command)
         super(command)

--- a/lib/bcdice/game_system/SwordWorld.rb
+++ b/lib/bcdice/game_system/SwordWorld.rb
@@ -17,7 +17,7 @@ module BCDice
       # ダイスボットの使い方
       HELP_MESSAGE = "・SW　レーティング表　(Kx[c]+m$f) (x:キー, c:クリティカル値, m:ボーナス, f:出目修正)\n"
 
-      register_prefix('H?K\d+.*')
+      register_prefix('H?K\d+')
 
       def initialize(command)
         super(command)

--- a/lib/bcdice/game_system/SwordWorld2_0.rb
+++ b/lib/bcdice/game_system/SwordWorld2_0.rb
@@ -68,7 +68,7 @@ module BCDice
         　絡み効果表を出すことができます。
       INFO_MESSAGE_TEXT
 
-      register_prefix('H?K\d+.*', 'Gr(\d+)?', '2D6?@\d+.*', 'FT', 'TT')
+      register_prefix('H?K\d+', 'Gr(\d+)?', '2D6?@\d+', 'FT', 'TT')
 
       def initialize(command)
         super(command)

--- a/lib/bcdice/game_system/SwordWorld2_5.rb
+++ b/lib/bcdice/game_system/SwordWorld2_5.rb
@@ -76,7 +76,7 @@ module BCDice
         　アビスカース表を出すことができます。
       INFO_MESSAGE_TEXT
 
-      register_prefix('H?K\d+.*', 'Gr(\d+)?', '2D6?@\d+.*', 'FT', 'TT', 'Dru\[\d+,\d+,\d+\].*', 'ABT')
+      register_prefix('H?K\d+', 'Gr(\d+)?', '2D6?@\d+', 'FT', 'TT', 'Dru\[\d+,\d+,\d+\]', 'ABT')
 
       ABYSS_CURSE_TABLE = DiceTable::D66GridTable.new(
         'アビスカース表', [

--- a/lib/bcdice/game_system/TunnelsAndTrolls.rb
+++ b/lib/bcdice/game_system/TunnelsAndTrolls.rb
@@ -30,7 +30,7 @@ module BCDice
         　下から２番目の出目をずらした分だけ合計にマイナス修正を追加して表示します。
       INFO_MESSAGE_TEXT
 
-      register_prefix('\d+H?BS.*', '\d+R6.*', '\d+D\d+.+', '\dD6.*')
+      register_prefix('\d+H?BS', '\d+R6', '\d+D\d+.+', '\dD6')
 
       def initialize(command)
         super(command)

--- a/lib/bcdice/game_system/TwilightGunsmoke.rb
+++ b/lib/bcdice/game_system/TwilightGunsmoke.rb
@@ -520,7 +520,7 @@ module BCDice
         )
       }.freeze
 
-      register_prefix('2D6.*', TABLES.keys)
+      register_prefix('2D6', TABLES.keys)
     end
   end
 end

--- a/lib/bcdice/game_system/Utakaze.rb
+++ b/lib/bcdice/game_system/Utakaze.rb
@@ -25,7 +25,7 @@ module BCDice
           例）3UK@5 ：龍のダイス「月」でクリティカルコール宣言したサイコロ3個の行為判定
       MESSAGETEXT
 
-      register_prefix('\d*UK[@\d]*.*')
+      register_prefix('\d*UK[@\d]*')
 
       def initialize(command)
         super(command)

--- a/lib/bcdice/game_system/VampireTheMasquerade5th.rb
+++ b/lib/bcdice/game_system/VampireTheMasquerade5th.rb
@@ -41,7 +41,7 @@ module BCDice
       NOT_CHECK_SUCCESS = -1 # 判定成功にかかわるチェックを行わない(判定失敗に関わるチェックは行う)
 
       # ダイスボットで使用するコマンドを配列で列挙する
-      register_prefix('\d*VMF.*')
+      register_prefix('\d*VMF')
 
       def eval_game_system_specific_command(command)
         m = /\A(\d+)?(VMF)(\d+)(\+(\d+))?/.match(command)

--- a/lib/bcdice/game_system/Warhammer.rb
+++ b/lib/bcdice/game_system/Warhammer.rb
@@ -26,7 +26,7 @@ module BCDice
         　例）wh60　　wh43@4W　　WH65@
       INFO_MESSAGE_TEXT
 
-      register_prefix('WH.*')
+      register_prefix('WH')
 
       def initialize(command)
         super(command)

--- a/lib/bcdice/game_system/WorldOfDarkness.rb
+++ b/lib/bcdice/game_system/WorldOfDarkness.rb
@@ -23,7 +23,7 @@ module BCDice
         　自動成功=省略時0
       INFO_MESSAGE_TEXT
 
-      register_prefix('\d+ST.*')
+      register_prefix('\d+ST')
 
       def initialize(command)
         super(command)

--- a/lib/bcdice/game_system/YearZeroEngine.rb
+++ b/lib/bcdice/game_system/YearZeroEngine.rb
@@ -29,7 +29,7 @@ module BCDice
       SKILL_INDEX        = 5 # 技能値ダイスのインデックス
       MODIFIED_INDEX     = 7 # 修正ダイスのインデックス
 
-      register_prefix('(\d+)?(YZE|MYZ).*')
+      register_prefix('(\d+)?(YZE|MYZ)')
 
       def dice_info_init()
         @total_success_dice = 0

--- a/lib/bcdice/game_system/ZettaiReido.rb
+++ b/lib/bcdice/game_system/ZettaiReido.rb
@@ -20,7 +20,7 @@ module BCDice
         DPの取得の有無も表示されます。
       INFO_MESSAGE_TEXT
 
-      register_prefix('\d+\-2DR.*')
+      register_prefix('\d+\-2DR')
 
       def eval_game_system_specific_command(command)
         return nil unless command =~ /^(\d+)-2DR([+\-\d]*)(>=(\d+))?$/i


### PR DESCRIPTION
register_prefixは以前と違い先頭一致のみ確認するようになったので、
完全一致にするための `.*` は不要になった。

以下は別途リファクタリング中なので、今回の修正には含まれていない
- FilledWith
- Satasupe