### PR TITLE
SaiFicSkillTableのcommand_patternがRuby依存にならないように

### DIFF
--- a/lib/bcdice/common_command/add_dice.rb
+++ b/lib/bcdice/common_command/add_dice.rb
@@ -7,7 +7,7 @@ require "bcdice/common_command/add_dice/randomizer"
 module BCDice
   module CommonCommand
     module AddDice
-      PREFIX_PATTERN = /[+\-\dD(\[]+/.freeze
+      PREFIX_PATTERN = /[+\-\dD(]+/.freeze
 
       class << self
         def eval(command, game_system, randomizer)

--- a/lib/bcdice/dice_table/sai_fic_skill_table.rb
+++ b/lib/bcdice/dice_table/sai_fic_skill_table.rb
@@ -77,7 +77,7 @@ module BCDice
       end
 
       def prefixes
-        ([/RTT[1-6]?/i, "RCT", @rtt, @rct] + @rttn).compact
+        (["RTT[1-6]?", "RCT", @rtt, @rct] + @rttn).compact
       end
 
       private

--- a/test/test_base.rb
+++ b/test/test_base.rb
@@ -9,27 +9,27 @@ end
 
 class TestBase < Test::Unit::TestCase
   def test_command_pattern
-    assert_equal(/^S?([+\-\dD(\[]+|\d+B\d+|C|choice|D66|(repeat|rep|x)\d+|\d+R\d+|\d+U\d+|BCDiceVersion|ABC|XYZ|IP\d+)/i, DummySystem.command_pattern)
+    assert_equal(/^S?([+\-\dD(]+|\d+B\d+|C|choice|D66|(repeat|rep|x)\d+|\d+R\d+|\d+U\d+|BCDiceVersion|ABC|XYZ|IP\d+)/i, DummySystem.command_pattern)
 
-    assert(DummySystem.command_pattern.match?("ABC+123"))
-    assert(DummySystem.command_pattern.match?("XYZ[hoge]"))
-    assert(DummySystem.command_pattern.match?("IP900+1000"))
-    assert_false(DummySystem.command_pattern.match?("IP+1000"))
-    assert_false(DummySystem.command_pattern.match?("EFG"))
+    assert_match(DummySystem.command_pattern, "ABC+123")
+    assert_match(DummySystem.command_pattern, "XYZ[hoge]")
+    assert_match(DummySystem.command_pattern, "IP900+1000")
+    assert_not_match(DummySystem.command_pattern, "IP+1000")
+    assert_not_match(DummySystem.command_pattern, "EFG")
 
-    assert(DummySystem.command_pattern.match?("1D100<=70"))
-    assert(DummySystem.command_pattern.match?("4D6+2D8"))
-    assert(DummySystem.command_pattern.match?("4B6+2B8"))
-    assert(DummySystem.command_pattern.match?("C2+4*3/2"))
-    assert(DummySystem.command_pattern.match?("choice[うさぎ,かめ]"))
-    assert(DummySystem.command_pattern.match?("D66s"))
-    assert(DummySystem.command_pattern.match?("1R10+5R6"))
-    assert(DummySystem.command_pattern.match?("1U10+2U20"))
-    assert(DummySystem.command_pattern.match?("bcdiceversion"))
+    assert_match(DummySystem.command_pattern, "1D100<=70")
+    assert_match(DummySystem.command_pattern, "4D6+2D8")
+    assert_match(DummySystem.command_pattern, "4B6+2B8")
+    assert_match(DummySystem.command_pattern, "C2+4*3/2")
+    assert_match(DummySystem.command_pattern, "choice[うさぎ,かめ]")
+    assert_match(DummySystem.command_pattern, "D66s")
+    assert_match(DummySystem.command_pattern, "1R10+5R6")
+    assert_match(DummySystem.command_pattern, "1U10+2U20")
+    assert_match(DummySystem.command_pattern, "bcdiceversion")
 
-    assert(DummySystem.command_pattern.match?("(1+2)D100<=70"))
-    assert(DummySystem.command_pattern.match?("[1...3]D100<=70"))
-    assert(DummySystem.command_pattern.match?("-3+2D100<=70"))
-    assert(DummySystem.command_pattern.match?("+3+2D100<=70"))
+    assert_match(DummySystem.command_pattern, "(1+2)D100<=70")
+    assert_not_match(DummySystem.command_pattern, "[1...3]D100<=70")
+    assert_match(DummySystem.command_pattern, "-3+2D100<=70")
+    assert_match(DummySystem.command_pattern, "+3+2D100<=70")
   end
 end

--- a/test/test_sai_fic_skill_table.rb
+++ b/test/test_sai_fic_skill_table.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require "test/unit"
+require "bcdice"
+require "bcdice/dice_table/sai_fic_skill_table"
+
+class TestSaiFicSkillTable < Test::Unit::TestCase
+  class DummySystem < BCDice::Base
+    table = BCDice::DiceTable::SaiFicSkillTable.new([])
+
+    register_prefix(table.prefixes)
+  end
+
+  def test_command_pattern
+    assert_equal(/^S?([+\-\dD(]+|\d+B\d+|C|choice|D66|(repeat|rep|x)\d+|\d+R\d+|\d+U\d+|BCDiceVersion|RTT[1-6]?|RCT)/i, DummySystem.command_pattern)
+  end
+end


### PR DESCRIPTION
`BCDice::Base#register_prefix` にRegexpのインスタンスが渡されると、 `BCDice::Base#command_pattern` がJavaScript等で解釈できない応答になるため修正する。

`register_prefix` にRegexpが渡されると以下のようになってしまう。 `(?-mix:RTT[1-6]?)` の部分がJavaScriptでは解釈できない。

```ruby
/^S?([+\-\dD(]+|\d+B\d+|C|choice|D66|(repeat|rep|x)\d+|\d+R\d+|\d+U\d+|BCDiceVersion|(?-mix:RTT[1-6]?)|RCT)/i
```