### PR TITLE
[StellarKnights] success/failure を明示

### DIFF
--- a/lib/bcdice/game_system/StellarKnights.rb
+++ b/lib/bcdice/game_system/StellarKnights.rb
@@ -113,12 +113,20 @@ module BCDice
           output += " ＞ [#{dices.join(',')}]"
         end
 
-        unless defence.nil?
-          success = dices.count { |val| val >= defence }
-          output += " ＞ " + translate("StellarKnights.SK.success_num", success_num: success)
+        if defence.nil?
+          success = false
+          failure = false
+        else
+          success_num = dices.count { |val| val >= defence }
+          output += " ＞ " + translate("StellarKnights.SK.success_num", success_num: success_num)
+          success = success_num > 0
+          failure = !success
         end
 
-        output
+        Result.new(output).tap do |r|
+          r.success = success
+          r.failure = failure
+        end
       end
 
       def parse_dice_change_rules(text)

--- a/test/data/StellarKnights.toml
+++ b/test/data/StellarKnights.toml
@@ -2,8 +2,6 @@
 game_system = "StellarKnights"
 input = "4SK"
 output = "(4SK) ＞ 1,3,4,5"
-success = false
-failure = false
 rands = [
   { sides = 6, value = 5 },
   { sides = 6, value = 1 },

--- a/test/data/StellarKnights.toml
+++ b/test/data/StellarKnights.toml
@@ -2,6 +2,8 @@
 game_system = "StellarKnights"
 input = "4SK"
 output = "(4SK) ＞ 1,3,4,5"
+success = false
+failure = false
 rands = [
   { sides = 6, value = 5 },
   { sides = 6, value = 1 },
@@ -13,6 +15,7 @@ rands = [
 game_system = "StellarKnights"
 input = "5SK3"
 output = "(5SK3) ＞ 2,3,5,6,6 ＞ 成功数: 4"
+success = true
 rands = [
   { sides = 6, value = 6 },
   { sides = 6, value = 5 },
@@ -23,8 +26,21 @@ rands = [
 
 [[ test ]]
 game_system = "StellarKnights"
+input = "3SK6"
+output = "(3SK6) ＞ 2,3,5 ＞ 成功数: 0"
+failure = true
+rands = [
+  { sides = 6, value = 5 },
+  { sides = 6, value = 3 },
+  { sides = 6, value = 2 },
+]
+
+[[ test ]]
+game_system = "StellarKnights"
 input = "3SK,1>6"
 output = "(3SK,1>6) ＞ 1,2,3 ＞ [2,3,6]"
+success = false
+failure = false
 rands = [
   { sides = 6, value = 2 },
   { sides = 6, value = 3 },
@@ -35,6 +51,7 @@ rands = [
 game_system = "StellarKnights"
 input = "6SK4,1>6,2>6"
 output = "(6SK4,1>6,2>6) ＞ 1,2,3,4,5,6 ＞ [3,4,5,6,6,6] ＞ 成功数: 5"
+success = true
 rands = [
   { sides = 6, value = 1 },
   { sides = 6, value = 2 },
@@ -48,6 +65,7 @@ rands = [
 game_system = "StellarKnights"
 input = "6SK4,1>6,6>1"
 output = "(6SK4,1>6,6>1) ＞ 1,2,3,4,5,6 ＞ [1,1,2,3,4,5] ＞ 成功数: 2"
+success = true
 rands = [
   { sides = 6, value = 1 },
   { sides = 6, value = 2 },

--- a/test/data/StellarKnights.toml
+++ b/test/data/StellarKnights.toml
@@ -37,8 +37,6 @@ rands = [
 game_system = "StellarKnights"
 input = "3SK,1>6"
 output = "(3SK,1>6) ＞ 1,2,3 ＞ [2,3,6]"
-success = false
-failure = false
 rands = [
   { sides = 6, value = 2 },
   { sides = 6, value = 3 },


### PR DESCRIPTION
#423 

---

# 対象

　成功／失敗の概念があるのは、【アタック判定】に防御力との比較が指定された場合のみであるはず。

# 方針

　当該の【アタック判定】において、成功数が１以上ならば成功、成功数が０ならば失敗とみなす。

　基本ルールブック『銀剣のステラナイツ』の時点では「失敗」という表現はもちいられていないが（同書p150）、『銀剣のステラナイツ　星屑のリヴラガーデン』p119では同じ意味合いの処理に対して「失敗」という表現がされているため、この方針で妥当だと考える。

# 備考

　成功数が 0 になるテストケースがもともとなかったので、それも追加してある。