### PR TITLE
[ShinobiGami] 行為判定コマンドでダイス数を指定できるようにする

### DIFF
--- a/test/data/ShinobiGami.toml
+++ b/test/data/ShinobiGami.toml
@@ -165,6 +165,77 @@ rands = [
   { sides = 6, value = 3 },
 ]
 
+[[ test ]]
+game_system = "ShinobiGami"
+input = "0SG>=7"
+output = ""
+rands = []
+
+[[ test ]]
+game_system = "ShinobiGami"
+input = "1SG>=7"
+output = ""
+rands = []
+
+[[ test ]]
+game_system = "ShinobiGami"
+input = "2SG@11#3>=7"
+output = "(2SG@11#3>=7) ＞ 7[3,4] ＞ 7 ＞ 成功"
+success = true
+rands = [
+  { sides = 6, value = 4 },
+  { sides = 6, value = 3 },
+]
+
+[[ test ]]
+game_system = "ShinobiGami"
+input = "4SG+1>=7"
+output = "(4SG+1@12#2>=7) ＞ [2,3,4,5] ＞ 9[4,5]+1 ＞ 10 ＞ 成功"
+success = true
+rands = [
+  { sides = 6, value = 2 },
+  { sides = 6, value = 4 },
+  { sides = 6, value = 3 },
+  { sides = 6, value = 5 },
+]
+
+[[ test ]]
+game_system = "ShinobiGami"
+input = "4SG+1>=7"
+output = "(4SG+1@12#2>=7) ＞ [1,1,2,2] ＞ 4[2,2]+1 ＞ 5 ＞ 失敗"
+failure = true
+rands = [
+  { sides = 6, value = 1 },
+  { sides = 6, value = 2 },
+  { sides = 6, value = 2 },
+  { sides = 6, value = 1 },
+]
+
+[[ test ]]
+game_system = "ShinobiGami"
+input = "4SG+1>=7"
+output = "(4SG+1@12#2>=7) ＞ [1,1,1,1] ＞ 2[1,1]+1 ＞ 3 ＞ ファンブル"
+failure = true
+fumble = true
+rands = [
+  { sides = 6, value = 1 },
+  { sides = 6, value = 1 },
+  { sides = 6, value = 1 },
+  { sides = 6, value = 1 },
+]
+
+[[ test ]]
+game_system = "ShinobiGami"
+input = "4SG+1>=7"
+output = "(4SG+1@12#2>=7) ＞ [1,1,6,6] ＞ 12[6,6]+1 ＞ 13 ＞ スペシャル(【生命力】1点か変調一つを回復)"
+success = true
+critical = true
+rands = [
+  { sides = 6, value = 1 },
+  { sides = 6, value = 1 },
+  { sides = 6, value = 6 },
+  { sides = 6, value = 6 },
+]
 
 [[ test ]]
 game_system = "ShinobiGami"


### PR DESCRIPTION
一部の技能で行為判定時に2D6でなく3D6や4D6から出目を2つ選んで達成値にする効果がある。 `SG`コマンドでその対応として`nD6KH2`相当の処理を実行できるようにする。