### PR TITLE
AddDiceのPREFIX_PATTERNをより厳密に

### DIFF
--- a/lib/bcdice/common_command/add_dice.rb
+++ b/lib/bcdice/common_command/add_dice.rb
@@ -7,7 +7,7 @@ require "bcdice/common_command/add_dice/randomizer"
 module BCDice
   module CommonCommand
     module AddDice
-      PREFIX_PATTERN = /[+\-\dD(]+/.freeze
+      PREFIX_PATTERN = /[+\-(]*\d+/.freeze
 
       class << self
         def eval(command, game_system, randomizer)

--- a/test/test_base.rb
+++ b/test/test_base.rb
@@ -32,5 +32,7 @@ class TestBase < Test::Unit::TestCase
     assert_match(DummySystem.command_pattern, "-3+2D100<=70")
     assert_match(DummySystem.command_pattern, "+3+2D100<=70")
     assert_not_match(DummySystem.command_pattern, "D6")
+    assert_not_match(DummySystem.command_pattern, "+-")
+    assert_match(DummySystem.command_pattern, "+(---(-3+1))D")
   end
 end

--- a/test/test_base.rb
+++ b/test/test_base.rb
@@ -9,7 +9,7 @@ end
 
 class TestBase < Test::Unit::TestCase
   def test_command_pattern
-    assert_equal(/^S?([+\-\dD(]+|\d+B\d+|C|choice|D66|(repeat|rep|x)\d+|\d+R\d+|\d+U\d+|BCDiceVersion|ABC|XYZ|IP\d+)/i, DummySystem.command_pattern)
+    assert_equal(/^S?([+\-(]*\d+|\d+B\d+|C|choice|D66|(repeat|rep|x)\d+|\d+R\d+|\d+U\d+|BCDiceVersion|ABC|XYZ|IP\d+)/i, DummySystem.command_pattern)
 
     assert_match(DummySystem.command_pattern, "ABC+123")
     assert_match(DummySystem.command_pattern, "XYZ[hoge]")
@@ -31,5 +31,6 @@ class TestBase < Test::Unit::TestCase
     assert_not_match(DummySystem.command_pattern, "[1...3]D100<=70")
     assert_match(DummySystem.command_pattern, "-3+2D100<=70")
     assert_match(DummySystem.command_pattern, "+3+2D100<=70")
+    assert_not_match(DummySystem.command_pattern, "D6")
   end
 end

--- a/test/test_sai_fic_skill_table.rb
+++ b/test/test_sai_fic_skill_table.rb
@@ -12,6 +12,6 @@ class TestSaiFicSkillTable < Test::Unit::TestCase
   end
 
   def test_command_pattern
-    assert_equal(/^S?([+\-\dD(]+|\d+B\d+|C|choice|D66|(repeat|rep|x)\d+|\d+R\d+|\d+U\d+|BCDiceVersion|RTT[1-6]?|RCT)/i, DummySystem.command_pattern)
+    assert_equal(/^S?([+\-(]*\d+|\d+B\d+|C|choice|D66|(repeat|rep|x)\d+|\d+R\d+|\d+U\d+|BCDiceVersion|RTT[1-6]?|RCT)/i, DummySystem.command_pattern)
   end
 end


### PR DESCRIPTION
AddDiceの`PREFIX_PATTERN`を変更して、下記のようなコマンドが`command_pattern`にマッチしないようにする
- `D6`
- `+-`

https://discord.com/channels/597133335243784192/677433815756439562/828206792860368906