### PR TITLE
[アマデウス] リファクタリングおよびResultの使用

### DIFF
--- a/lib/bcdice/game_system/Amadeus.rb
+++ b/lib/bcdice/game_system/Amadeus.rb
@@ -78,10 +78,28 @@ module BCDice
         available_inga = dice_list.size > 1
         inga_table = translate("Amadeus.inga_table")
 
+        success = false
+        critical = false
+        fumble = false
+
         results =
           dice_list.map do |dice|
             total = dice + modifier
-            result = check_success(total, dice, cmp_op, target, special)
+            result =
+              if dice == 1
+                fumble = true
+                translate("Amadeus.fumble")
+              elsif dice >= special
+                critical = true
+                success = true
+                translate("Amadeus.special")
+              elsif total.send(cmp_op, target)
+                success = true
+                translate("success")
+              else
+                translate("failure")
+              end
+
             if available_inga
               inga = inga_table[dice - 1]
               "#{total}_#{result}[#{dice}#{inga}]"
@@ -96,17 +114,15 @@ module BCDice
           results.join(" / ")
         ]
 
-        return sequence.join(" ＞ ")
-      end
-
-      def check_success(total, dice, cmp_op, target, special)
-        return translate("Amadeus.fumble") if dice == 1
-        return translate("Amadeus.special") if dice >= special
-
-        if total.send(cmp_op, target)
-          translate("success")
-        else
-          translate("failure")
+        Result.new.tap do |r|
+          r.text = sequence.join(" ＞ ")
+          if success
+            r.success = true
+            r.critical = critical
+          else
+            r.failure = true
+            r.fumble = fumble
+          end
         end
       end
 

--- a/lib/bcdice/game_system/Amadeus.rb
+++ b/lib/bcdice/game_system/Amadeus.rb
@@ -57,16 +57,16 @@ module BCDice
       end
 
       def amadeusDice(command)
-        m = /^(R([A-DS])([+\-\d]*))(@(\d))?((>(=)?)([+\-\d]*))?(@(\d))?$/i.match(command)
+        m = /^R([A-DS])([+\-\d]*)(@(\d))?((>=?)([+\-\d]*))?(@(\d))?$/i.match(command)
         unless m
           return nil
         end
 
-        skillRank = m[2]
-        modifier = ArithmeticEvaluator.eval(m[3])
-        cmp_op = m[7] ? Normalize.comparison_operator(m[7]) : :>=
-        target = m[9] ? ArithmeticEvaluator.eval(m[9]) : 4
-        specialNum = (m[5] || m[11] || 6).to_i
+        skillRank = m[1]
+        modifier = ArithmeticEvaluator.eval(m[2])
+        cmp_op = m[6] ? Normalize.comparison_operator(m[6]) : :>=
+        target = m[7] ? ArithmeticEvaluator.eval(m[7]) : 4
+        specialNum = (m[4] || m[9] || 6).to_i
 
         diceCount = CHECK_DICE_COUNT[skillRank]
 

--- a/lib/bcdice/game_system/Amadeus.rb
+++ b/lib/bcdice/game_system/Amadeus.rb
@@ -54,6 +54,8 @@ module BCDice
           roll_tables(command, self.class::TABLES)
       end
 
+      private
+
       def roll_amadeus(command)
         m = /^R([A-DS])([+\-\d]*)(@(\d))?((>=?)([+\-\d]*))?(@(\d))?$/i.match(command)
         unless m
@@ -110,42 +112,46 @@ module BCDice
 
       CHECK_DICE_COUNT = {"S" => 4, "A" => 3, "B" => 2, "C" => 1, "D" => 2}.freeze
 
