### PR TITLE
先輩後輩TRPG エネカデットに対応

### DIFF
--- a/lib/bcdice/game_system.rb
+++ b/lib/bcdice/game_system.rb
@@ -2,6 +2,7 @@
 
 require "bcdice/game_system/AFF2e"
 require "bcdice/game_system/AceKillerGene"
+require "bcdice/game_system/Ainecadette"
 require "bcdice/game_system/Airgetlamh"
 require "bcdice/game_system/AlchemiaStruggle"
 require "bcdice/game_system/Alsetto"

--- a/lib/bcdice/game_system/Ainecadette.rb
+++ b/lib/bcdice/game_system/Ainecadette.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+module BCDice
+  module GameSystem
+    class Ainecadette < Base
+      # ゲームシステムの識別子
+      ID = "Ainecadette"
+
+      # ゲームシステム名
+      NAME = "エネカデット"
+
+      # ゲームシステム名の読みがな
+      SORT_KEY = "えねかてつと"
+
+      # ダイスボットの使い方
+      HELP_MESSAGE = <<~MESSAGETEXT
+        ■ 判定
+        - 先輩 (AI) 10面ダイスを2つ振って判定します。『有利』なら【3AI】、『不利』なら【1AI】を使います。
+        - 後輩 (CA) 6面ダイスを2つ振って判定します。『有利』なら【3CA】、『不利』なら【1CA】を使います。
+      MESSAGETEXT
+
+      register_prefix('(\d+)?AI', '(\d+)?CA')
+
+      def eval_game_system_specific_command(command)
+        roll_action(command)
+      end
+
+      private
+
+      # 成功の目標値
+      SUCCESS_THRESHOLD = 4
+
+      # スペシャルとなる出目
+      SPECIAL_DICE = 6
+
+      def roll_action(command)
+        m = /^(\d+)?(AI|CA)$/.match(command)
+        return nil unless m
+
+        is_senpai = m[2] == "AI"
+
+        times = m[1]&.to_i || 2
+        sides = is_senpai ? 10 : 6
+        return nil if times <= 0
+
+        dice_list = @randomizer.roll_barabara(times, sides)
+        max = dice_list.max
+
+        result =
+          if max <= 1
+            Result.fumble("ファンブル（もやもやカウンターを2個獲得）")
+          elsif dice_list.include?(6)
+            me = is_senpai ? "先輩" : "後輩"
+            target = is_senpai ? "後輩" : "先輩"
+            Result.critical("スペシャル（絆カウンターを1個獲得し、#{target}は#{me}への感情を1つ獲得）")
+          elsif max >= SUCCESS_THRESHOLD
+            Result.success("成功")
+          else
+            Result.failure("失敗")
+          end
+
+        result.text = "(#{command}) ＞ [#{dice_list.join(',')}] ＞ #{result.text}"
+
+        return result
+      end
+    end
+  end
+end

