### PR TITLE
[MonotoneMuseum] Resultに対応する

### DIFF
--- a/lib/bcdice/game_system/MonotoneMuseum.rb
+++ b/lib/bcdice/game_system/MonotoneMuseum.rb
@@ -77,23 +77,25 @@ module BCDice
 
         result =
           if dice_value <= fumble
-            translate("MonotoneMuseum.automatic_failure")
+            Result.fumble(translate("MonotoneMuseum.automatic_failure"))
           elsif dice_value >= critical
-            translate("MonotoneMuseum.automatic_success")
+            Result.critical(translate("MonotoneMuseum.automatic_success"))
           elsif total >= target
-            translate("success")
+            Result.success(translate("success"))
           else
-            translate("failure")
+            Result.failure(translate("failure"))
           end
 
         sequence = [
           "(#{command})",
           "#{dice_value}[#{dice_str}]#{Format.modifier(modify_number)}",
           total.to_s,
-          result,
+          result.text,
         ]
 
-        return sequence.join(" ＞ ")
+        result.text = sequence.join(" ＞ ")
+
+        result
       end
 
       # モノトーンミュージアム用のテーブル

--- a/test/data/MonotoneMuseum.toml
+++ b/test/data/MonotoneMuseum.toml
@@ -2,6 +2,7 @@
 game_system = "MonotoneMuseum"
 input = "2D6>=7"
 output = "(2D6>=7) ＞ 7[2,5] ＞ 7 ＞ 成功"