-      def self.translate_tables(locale)
-        {
-          "ECT" => DiceTable::Table.from_i18n("Amadeus.table.ECT", locale),
-          "BST" => DiceTable::Table.from_i18n("Amadeus.table.BST", locale),
-          "RT" => DiceTable::Table.from_i18n("Amadeus.table.RT", locale),
-          "PRT" => DiceTable::Table.from_i18n("Amadeus.table.PRT", locale),
-          "FT" => DiceTable::Table.from_i18n("Amadeus.table.FT", locale),
-          "BT" => DiceTable::D66Table.from_i18n("Amadeus.table.BT", locale),
-          "FWT" => DiceTable::Table.from_i18n("Amadeus.table.FWT", locale),
-          "BRT" => DiceTable::Table.from_i18n("Amadeus.table.BRT", locale),
-          "RIT" => DiceTable::Table.from_i18n("Amadeus.table.RIT", locale),
-          "WT" => DiceTable::Table.from_i18n("Amadeus.table.WT", locale),
-          "NMT" => DiceTable::Table.from_i18n("Amadeus.table.NMT", locale),
-          "TGT" => DiceTable::Table.from_i18n("Amadeus.table.TGT", locale),
-          "CST" => DiceTable::Table.from_i18n("Amadeus.table.CST", locale),
-          "GCVT" => DiceTable::Table.from_i18n("Amadeus.table.GCVT", locale),
-          "YCVT" => DiceTable::Table.from_i18n("Amadeus.table.YCVT", locale),
-          "ECVT" => DiceTable::Table.from_i18n("Amadeus.table.ECVT", locale),
-          "CCVT" => DiceTable::Table.from_i18n("Amadeus.table.CCVT", locale),
-          "NCVT" => DiceTable::Table.from_i18n("Amadeus.table.NCVT", locale),
-          "DGVT" => DiceTable::Table.from_i18n("Amadeus.table.DGVT", locale),
-          "DAVT" => DiceTable::Table.from_i18n("Amadeus.table.DAVT", locale),
-          "PRCT" => DiceTable::Table.from_i18n("Amadeus.table.PRCT", locale),
-          "TCCT" => DiceTable::Table.from_i18n("Amadeus.table.TCCT", locale),
-          "INCT" => DiceTable::Table.from_i18n("Amadeus.table.INCT", locale),
-          "PSCT" => DiceTable::Table.from_i18n("Amadeus.table.PSCT", locale),
-          "LVCT" => DiceTable::Table.from_i18n("Amadeus.table.LVCT", locale),
-          "DACT" => DiceTable::Table.from_i18n("Amadeus.table.DACT", locale),
-          "RGT" => DiceTable::Table.from_i18n("Amadeus.table.RGT", locale),
-          "FBT" => DiceTable::Table.from_i18n("Amadeus.table.FBT", locale),
-          "CHVT" => DiceTable::Table.from_i18n("Amadeus.table.CHVT", locale),
-          "LCVT" => DiceTable::Table.from_i18n("Amadeus.table.LCVT", locale),
-          "KCVT" => DiceTable::Table.from_i18n("Amadeus.table.KCVT", locale),
-          "SAT" => DiceTable::D66Table.from_i18n("Amadeus.table.SAT", locale),
-          "SMT" => DiceTable::D66Table.from_i18n("Amadeus.table.SMT", locale),
-        }
+      class << self
+        private
+
+        def translate_tables(locale)
+          {
+            "ECT" => DiceTable::Table.from_i18n("Amadeus.table.ECT", locale),
+            "BST" => DiceTable::Table.from_i18n("Amadeus.table.BST", locale),
+            "RT" => DiceTable::Table.from_i18n("Amadeus.table.RT", locale),
+            "PRT" => DiceTable::Table.from_i18n("Amadeus.table.PRT", locale),
+            "FT" => DiceTable::Table.from_i18n("Amadeus.table.FT", locale),
+            "BT" => DiceTable::D66Table.from_i18n("Amadeus.table.BT", locale),
+            "FWT" => DiceTable::Table.from_i18n("Amadeus.table.FWT", locale),
+            "BRT" => DiceTable::Table.from_i18n("Amadeus.table.BRT", locale),
+            "RIT" => DiceTable::Table.from_i18n("Amadeus.table.RIT", locale),
+            "WT" => DiceTable::Table.from_i18n("Amadeus.table.WT", locale),
+            "NMT" => DiceTable::Table.from_i18n("Amadeus.table.NMT", locale),
+            "TGT" => DiceTable::Table.from_i18n("Amadeus.table.TGT", locale),
+            "CST" => DiceTable::Table.from_i18n("Amadeus.table.CST", locale),
+            "GCVT" => DiceTable::Table.from_i18n("Amadeus.table.GCVT", locale),
+            "YCVT" => DiceTable::Table.from_i18n("Amadeus.table.YCVT", locale),
+            "ECVT" => DiceTable::Table.from_i18n("Amadeus.table.ECVT", locale),
+            "CCVT" => DiceTable::Table.from_i18n("Amadeus.table.CCVT", locale),
+            "NCVT" => DiceTable::Table.from_i18n("Amadeus.table.NCVT", locale),
+            "DGVT" => DiceTable::Table.from_i18n("Amadeus.table.DGVT", locale),
+            "DAVT" => DiceTable::Table.from_i18n("Amadeus.table.DAVT", locale),
+            "PRCT" => DiceTable::Table.from_i18n("Amadeus.table.PRCT", locale),
+            "TCCT" => DiceTable::Table.from_i18n("Amadeus.table.TCCT", locale),
+            "INCT" => DiceTable::Table.from_i18n("Amadeus.table.INCT", locale),
+            "PSCT" => DiceTable::Table.from_i18n("Amadeus.table.PSCT", locale),
+            "LVCT" => DiceTable::Table.from_i18n("Amadeus.table.LVCT", locale),
+            "DACT" => DiceTable::Table.from_i18n("Amadeus.table.DACT", locale),
+            "RGT" => DiceTable::Table.from_i18n("Amadeus.table.RGT", locale),
+            "FBT" => DiceTable::Table.from_i18n("Amadeus.table.FBT", locale),
+            "CHVT" => DiceTable::Table.from_i18n("Amadeus.table.CHVT", locale),
+            "LCVT" => DiceTable::Table.from_i18n("Amadeus.table.LCVT", locale),
+            "KCVT" => DiceTable::Table.from_i18n("Amadeus.table.KCVT", locale),
+            "SAT" => DiceTable::D66Table.from_i18n("Amadeus.table.SAT", locale),
+            "SMT" => DiceTable::D66Table.from_i18n("Amadeus.table.SMT", locale),
+          }
+        end
       end
 
       TABLES = translate_tables(:ja_jp)

--- a/lib/bcdice/game_system/Amadeus.rb
+++ b/lib/bcdice/game_system/Amadeus.rb
@@ -76,27 +76,29 @@ module BCDice
         diceText = diceList.join(",")
         specialText = (specialNum == 6 ? "" : "@#{specialNum}")
 
-        message = "(#{commandText}#{specialText}#{signOfInequality}#{targetText}) ＞ [#{diceText}]#{modifyText} ＞ "
         diceList = [diceList.min] if skillRank == "D"
-        is_loop = false
-        diceList.each do |dice|
-          if  is_loop
-            message += " / "
-          elsif diceList.length > 1
-            is_loop = true
-          end
-          achieve = dice + modify
-          result = check_success(achieve, dice, signOfInequality, target, specialNum)
-          if is_loop
-            inga_table = translate("Amadeus.inga_table")
-            inga = inga_table[dice - 1]
-            message += "#{achieve}_#{result}[#{dice}#{inga}]"
-          else
-            message += "#{achieve}_#{result}[#{dice}]"
-          end
-        end
+        available_inga = diceList.size > 1
+        inga_table = translate("Amadeus.inga_table")
 
-        return message
+        results =
+          diceList.map do |dice|
+            achieve = dice + modify
+            result = check_success(achieve, dice, signOfInequality, target, specialNum)
+            if available_inga
+              inga = inga_table[dice - 1]
+              "#{achieve}_#{result}[#{dice}#{inga}]"
+            else
+              "#{achieve}_#{result}[#{dice}]"
+            end
+          end
+
+        sequence = [
+          "(#{commandText}#{specialText}#{signOfInequality}#{targetText})",
+          "[#{diceText}]#{modifyText}",
+          results.join(" / ")
+        ]
+
+        return sequence.join(" ＞ ")
       end
 
       def check_success(total_n, dice_n, signOfInequality, diff, special_n)

--- a/test/data/Amadeus.toml
+++ b/test/data/Amadeus.toml
@@ -2,6 +2,7 @@
 game_system = "Amadeus"
 input = "RC>=5"
 output = "(RC>=5) ＞ [5] ＞ 5_成功[5]"
+success = true
 rands = [
   { sides = 6, value = 5 },
 ]