--- a/test/data/Ainecadette.toml
+++ b/test/data/Ainecadette.toml
@@ -1,0 +1,208 @@
+# 行為判定（先輩）
+[[ test ]]
+game_system = "Ainecadette"
+input = "AI"
+output = "(AI) ＞ [4,3] ＞ 成功"
+success = true
+rands = [
+  { sides = 10, value = 4 },
+  { sides = 10, value = 3 },
+]
+
+[[ test ]]
+game_system = "Ainecadette"
+input = "AI"
+output = "(AI) ＞ [3,1] ＞ 失敗"
+failure = true
+rands = [
+  { sides = 10, value = 3 },
+  { sides = 10, value = 1 },
+]
+
+[[ test ]]
+game_system = "Ainecadette"
+input = "AI"
+output = "(AI) ＞ [1,1] ＞ ファンブル（もやもやカウンターを2個獲得）"
+fumble = true
+failure = true
+rands = [
+  { sides = 10, value = 1 },
+  { sides = 10, value = 1 },
+]
+
+[[ test ]]
+game_system = "Ainecadette"
+input = "AI"
+output = "(AI) ＞ [6,1] ＞ スペシャル（絆カウンターを1個獲得し、後輩は先輩への感情を1つ獲得）"
+critical = true
+success = true
+rands = [
+  { sides = 10, value = 6 },
+  { sides = 10, value = 1 },
+]
+
+[[ test ]]
+game_system = "Ainecadette"
+input = "AI 6がある時だけクリティカル"
+output = "(AI) ＞ [8,10] ＞ 成功"
+success = true
+rands = [
+  { sides = 10, value = 8 },
+  { sides = 10, value = 10 },
+]
+
+
+# 行為判定（先輩）不利
+[[ test ]]
+game_system = "Ainecadette"
+input = "1AI"
+output = "(1AI) ＞ [4] ＞ 成功"
+success = true
+rands = [
+  { sides = 10, value = 4 },
+]
+
+[[ test ]]
+game_system = "Ainecadette"
+input = "1AI"
+output = "(1AI) ＞ [3] ＞ 失敗"
+failure = true
+rands = [
+  { sides = 10, value = 3 },
+]
+
+
+# 行為判定（先輩）有利
+[[ test ]]
+game_system = "Ainecadette"
+input = "3AI"
+output = "(3AI) ＞ [2,3,4] ＞ 成功"
+success = true
+rands = [
+  { sides = 10, value = 2 },
+  { sides = 10, value = 3 },
+  { sides = 10, value = 4 },
+]
+
+[[ test ]]
+game_system = "Ainecadette"
+input = "3AI"
+output = "(3AI) ＞ [2,3,3] ＞ 失敗"
+failure = true
+rands = [
+  { sides = 10, value = 2 },
+  { sides = 10, value = 3 },
+  { sides = 10, value = 3 },
+]
+
+[[ test ]]
+game_system = "Ainecadette"
+input = "4AI 有利+ブースト"
+output = "(4AI) ＞ [2,3,4,5] ＞ 成功"
+success = true
+rands = [
+  { sides = 10, value = 2 },
+  { sides = 10, value = 3 },
+  { sides = 10, value = 4 },
+  { sides = 10, value = 5 },
+]
+
+
+# 行為判定（後輩）
+[[ test ]]
+game_system = "Ainecadette"
+input = "CA"
+output = "(CA) ＞ [4,3] ＞ 成功"
+success = true
+rands = [
+  { sides = 6, value = 4 },
+  { sides = 6, value = 3 },
+]
+
+[[ test ]]
+game_system = "Ainecadette"
+input = "CA"
+output = "(CA) ＞ [3,1] ＞ 失敗"
+failure = true
+rands = [
+  { sides = 6, value = 3 },
+  { sides = 6, value = 1 },
+]
+
+[[ test ]]
+game_system = "Ainecadette"
+input = "CA"
+output = "(CA) ＞ [1,1] ＞ ファンブル（もやもやカウンターを2個獲得）"
+fumble = true
+failure = true
+rands = [
+  { sides = 6, value = 1 },
+  { sides = 6, value = 1 },
+]
+
+[[ test ]]
+game_system = "Ainecadette"
+input = "CA"
+output = "(CA) ＞ [6,1] ＞ スペシャル（絆カウンターを1個獲得し、先輩は後輩への感情を1つ獲得）"
+critical = true
+success = true
+rands = [
+  { sides = 6, value = 6 },
+  { sides = 6, value = 1 },
+]
+
+
+# 行為判定（後輩）不利
+[[ test ]]
+game_system = "Ainecadette"
+input = "1CA"
+output = "(1CA) ＞ [4] ＞ 成功"
+success = true
+rands = [
+  { sides = 6, value = 4 },
+]
+
+[[ test ]]
+game_system = "Ainecadette"
+input = "1CA"
+output = "(1CA) ＞ [3] ＞ 失敗"
+failure = true
+rands = [
+  { sides = 6, value = 3 },
+]
+
+
+# 行為判定（後輩）有利
+[[ test ]]
+game_system = "Ainecadette"
+input = "3CA"
+output = "(3CA) ＞ [2,3,4] ＞ 成功"
+success = true
+rands = [
+  { sides = 6, value = 2 },
+  { sides = 6, value = 3 },
+  { sides = 6, value = 4 },
+]
+
+[[ test ]]
+game_system = "Ainecadette"
+input = "3CA"
+output = "(3CA) ＞ [2,3,3] ＞ 失敗"
+failure = true
+rands = [
+  { sides = 6, value = 2 },
+  { sides = 6, value = 3 },
+  { sides = 6, value = 3 },
+]
+
+[[ test ]]
+game_system = "Ainecadette"
+input = "4CA 有利+ブースト"
+output = "(4CA) ＞ [2,3,4,5] ＞ 成功"
+success = true
+rands = [
+  { sides = 6, value = 2 },
+  { sides = 6, value = 3 },
+  { sides = 6, value = 4 },
+  { sides = 6, value = 5 },
+]


### PR DESCRIPTION
[先輩後輩TRPG エネカデット](http://www.bouken.jp/pd/ac/)

## ヘルプメッセージ
```
■ 判定
- 先輩 (AI) 10面ダイスを2つ振って判定します。『有利』なら【3AI】、『不利』なら【1AI】を使います。
- 後輩 (CA) 6面ダイスを2つ振って判定します。『有利』なら【3CA】、『不利』なら【1CA】を使います。
```