+success = true
 rands = [
   { sides = 6, value = 5 },
   { sides = 6, value = 2 },
@@ -9,8 +10,20 @@ rands = [
 
 [[ test ]]
 game_system = "MonotoneMuseum"
+input = "2D6+1>=7"
+output = "(2D6+1>=7) ＞ 5[1,4]+1 ＞ 6 ＞ 失敗"
+failure = true
+rands = [
+  { sides = 6, value = 4 },
+  { sides = 6, value = 1 },
+]
+
+[[ test ]]
+game_system = "MonotoneMuseum"
 input = "2D6>=7"
 output = "(2D6>=7) ＞ 12[6,6] ＞ 12 ＞ 自動成功"
+success = true
+critical = true
 rands = [
   { sides = 6, value = 6 },
   { sides = 6, value = 6 },
@@ -20,6 +33,8 @@ rands = [
 game_system = "MonotoneMuseum"
 input = "2D6>=7"
 output = "(2D6>=7) ＞ 2[1,1] ＞ 2 ＞ 自動失敗"
+failure = true
+fumble = true
 rands = [
   { sides = 6, value = 1 },
   { sides = 6, value = 1 },
@@ -29,6 +44,7 @@ rands = [
 game_system = "MonotoneMuseum"
 input = "2D6+1>=5[11,3]"
 output = "(2D6+1>=5[11,3]) ＞ 6[2,4]+1 ＞ 7 ＞ 成功"
+success = true
 rands = [
   { sides = 6, value = 2 },
   { sides = 6, value = 4 },
@@ -38,6 +54,8 @@ rands = [
 game_system = "MonotoneMuseum"
 input = "2D6+1>=5[11,3]"
 output = "(2D6+1>=5[11,3]) ＞ 11[5,6]+1 ＞ 12 ＞ 自動成功"
+success = true
+critical = true
 rands = [
   { sides = 6, value = 5 },
   { sides = 6, value = 6 },
@@ -47,6 +65,8 @@ rands = [
 game_system = "MonotoneMuseum"
 input = "2D6+1>=5[11,3]"
 output = "(2D6+1>=5[11,3]) ＞ 3[1,2]+1 ＞ 4 ＞ 自動失敗"
+failure = true
+fumble = true
 rands = [
   { sides = 6, value = 1 },
   { sides = 6, value = 2 },
@@ -56,6 +76,8 @@ rands = [
 game_system = "MonotoneMuseum"
 input = "2D6+1>=5[11]"
 output = "(2D6+1>=5[11]) ＞ 11[5,6]+1 ＞ 12 ＞ 自動成功"
+success = true
+critical = true
 rands = [
   { sides = 6, value = 5 },
   { sides = 6, value = 6 },
@@ -65,6 +87,8 @@ rands = [
 game_system = "MonotoneMuseum"
 input = "2D6+1>=5[,3]"
 output = "(2D6+1>=5[,3]) ＞ 3[1,2]+1 ＞ 4 ＞ 自動失敗"
+failure = true
+fumble = true
 rands = [
   { sides = 6, value = 1 },
   { sides = 6, value = 2 },
@@ -74,6 +98,8 @@ rands = [
 game_system = "MonotoneMuseum"
 input = "2D6+1>=5[,3]"
 output = "(2D6+1>=5[,3]) ＞ 12[6,6]+1 ＞ 13 ＞ 自動成功"
+success = true
+critical = true
 rands = [
   { sides = 6, value = 6 },
   { sides = 6, value = 6 },
@@ -83,6 +109,8 @@ rands = [
 game_system = "MonotoneMuseum"
 input = "2D6+1>=5[7,7] ファンブル値優先"
 output = "(2D6+1>=5[7,7]) ＞ 7[2,5]+1 ＞ 8 ＞ 自動失敗"
+failure = true
+fumble = true
 rands = [
   { sides = 6, value = 5 },
   { sides = 6, value = 2 },
@@ -92,6 +120,8 @@ rands = [
 game_system = "MonotoneMuseum"
 input = "3D6+1>=7"
 output = "(3D6+1>=7) ＞ 12[2,4,6]+1 ＞ 13 ＞ 自動成功"
+success = true
+critical = true
 rands = [
   { sides = 6, value = 2 },
   { sides = 6, value = 6 },
@@ -102,6 +132,8 @@ rands = [
 game_system = "MonotoneMuseum"
 input = "1D6>=2"
 output = "(1D6>=2) ＞ 2[2] ＞ 2 ＞ 自動失敗"
+failure = true
+fumble = true
 rands = [
   { sides = 6, value = 2 },
 ]

--- a/test/data/MonotoneMuseum_Korean.toml
+++ b/test/data/MonotoneMuseum_Korean.toml
@@ -2,6 +2,7 @@
 game_system = "MonotoneMuseum:Korean"
 input = "2D6>=7"
 output = "(2D6>=7) ＞ 7[2,5] ＞ 7 ＞ 성공"
+success = true
 rands = [
   { sides = 6, value = 5 },
   { sides = 6, value = 2 },
@@ -9,8 +10,20 @@ rands = [
 
 [[ test ]]
 game_system = "MonotoneMuseum:Korean"
+input = "2D6+1>=7"
+output = "(2D6+1>=7) ＞ 5[1,4]+1 ＞ 6 ＞ 실패"
+failure = true
+rands = [
+  { sides = 6, value = 4 },
+  { sides = 6, value = 1 },
+]
+
+[[ test ]]
+game_system = "MonotoneMuseum:Korean"
 input = "2D6>=7"
 output = "(2D6>=7) ＞ 12[6,6] ＞ 12 ＞ 자동 성공"
+success = true
+critical = true
 rands = [
   { sides = 6, value = 6 },
   { sides = 6, value = 6 },
@@ -20,6 +33,8 @@ rands = [
 game_system = "MonotoneMuseum:Korean"
 input = "2D6>=7"
 output = "(2D6>=7) ＞ 2[1,1] ＞ 2 ＞ 자동 실패"
+failure = true
+fumble = true
 rands = [
   { sides = 6, value = 1 },
   { sides = 6, value = 1 },
@@ -29,6 +44,7 @@ rands = [
 game_system = "MonotoneMuseum:Korean"
 input = "2D6+1>=5[11,3]"
 output = "(2D6+1>=5[11,3]) ＞ 6[2,4]+1 ＞ 7 ＞ 성공"
+success = true
 rands = [
   { sides = 6, value = 2 },
   { sides = 6, value = 4 },
@@ -38,6 +54,8 @@ rands = [
 game_system = "MonotoneMuseum:Korean"
 input = "2D6+1>=5[11,3]"
 output = "(2D6+1>=5[11,3]) ＞ 11[5,6]+1 ＞ 12 ＞ 자동 성공"
+success = true
+critical = true
 rands = [
   { sides = 6, value = 5 },
   { sides = 6, value = 6 },
@@ -47,8 +65,76 @@ rands = [
 game_system = "MonotoneMuseum:Korean"
 input = "2D6+1>=5[11,3]"
 output = "(2D6+1>=5[11,3]) ＞ 3[1,2]+1 ＞ 4 ＞ 자동 실패"
+failure = true
+fumble = true
 rands = [
   { sides = 6, value = 1 },
+  { sides = 6, value = 2 },
+]
+
+[[ test ]]
+game_system = "MonotoneMuseum:Korean"
+input = "2D6+1>=5[11]"
+output = "(2D6+1>=5[11]) ＞ 11[5,6]+1 ＞ 12 ＞ 자동 성공"
+success = true
+critical = true
+rands = [
+  { sides = 6, value = 5 },
+  { sides = 6, value = 6 },
+]
+
+[[ test ]]
+game_system = "MonotoneMuseum:Korean"
+input = "2D6+1>=5[,3]"
+output = "(2D6+1>=5[,3]) ＞ 3[1,2]+1 ＞ 4 ＞ 자동 실패"
+failure = true
+fumble = true
+rands = [
+  { sides = 6, value = 1 },
+  { sides = 6, value = 2 },
+]
+
+[[ test ]]
+game_system = "MonotoneMuseum:Korean"
+input = "2D6+1>=5[,3]"
+output = "(2D6+1>=5[,3]) ＞ 12[6,6]+1 ＞ 13 ＞ 자동 성공"
+success = true
+critical = true
+rands = [
+  { sides = 6, value = 6 },
+  { sides = 6, value = 6 },
+]
+
+[[ test ]]
+game_system = "MonotoneMuseum:Korean"
+input = "2D6+1>=5[7,7] ファンブル値優先"
+output = "(2D6+1>=5[7,7]) ＞ 7[2,5]+1 ＞ 8 ＞ 자동 실패"
+failure = true
+fumble = true
+rands = [
+  { sides = 6, value = 5 },
+  { sides = 6, value = 2 },
+]
+
+[[ test ]]
+game_system = "MonotoneMuseum:Korean"
+input = "3D6+1>=7"
+output = "(3D6+1>=7) ＞ 12[2,4,6]+1 ＞ 13 ＞ 자동 성공"
+success = true
+critical = true
+rands = [
+  { sides = 6, value = 2 },
+  { sides = 6, value = 6 },
+  { sides = 6, value = 4 },
+]
+
+[[ test ]]
+game_system = "MonotoneMuseum:Korean"
+input = "1D6>=2"
+output = "(1D6>=2) ＞ 2[2] ＞ 2 ＞ 자동 실패"
+failure = true
+fumble = true
+rands = [
   { sides = 6, value = 2 },
 ]
 


### PR DESCRIPTION
#423 
MonotoneMuseum および MonotoneMuseum:Korean の対応

- 自動成功 -> `critical`
- 自動失敗 -> `fumble`

## 備考
MonotoneMuseum:Korean のテストケースの内容が日本語版と差異があったため移植した