@@ -10,6 +11,7 @@ rands = [
 game_system = "Amadeus"
 input = "RC"
 output = "(RC>=4) ＞ [5] ＞ 5_成功[5]"
+success = true
 rands = [
   { sides = 6, value = 5 },
 ]
@@ -18,6 +20,7 @@ rands = [
 game_system = "Amadeus"
 input = "RC"
 output = "(RC>=4) ＞ [2] ＞ 2_失敗[2]"
+failure = true
 rands = [
   { sides = 6, value = 2 },
 ]
@@ -26,6 +29,7 @@ rands = [
 game_system = "Amadeus"
 input = "RC+2"
 output = "(RC+2>=4) ＞ [2]+2 ＞ 4_成功[2]"
+success = true
 rands = [
   { sides = 6, value = 2 },
 ]
@@ -34,6 +38,7 @@ rands = [
 game_system = "Amadeus"
 input = "RC-3"
 output = "(RC-3>=4) ＞ [2]-3 ＞ -1_失敗[2]"
+failure = true
 rands = [
   { sides = 6, value = 2 },
 ]
@@ -42,6 +47,7 @@ rands = [
 game_system = "Amadeus"
 input = "RC-3+2"
 output = "(RC-1>=4) ＞ [2]-1 ＞ 1_失敗[2]"
+failure = true
 rands = [
   { sides = 6, value = 2 },
 ]
@@ -50,6 +56,7 @@ rands = [
 game_system = "Amadeus"
 input = "RC>=5-1"
 output = "(RC>=4) ＞ [5] ＞ 5_成功[5]"
+success = true
 rands = [
   { sides = 6, value = 5 },
 ]
@@ -58,6 +65,7 @@ rands = [
 game_system = "Amadeus"
 input = "RC>=5-2 hogehoge"
 output = "(RC>=3) ＞ [5] ＞ 5_成功[5]"
+success = true
 rands = [
   { sides = 6, value = 5 },
 ]
@@ -66,6 +74,7 @@ rands = [
 game_system = "Amadeus"
 input = "RB+1>=5"
 output = "(RB+1>=5) ＞ [2,4]+1 ＞ 3_失敗[2赤] / 5_成功[4緑]"
+success = true
 rands = [
   { sides = 6, value = 2 },
   { sides = 6, value = 4 },
@@ -73,8 +82,20 @@ rands = [
 
 [[ test ]]
 game_system = "Amadeus"
+input = "RB+2 ファンブルかつ成功のときはsuccessのみ"
+output = "(RB+2>=4) ＞ [1,2]+2 ＞ 3_ファンブル！[1黒] / 4_成功[2赤]"
+success = true
+rands = [
+  { sides = 6, value = 1 },
+  { sides = 6, value = 2 },
+]
+
+[[ test ]]
+game_system = "Amadeus"
 input = "RA-1"
 output = "(RA-1>=4) ＞ [1,5,6]-1 ＞ 0_ファンブル！[1黒] / 4_成功[5白] / 5_スペシャル！[6任意]"
+success = true
+critical = true
 rands = [
   { sides = 6, value = 1 },
   { sides = 6, value = 5 },
@@ -85,6 +106,8 @@ rands = [
 game_system = "Amadeus"
 input = "RS"
 output = "(RS>=4) ＞ [2,1,5,6] ＞ 2_失敗[2赤] / 1_ファンブル！[1黒] / 5_成功[5白] / 6_スペシャル！[6任意]"
+success = true
+critical = true
 rands = [
   { sides = 6, value = 2 },
   { sides = 6, value = 1 },
@@ -96,6 +119,7 @@ rands = [
 game_system = "Amadeus"
 input = "RD+1>=5"
 output = "(RD+1>=5) ＞ [2,4]+1 ＞ 3_失敗[2]"
+failure = true
 rands = [
   { sides = 6, value = 2 },
   { sides = 6, value = 4 },
@@ -105,6 +129,8 @@ rands = [
 game_system = "Amadeus"
 input = "RB@5"
 output = "(RB@5>=4) ＞ [2,5] ＞ 2_失敗[2赤] / 5_スペシャル！[5白]"
+success = true
+critical = true
 rands = [
   { sides = 6, value = 2 },
   { sides = 6, value = 5 },
@@ -114,6 +140,8 @@ rands = [
 game_system = "Amadeus"
 input = "RB+2@5"
 output = "(RB+2@5>=4) ＞ [2,5]+2 ＞ 4_成功[2赤] / 7_スペシャル！[5白]"
+success = true
+critical = true
 rands = [
   { sides = 6, value = 2 },
   { sides = 6, value = 5 },
@@ -123,6 +151,8 @@ rands = [
 game_system = "Amadeus"
 input = "RB+2@5>=5"
 output = "(RB+2@5>=5) ＞ [2,5]+2 ＞ 4_失敗[2赤] / 7_スペシャル！[5白]"
+success = true
+critical = true
 rands = [
   { sides = 6, value = 2 },
   { sides = 6, value = 5 },
@@ -132,6 +162,8 @@ rands = [
 game_system = "Amadeus"
 input = "RB+2>=5@5"
 output = "(RB+2@5>=5) ＞ [2,5]+2 ＞ 4_失敗[2赤] / 7_スペシャル！[5白]"
+success = true
+critical = true
 rands = [
   { sides = 6, value = 2 },
   { sides = 6, value = 5 },
@@ -667,6 +699,7 @@ rands = [
 game_system = "Amadeus"
 input = "RB+1>3 不要な機能だけど一応実装してみる。"
 output = "(RB+1>3) ＞ [2,4]+1 ＞ 3_失敗[2赤] / 5_成功[4緑]"
+success = true
 rands = [
   { sides = 6, value = 2 },
   { sides = 6, value = 4 },

--- a/test/data/Amadeus.toml
+++ b/test/data/Amadeus.toml
@@ -41,7 +41,7 @@ rands = [
 [[ test ]]
 game_system = "Amadeus"
 input = "RC-3+2"
-output = "(RC-3+2>=4) ＞ [2]-3+2 ＞ 1_失敗[2]"
+output = "(RC-1>=4) ＞ [2]-1 ＞ 1_失敗[2]"
 rands = [
   { sides = 6, value = 2 },
 ]
@@ -49,7 +49,7 @@ rands = [
 [[ test ]]
 game_system = "Amadeus"
 input = "RC>=5-1"
-output = "(RC>=5-1) ＞ [5] ＞ 5_成功[5]"
+output = "(RC>=4) ＞ [5] ＞ 5_成功[5]"
 rands = [
   { sides = 6, value = 5 },
 ]
@@ -57,7 +57,7 @@ rands = [
 [[ test ]]
 game_system = "Amadeus"
 input = "RC>=5-2 hogehoge"
-output = "(RC>=5-2) ＞ [5] ＞ 5_成功[5]"
+output = "(RC>=3) ＞ [5] ＞ 5_成功[5]"
 rands = [
   { sides = 6, value = 5 },
 ]

--- a/test/data/Amadeus_Korean.toml
+++ b/test/data/Amadeus_Korean.toml
@@ -41,7 +41,7 @@ rands = [
 [[ test ]]
 game_system = "Amadeus:Korean"
 input = "RC-3+2"
-output = "(RC-3+2>=4) ＞ [2]-3+2 ＞ 1_실패[2]"
+output = "(RC-1>=4) ＞ [2]-1 ＞ 1_실패[2]"
 rands = [
   { sides = 6, value = 2 },
 ]
@@ -49,7 +49,7 @@ rands = [
 [[ test ]]
 game_system = "Amadeus:Korean"
 input = "RC>=5-1"
-output = "(RC>=5-1) ＞ [5] ＞ 5_성공[5]"
+output = "(RC>=4) ＞ [5] ＞ 5_성공[5]"
 rands = [
   { sides = 6, value = 5 },
 ]
@@ -57,7 +57,7 @@ rands = [
 [[ test ]]
 game_system = "Amadeus:Korean"
 input = "RC>=5-2 hogehoge"
-output = "(RC>=5-2) ＞ [5] ＞ 5_성공[5]"
+output = "(RC>=3) ＞ [5] ＞ 5_성공[5]"
 rands = [
   { sides = 6, value = 5 },
 ]

--- a/test/data/Amadeus_Korean.toml
+++ b/test/data/Amadeus_Korean.toml
@@ -2,6 +2,7 @@
 game_system = "Amadeus:Korean"
 input = "RC>=5"
 output = "(RC>=5) ＞ [5] ＞ 5_성공[5]"
+success = true
 rands = [
   { sides = 6, value = 5 },
 ]
@@ -10,6 +11,7 @@ rands = [
 game_system = "Amadeus:Korean"
 input = "RC"
 output = "(RC>=4) ＞ [5] ＞ 5_성공[5]"
+success = true
 rands = [
   { sides = 6, value = 5 },
 ]
@@ -18,6 +20,7 @@ rands = [
 game_system = "Amadeus:Korean"
 input = "RC"
 output = "(RC>=4) ＞ [2] ＞ 2_실패[2]"
+failure = true
 rands = [
   { sides = 6, value = 2 },
 ]
@@ -26,6 +29,7 @@ rands = [
 game_system = "Amadeus:Korean"
 input = "RC+2"
 output = "(RC+2>=4) ＞ [2]+2 ＞ 4_성공[2]"
+success = true
 rands = [
   { sides = 6, value = 2 },
 ]
@@ -34,6 +38,7 @@ rands = [
 game_system = "Amadeus:Korean"
 input = "RC-3"
 output = "(RC-3>=4) ＞ [2]-3 ＞ -1_실패[2]"
+failure = true
 rands = [
   { sides = 6, value = 2 },
 ]
@@ -42,6 +47,7 @@ rands = [
 game_system = "Amadeus:Korean"
 input = "RC-3+2"
 output = "(RC-1>=4) ＞ [2]-1 ＞ 1_실패[2]"
+failure = true
 rands = [
   { sides = 6, value = 2 },
 ]
@@ -50,6 +56,7 @@ rands = [
 game_system = "Amadeus:Korean"
 input = "RC>=5-1"
 output = "(RC>=4) ＞ [5] ＞ 5_성공[5]"
+success = true
 rands = [
   { sides = 6, value = 5 },
 ]
@@ -58,6 +65,7 @@ rands = [
 game_system = "Amadeus:Korean"
 input = "RC>=5-2 hogehoge"
 output = "(RC>=3) ＞ [5] ＞ 5_성공[5]"
+success = true
 rands = [
   { sides = 6, value = 5 },
 ]
@@ -66,6 +74,7 @@ rands = [
 game_system = "Amadeus:Korean"
 input = "RB+1>=5"
 output = "(RB+1>=5) ＞ [2,4]+1 ＞ 3_실패[2적] / 5_성공[4녹]"
+success = true
 rands = [
   { sides = 6, value = 2 },
   { sides = 6, value = 4 },
@@ -75,6 +84,8 @@ rands = [
 game_system = "Amadeus:Korean"
 input = "RA-1"
 output = "(RA-1>=4) ＞ [1,5,6]-1 ＞ 0_펌블！[1흑] / 4_성공[5백] / 5_스페셜！[6임의]"
+success = true
+critical = true
 rands = [
   { sides = 6, value = 1 },
   { sides = 6, value = 5 },
@@ -85,6 +96,8 @@ rands = [
 game_system = "Amadeus:Korean"
 input = "RS"
 output = "(RS>=4) ＞ [2,1,5,6] ＞ 2_실패[2적] / 1_펌블！[1흑] / 5_성공[5백] / 6_스페셜！[6임의]"
+success = true
+critical = true
 rands = [
   { sides = 6, value = 2 },
   { sides = 6, value = 1 },
@@ -96,6 +109,7 @@ rands = [
 game_system = "Amadeus:Korean"
 input = "RD+1>=5"
 output = "(RD+1>=5) ＞ [2,4]+1 ＞ 3_실패[2]"
+failure = true
 rands = [
   { sides = 6, value = 2 },
   { sides = 6, value = 4 },
@@ -105,6 +119,8 @@ rands = [
 game_system = "Amadeus:Korean"
 input = "RB@5"
 output = "(RB@5>=4) ＞ [2,5] ＞ 2_실패[2적] / 5_스페셜！[5백]"
+success = true
+critical = true
 rands = [
   { sides = 6, value = 2 },
   { sides = 6, value = 5 },
@@ -114,6 +130,8 @@ rands = [
 game_system = "Amadeus:Korean"
 input = "RB+2@5"
 output = "(RB+2@5>=4) ＞ [2,5]+2 ＞ 4_성공[2적] / 7_스페셜！[5백]"
+success = true
+critical = true
 rands = [
   { sides = 6, value = 2 },
   { sides = 6, value = 5 },
@@ -123,6 +141,8 @@ rands = [
 game_system = "Amadeus:Korean"
 input = "RB+2@5>=5"
 output = "(RB+2@5>=5) ＞ [2,5]+2 ＞ 4_실패[2적] / 7_스페셜！[5백]"
+success = true
+critical = true
 rands = [
   { sides = 6, value = 2 },
   { sides = 6, value = 5 },
@@ -132,6 +152,8 @@ rands = [
 game_system = "Amadeus:Korean"
 input = "RB+2>=5@5"
 output = "(RB+2@5>=5) ＞ [2,5]+2 ＞ 4_실패[2적] / 7_스페셜！[5백]"
+success = true
+critical = true
 rands = [
   { sides = 6, value = 2 },
   { sides = 6, value = 5 },
@@ -363,6 +385,7 @@ rands = [
 game_system = "Amadeus:Korean"
 input = "RB+1>3 不要な機能だけど一応実装してみる。"
 output = "(RB+1>3) ＞ [2,4]+1 ＞ 3_실패[2적] / 5_성공[4녹]"
+success = true
 rands = [
   { sides = 6, value = 2 },
   { sides = 6, value = 4 },

--- a/test/data/Amadeus_Korean.toml
+++ b/test/data/Amadeus_Korean.toml
@@ -82,6 +82,16 @@ rands = [
 
 [[ test ]]
 game_system = "Amadeus:Korean"
+input = "RB+2 ファンブルかつ成功のときはsuccessのみ"
+output = "(RB+2>=4) ＞ [1,2]+2 ＞ 3_펌블！[1흑] / 4_성공[2적]"
+success = true
+rands = [
+  { sides = 6, value = 1 },
+  { sides = 6, value = 2 },
+]
+
+[[ test ]]
+game_system = "Amadeus:Korean"
 input = "RA-1"
 output = "(RA-1>=4) ＞ [1,5,6]-1 ＞ 0_펌블！[1흑] / 4_성공[5백] / 5_스페셜！[6임의]"
 success = true
@@ -383,6 +393,310 @@ rands = [
 
 [[ test ]]
 game_system = "Amadeus:Korean"
+input = "CST"
+output = "制約表(1) ＞ 短命"
+rands = [
+  { sides = 6, value = 1 },
+]
+
+[[ test ]]
+game_system = "Amadeus:Korean"
+input = "CST"
+output = "制約表(5) ＞ 喧嘩"
+rands = [
+  { sides = 6, value = 5 },
+]
+
+[[ test ]]
+game_system = "Amadeus:Korean"
+input = "GCVT"
+output = "ギリシャ神群試練表(2) ＞ 水音に目を向けると、アルテミスが泉で水浴びをしていた。美しい……あ、気づかれた？自分が男性なら、「重傷2」の変調を受ける。自分が女性なら、「恥辱」の変調を受ける。"
+rands = [
+  { sides = 6, value = 2 },
+]
+
+[[ test ]]
+game_system = "Amadeus:Korean"
+input = "GCVT"
+output = "ギリシャ神群試練表(6) ＞ 「あなた最近、調子に乗ってない？」アフロディーテに難癖をつけられた。「自分のことだけ見てればいいんじゃない？」鏡に映る自分が、とても美しく思えてきた。自分への【想い】が2点上昇し、それ以外の人物欄のパトスすべてにチェックを入れる。"
+rands = [
+  { sides = 6, value = 6 },
+]
+
+[[ test ]]
+game_system = "Amadeus:Korean"
+input = "YCVT"
+output = "ヤマト神群試練表(1) ＞ 空が急に暗くなる。太陽がどこにも見えない。もしかして、アマテラスが隠れてしまったのか？黒の領域にインガを一つ配置する。"
+rands = [
+  { sides = 6, value = 1 },
+]
+
+[[ test ]]
+game_system = "Amadeus:Korean"
+input = "YCVT"
+output = "ヤマト神群試練表(6) ＞ 海岸でいじめられている亀を助けたら、海の中の宮殿につれてきてくれた。トヨタマヒメが現れ、盛大にもてなしてくれる。あっという間に、夢のような時間が過ぎていく。でも、そろそろ行かなくては。【日常】で判定する。失敗すると、自分の年齢を6D6歳増やし、「絶望」の変調を受ける。"
+rands = [
+  { sides = 6, value = 6 },
+]
+
+[[ test ]]
+game_system = "Amadeus:Korean"
+input = "ECVT"
+output = "エジプト神群試練表(1) ＞ 大蛇アペプが今にも目の前の空で輝く太陽を、飲み込もうとしている！止めなくては！【武勇】で判定する。失敗すると、黒の領域にインガを二つ配置する。"
+rands = [
+  { sides = 6, value = 1 },
+]
+
+[[ test ]]
+game_system = "Amadeus:Korean"
+input = "ECVT"
+output = "エジプト神群試練表(6) ＞ 獅子頭の神、シェセムが、悪人の頭を砕いて、死者のためのワインにしている。悪人と見なされれば、頭をもがれてしまうだろう。【日常】で判定を行う。失敗すると、「重傷2」の変調を受ける。"
+rands = [
+  { sides = 6, value = 6 },
+]
+
+[[ test ]]
+game_system = "Amadeus:Korean"
+input = "CCVT"
+output = "クトゥルフ神群試練表(1) ＞ 新聞記者たちが忙しく行き来しているオフィスにいる。ここは、新聞社アーカムアドバタイザーの編集部だ。「君が大きなニュースを持っていると聞いたんだけれど」記者の一人が尋ねてくる。自分の【真実】が公開されていなければ、「臆病1」の変調を受ける。"
+rands = [
+  { sides = 6, value = 1 },
+]
+
+[[ test ]]
+game_system = "Amadeus:Korean"
+input = "CCVT"
+output = "クトゥルフ神群試練表(6) ＞ なんの変哲も無い民家にいる。アーカムの静かな風景が……ああ、窓に！窓に！黒の領域にインガを一つ配置する。"
+rands = [
+  { sides = 6, value = 6 },
+]
+
+[[ test ]]
+game_system = "Amadeus:Korean"
+input = "NCVT"
+output = "北欧神群試練表(1) ＞ 美しい乙女が告げる。「あなたはエインヘリアルたる資格がある」どうやら、戦乙女ヴァルキュリャに見初められたらしい。彼女たちは、戦死した者の魂を連れていくのだが。自分は、戦乙女から【想い】を2点獲得する。この【想い】の関係はマイナスの「殺意」となる。"
+rands = [
+  { sides = 6, value = 1 },
+]
+
+[[ test ]]
+game_system = "Amadeus:Korean"
+input = "NCVT"
+output = "北欧神群試練表(6) ＞ 巨人が話し掛けてくる。「お前に力をやってもいい。代わりに、片目か、片腕をよこせ」オーディンは片目を差し出して、知恵を手に入れた。嘘ではないだろうが……。【生命力】を3D6点減少することで、好きな領域にインガを二つ配置できる。減少しなかった場合、「臆病1」の変調を受ける。"
+rands = [
+  { sides = 6, value = 6 },
+]
+
+[[ test ]]
+game_system = "Amadeus:Korean"
+input = "DGVT"
+output = "ダンジョン試練表(1) ＞ 照明が切れてしまい、暗闇の中に放り出される。前が見えない。白の領域からインガを一つ取り除く。"
+rands = [
+  { sides = 6, value = 1 },
+]
+
+[[ test ]]
+game_system = "Amadeus:Korean"
+input = "DGVT"
+output = "ダンジョン試練表(6) ＞ 怪物たちのすみかに迷い込んでしまったようだ。怪物が一斉に襲ってくる！【武勇】で判定を行う。失敗すると、2D6点のダメージを受ける。"
+rands = [
+  { sides = 6, value = 6 },
+]
+
+[[ test ]]
+game_system = "Amadeus:Korean"
+input = "DAVT"
+output = "日常試練表(1) ＞ 仲間と移動していると、一般人の友達と偶然出会ってしまう。今何をしているかを聞かれたので、なんとかごまかす。自分に対して【想い】の値を持っているPC全員の属性が反転する。"
+rands = [
+  { sides = 6, value = 1 },
+]
+
+[[ test ]]
+game_system = "Amadeus:Korean"
+input = "DAVT"
+output = "日常試練表(6) ＞ 乗りたかった電車やバスに乗り遅れる。仕方ないから、走るか。移動判定を行う。失敗すると、「堕落」の変調を受け、もう一度「試練表」を使用する。"
+rands = [
+  { sides = 6, value = 6 },
+]
+
+[[ test ]]
+game_system = "Amadeus:Korean"
+input = "PRCT"
+output = "挑戦テーマ表【武勇】(1) ＞ 腕相撲"
+rands = [
+  { sides = 6, value = 1 },
+]
+
+[[ test ]]
+game_system = "Amadeus:Korean"
+input = "PRCT"
+output = "挑戦テーマ表【武勇】(6) ＞ 武勇伝自慢"
+rands = [
+  { sides = 6, value = 6 },
+]
+
+[[ test ]]
+game_system = "Amadeus:Korean"
+input = "TCCT"
+output = "挑戦テーマ表【技術】(1) ＞ 織物"
+rands = [
+  { sides = 6, value = 1 },
+]
+
+[[ test ]]
+game_system = "Amadeus:Korean"
+input = "TCCT"
+output = "挑戦テーマ表【技術】(6) ＞ 資格自慢"
+rands = [
+  { sides = 6, value = 6 },
+]
+
+[[ test ]]
+game_system = "Amadeus:Korean"
+input = "INCT"
+output = "挑戦テーマ表【頭脳】(1) ＞ パズル"
+rands = [
+  { sides = 6, value = 1 },
+]
+
+[[ test ]]
+game_system = "Amadeus:Korean"
+input = "INCT"
+output = "挑戦テーマ表【頭脳】(6) ＞ 学歴自慢"
+rands = [
+  { sides = 6, value = 6 },
+]
+
+[[ test ]]
+game_system = "Amadeus:Korean"
+input = "PSCT"
+output = "挑戦テーマ表【霊力】(1) ＞ 詩作"
+rands = [
+  { sides = 6, value = 1 },
+]
+
+[[ test ]]
+game_system = "Amadeus:Korean"
+input = "PSCT"
+output = "挑戦テーマ表【霊力】(6) ＞ のど自慢"
+rands = [
+  { sides = 6, value = 6 },
+]
+
+[[ test ]]
+game_system = "Amadeus:Korean"
+input = "LVCT"
+output = "挑戦テーマ表【愛】(1) ＞ ナンパ勝負"
+rands = [
+  { sides = 6, value = 1 },
+]
+
+[[ test ]]
+game_system = "Amadeus:Korean"
+input = "LVCT"
+output = "挑戦テーマ表【愛】(6) ＞ 恋愛自慢"
+rands = [
+  { sides = 6, value = 6 },
+]
+
+[[ test ]]
+game_system = "Amadeus:Korean"
+input = "DACT"
+output = "挑戦テーマ表【日常】(1) ＞ 料理"
+rands = [
+  { sides = 6, value = 1 },
+]
+
+[[ test ]]
+game_system = "Amadeus:Korean"
+input = "DACT"
+output = "挑戦テーマ表【日常】(6) ＞ リア充自慢"
+rands = [
+  { sides = 6, value = 6 },
+]
+
+[[ test ]]
+game_system = "Amadeus:Korean"
+input = "RGT"
+output = "ランダムギフト表(1) ＞ ランダムに選んだPCと同じ親神の親神ギフトの中から選ぶ。"
+rands = [
+  { sides = 6, value = 1 },
+]
+
+[[ test ]]
+game_system = "Amadeus:Korean"
+input = "RGT"
+output = "ランダムギフト表(6) ＞ 好きな汎用ギフトの中から選ぶ。"
+rands = [
+  { sides = 6, value = 6 },
+]
+
+[[ test ]]
+game_system = "Amadeus:Korean"
+input = "FBT"
+output = "決戦戦果表(1) ＞ 1D6枚の神貨を獲得する。"
+rands = [
+  { sides = 6, value = 1 },
+]
+
+[[ test ]]
+game_system = "Amadeus:Korean"
+input = "FBT"
+output = "決戦戦果表(6) ＞ 「ランダムアイテム表」で、アイテムを入手できる。"
+rands = [
+  { sides = 6, value = 6 },
+]
+
+[[ test ]]
+game_system = "Amadeus:Korean"
+input = "CHVT"
+output = "中華神群試練表(1) ＞ たどりついた場所は、桃源郷であった。すべてを忘れて、しばらく楽しんでしまう。年齢が2D6点上昇し、「堕落」の変調を受ける。"
+rands = [
+  { sides = 6, value = 1 },
+]
+
+[[ test ]]
+game_system = "Amadeus:Korean"
+input = "CHVT"
+output = "中華神群試練表(6) ＞ 麒麟の死骸を発見してしまう。これは、不吉の前触れだ。黒の領域にインガを一つ配置する。"
+rands = [
+  { sides = 6, value = 6 },
+]
+
+[[ test ]]
+game_system = "Amadeus:Korean"
+input = "LCVT"
+output = "ラストクロニクル神群試練表(1) ＞ レ・ムゥの五色の太陽がすべて輝きを失う「千年夜」の到来を幻視する。これは起こりうる未来なのだろうか……。黒の領域にインガを1つ配置する。"
+rands = [
+  { sides = 6, value = 1 },
+]
+
+[[ test ]]
+game_system = "Amadeus:Korean"
+input = "LCVT"
+output = "ラストクロニクル神群試練表(6) ＞ 放浪の勇者・アルマイルから挨拶代わりの一撃を受ける。1D6点ダメージを受け、アルマイルからの【想い】が1点上昇する。"
+rands = [
+  { sides = 6, value = 6 },
+]
+
+[[ test ]]
+game_system = "Amadeus:Korean"
+input = "KCVT"
+output = "ケルト神群試練表(1) ＞ 怪物が奏でる銀の竪琴の音色が聞こえてきて、しばらくの間、眠ってしまう。眠っている間に、妖精たちに悪戯された。「恥辱」の変調を受け、アイテムを一つ選んで失う。"
+rands = [
+  { sides = 6, value = 1 },
+]
+
+[[ test ]]
+game_system = "Amadeus:Korean"
+input = "KCVT"
+output = "ケルト神群試練表(6) ＞ 道案内をしてくれた美女にそそのかされて、女人の国にたどりついてしまう。誘惑に耐えながら、なんとか脱出する。「堕落」と「臆病2」の変調を受ける。"
+rands = [
+  { sides = 6, value = 6 },
+]
+
+[[ test ]]
+game_system = "Amadeus:Korean"
 input = "RB+1>3 不要な機能だけど一応実装してみる。"
 output = "(RB+1>3) ＞ [2,4]+1 ＞ 3_실패[2적] / 5_성공[4녹]"
 success = true
@@ -392,199 +706,7 @@ rands = [
 ]
 
 [[ test ]]
-game_system = "Amadeus"
-input = "GCVT"
-output = "ギリシャ神群試練表(2) ＞ 水音に目を向けると、アルテミスが泉で水浴びをしていた。美しい……あ、気づかれた？自分が男性なら、「重傷2」の変調を受ける。自分が女性なら、「恥辱」の変調を受ける。"
-rands = [
-  { sides = 6, value = 2 },
-]
-
-[[ test ]]
-game_system = "Amadeus"
-input = "GCVT"
-output = "ギリシャ神群試練表(6) ＞ 「あなた最近、調子に乗ってない？」アフロディーテに難癖をつけられた。「自分のことだけ見てればいいんじゃない？」鏡に映る自分が、とても美しく思えてきた。自分への【想い】が2点上昇し、それ以外の人物欄のパトスすべてにチェックを入れる。"
-rands = [
-  { sides = 6, value = 6 },
-]
-
-[[ test ]]
-game_system = "Amadeus"
-input = "YCVT"
-output = "ヤマト神群試練表(1) ＞ 空が急に暗くなる。太陽がどこにも見えない。もしかして、アマテラスが隠れてしまったのか？黒の領域にインガを一つ配置する。"
-rands = [
-  { sides = 6, value = 1 },
-]
-
-[[ test ]]
-game_system = "Amadeus"
-input = "YCVT"
-output = "ヤマト神群試練表(6) ＞ 海岸でいじめられている亀を助けたら、海の中の宮殿につれてきてくれた。トヨタマヒメが現れ、盛大にもてなしてくれる。あっという間に、夢のような時間が過ぎていく。でも、そろそろ行かなくては。【日常】で判定する。失敗すると、自分の年齢を6D6歳増やし、「絶望」の変調を受ける。"
-rands = [
-  { sides = 6, value = 6 },
-]
-
-[[ test ]]
-game_system = "Amadeus"
-input = "ECVT"
-output = "エジプト神群試練表(1) ＞ 大蛇アペプが今にも目の前の空で輝く太陽を、飲み込もうとしている！止めなくては！【武勇】で判定する。失敗すると、黒の領域にインガを二つ配置する。"
-rands = [
-  { sides = 6, value = 1 },
-]
-
-[[ test ]]
-game_system = "Amadeus"
-input = "ECVT"
-output = "エジプト神群試練表(6) ＞ 獅子頭の神、シェセムが、悪人の頭を砕いて、死者のためのワインにしている。悪人と見なされれば、頭をもがれてしまうだろう。【日常】で判定を行う。失敗すると、「重傷2」の変調を受ける。"
-rands = [
-  { sides = 6, value = 6 },
-]
-
-[[ test ]]
-game_system = "Amadeus"
-input = "CCVT"
-output = "クトゥルフ神群試練表(1) ＞ 新聞記者たちが忙しく行き来しているオフィスにいる。ここは、新聞社アーカムアドバタイザーの編集部だ。「君が大きなニュースを持っていると聞いたんだけれど」記者の一人が尋ねてくる。自分の【真実】が公開されていなければ、「臆病1」の変調を受ける。"
-rands = [
-  { sides = 6, value = 1 },
-]
-
-[[ test ]]
-game_system = "Amadeus"
-input = "CCVT"
-output = "クトゥルフ神群試練表(6) ＞ なんの変哲も無い民家にいる。アーカムの静かな風景が……ああ、窓に！窓に！黒の領域にインガを一つ配置する。"
-rands = [
-  { sides = 6, value = 6 },
-]
-
-[[ test ]]
-game_system = "Amadeus"
-input = "NCVT"
-output = "北欧神群試練表(1) ＞ 美しい乙女が告げる。「あなたはエインヘリアルたる資格がある」どうやら、戦乙女ヴァルキュリャに見初められたらしい。彼女たちは、戦死した者の魂を連れていくのだが。自分は、戦乙女から【想い】を2点獲得する。この【想い】の関係はマイナスの「殺意」となる。"
-rands = [
-  { sides = 6, value = 1 },
-]
-
-[[ test ]]
-game_system = "Amadeus"
-input = "NCVT"
-output = "北欧神群試練表(6) ＞ 巨人が話し掛けてくる。「お前に力をやってもいい。代わりに、片目か、片腕をよこせ」オーディンは片目を差し出して、知恵を手に入れた。嘘ではないだろうが……。【生命力】を3D6点減少することで、好きな領域にインガを二つ配置できる。減少しなかった場合、「臆病1」の変調を受ける。"
-rands = [
-  { sides = 6, value = 6 },
-]
-
-[[ test ]]
-game_system = "Amadeus"
-input = "DGVT"
-output = "ダンジョン試練表(1) ＞ 照明が切れてしまい、暗闇の中に放り出される。前が見えない。白の領域からインガを一つ取り除く。"
-rands = [
-  { sides = 6, value = 1 },
-]
-
-[[ test ]]
-game_system = "Amadeus"
-input = "DGVT"
-output = "ダンジョン試練表(6) ＞ 怪物たちのすみかに迷い込んでしまったようだ。怪物が一斉に襲ってくる！【武勇】で判定を行う。失敗すると、2D6点のダメージを受ける。"
-rands = [
-  { sides = 6, value = 6 },
-]
-
-[[ test ]]
-game_system = "Amadeus"
-input = "DAVT"
-output = "日常試練表(1) ＞ 仲間と移動していると、一般人の友達と偶然出会ってしまう。今何をしているかを聞かれたので、なんとかごまかす。自分に対して【想い】の値を持っているPC全員の属性が反転する。"
-rands = [
-  { sides = 6, value = 1 },
-]
-
-[[ test ]]
-game_system = "Amadeus"
-input = "DAVT"
-output = "日常試練表(6) ＞ 乗りたかった電車やバスに乗り遅れる。仕方ないから、走るか。移動判定を行う。失敗すると、「堕落」の変調を受け、もう一度「試練表」を使用する。"
-rands = [
-  { sides = 6, value = 6 },
-]
-
-[[ test ]]
-game_system = "Amadeus"
-input = "CHVT"
-output = "中華神群試練表(1) ＞ たどりついた場所は、桃源郷であった。すべてを忘れて、しばらく楽しんでしまう。年齢が2D6点上昇し、「堕落」の変調を受ける。"
-rands = [
-  { sides = 6, value = 1 },
-]
-
-[[ test ]]
-game_system = "Amadeus"
-input = "CHVT"
-output = "中華神群試練表(6) ＞ 麒麟の死骸を発見してしまう。これは、不吉の前触れだ。黒の領域にインガを一つ配置する。"
-rands = [
-  { sides = 6, value = 6 },
-]
-
-[[ test ]]
-game_system = "Amadeus"
-input = "LCVT"
-output = "ラストクロニクル神群試練表(1) ＞ レ・ムゥの五色の太陽がすべて輝きを失う「千年夜」の到来を幻視する。これは起こりうる未来なのだろうか……。黒の領域にインガを1つ配置する。"
-rands = [
-  { sides = 6, value = 1 },
-]
-
-[[ test ]]
-game_system = "Amadeus"
-input = "LCVT"
-output = "ラストクロニクル神群試練表(6) ＞ 放浪の勇者・アルマイルから挨拶代わりの一撃を受ける。1D6点ダメージを受け、アルマイルからの【想い】が1点上昇する。"
-rands = [
-  { sides = 6, value = 6 },
-]
-
-[[ test ]]
-game_system = "Amadeus"
-input = "KCVT"
-output = "ケルト神群試練表(1) ＞ 怪物が奏でる銀の竪琴の音色が聞こえてきて、しばらくの間、眠ってしまう。眠っている間に、妖精たちに悪戯された。「恥辱」の変調を受け、アイテムを一つ選んで失う。"
-rands = [
-  { sides = 6, value = 1 },
-]
-
-[[ test ]]
-game_system = "Amadeus"
-input = "KCVT"
-output = "ケルト神群試練表(6) ＞ 道案内をしてくれた美女にそそのかされて、女人の国にたどりついてしまう。誘惑に耐えながら、なんとか脱出する。「堕落」と「臆病2」の変調を受ける。"
-rands = [
-  { sides = 6, value = 6 },
-]
-
-[[ test ]]
-game_system = "Amadeus"
-input = "RGT"
-output = "ランダムギフト表(1) ＞ ランダムに選んだPCと同じ親神の親神ギフトの中から選ぶ。"
-rands = [
-  { sides = 6, value = 1 },
-]
-
-[[ test ]]
-game_system = "Amadeus"
-input = "RGT"
-output = "ランダムギフト表(6) ＞ 好きな汎用ギフトの中から選ぶ。"
-rands = [
-  { sides = 6, value = 6 },
-]
-
-[[ test ]]
-game_system = "Amadeus"
-input = "FBT"
-output = "決戦戦果表(1) ＞ 1D6枚の神貨を獲得する。"
-rands = [
-  { sides = 6, value = 1 },
-]
-
-[[ test ]]
-game_system = "Amadeus"
-input = "FBT"
-output = "決戦戦果表(6) ＞ 「ランダムアイテム表」で、アイテムを入手できる。"
-rands = [
-  { sides = 6, value = 6 },
-]
-
-[[ test ]]
-game_system = "Amadeus"
+game_system = "Amadeus:Korean"
 input = "SAT"
 output = "店内雰囲気表(12) ＞ 煙草の煙がたゆたうセルフ式コーヒーチェーン店"
 rands = [
@@ -593,7 +715,7 @@ rands = [
 ]
 
 [[ test ]]
-game_system = "Amadeus"
+game_system = "Amadeus:Korean"
 input = "SAT"
 output = "店内雰囲気表(55) ＞ ショッピングモールのフードコート内にある出店"
 rands = [
@@ -602,7 +724,7 @@ rands = [
 ]
 
 [[ test ]]
-game_system = "Amadeus"
+game_system = "Amadeus:Korean"
 input = "SMT"
 output = "特殊メニュー表(11) ＞ アド・パトレス（ケルト）"
 rands = [
@@ -611,7 +733,7 @@ rands = [
 ]
 
 [[ test ]]
-game_system = "Amadeus"
+game_system = "Amadeus:Korean"
 input = "SMT"
 output = "特殊メニュー表(46) ＞ ジヴァヤ・ヴォジャ（スラブ）"
 rands = [


### PR DESCRIPTION
#423 Amadeus, Amadeus:Korean

# 対象
アマデウスでの能力値判定では複数個のダイスを振り、そのうちの1つを選択して判定に用いる。
そのため、コマンドの結果にはそれぞれのダイスの成功/失敗/スペシャル/ファンブルが示されている

# 方針
複数個のダイスを振った場合、success/failure/critical/fumbleは次の順に判定する
1. スペシャルがある → `success` かつ `critical`
2. 1つ以上成功している → `success`
3. 成功が無い、かつ、ファンブル → `failure` かつ `fumble`
4. 上記以外 → `failure`

success/critical と failure/fumble が同時に `true` にならないようにしている