### PR TITLE
[ColossalHunter] Resultの使用

### DIFF
--- a/lib/bcdice/game_system/ColossalHunter.rb
+++ b/lib/bcdice/game_system/ColossalHunter.rb
@@ -68,35 +68,27 @@ module BCDice
         total = dice + modify
 
         # 出力文の生成
-        result = "(#{parsed}) ＞ #{dice}[#{dice_str}]#{Format.modifier(modify)} ＞ #{total}"
+        text = "(#{parsed}) ＞ #{dice}[#{dice_str}]#{Format.modifier(modify)} ＞ #{total}"
 
-        # クリティカル・ファンブルチェック
-        if isFamble(dice)
-          result += " ＞ ファンブル"
-        elsif isCritical(total)
-          result += " ＞ クリティカル"
-        else
-          result += getJudgeResultString(total, parsed)
-        end
+        result = get_judge_result(dice, total, parsed)
 
+        result.text = text + result.text
         return result
       end
 
       # 成否判定
-      def getJudgeResultString(total, parsed)
-        return '' if parsed.cmp_op.nil?
-
-        return " ＞ 成功" if total >= parsed.target_number
-
-        return " ＞ 失敗"
-      end
-
-      def isCritical(total)
-        (total >= 16)
-      end
-
-      def isFamble(total)
-        (total <= 5)
+      def get_judge_result(dice, total, parsed)
+        if dice <= 5
+          Result.fumble(" ＞ ファンブル")
+        elsif total >= 16
+          Result.critical(" ＞ クリティカル")
+        elsif parsed.cmp_op.nil?
+          Result.new("")
+        elsif total >= parsed.target_number
+          Result.success(" ＞ 成功")
+        else
+          Result.failure(" ＞ 失敗")
+        end
       end
 
       def getSourceSceneDiceCommandResult(command)

--- a/lib/bcdice/game_system/ColossalHunter.rb
+++ b/lib/bcdice/game_system/ColossalHunter.rb
@@ -16,10 +16,12 @@ module BCDice
 
       # ダイスボットの使い方
       HELP_MESSAGE = <<~MESSAGETEXT
-        ・判定（CH±x>=y)
-        　3D6の判定。クリティカル、ファンブルの自動判定を行います。
-        　x：修正値。省略可能。y：目標値。省略可能。
-        　例） CH　CH+1　CH+2>=10
+        ・判定（nCH±x>=y)
+        　nD6の判定。クリティカル、ファンブルの自動判定を行います。
+        　n：ダイス数。省略可能。省略した場合3。
+        　x：修正値。省略可能。
+        　y：目標値。省略可能。
+        　例） CH　CH+1　CH+2>=10　4CH+1
         ・BIG-6表(B6T)
         ・覚醒表(AWT)
         ・現状表(CST)
@@ -547,7 +549,7 @@ module BCDice
 
         }.freeze
 
-      register_prefix("CH.*", "B6T", "CNP", TABLES.keys)
+      register_prefix('\d*CH', "B6T", "CNP", TABLES.keys)
     end
   end
 end

--- a/test/data/ColossalHunter.toml
+++ b/test/data/ColossalHunter.toml
@@ -150,6 +150,19 @@ rands = [
 
 [[ test ]]
 game_system = "ColossalHunter"
+input = "4CH+1"
+output = "(4CH+1) ＞ 5[1,1,2,1]+1 ＞ 6 ＞ ファンブル"
+failure = true
+fumble = true
+rands = [
+  { sides = 6, value = 1 },
+  { sides = 6, value = 1 },
+  { sides = 6, value = 2 },
+  { sides = 6, value = 1 },
+]
+
+[[ test ]]
+game_system = "ColossalHunter"
 input = "B6T"
 output = "BIG-6表(11) ＞ この世の地獄：あれはまさに地獄。屍の山。嘆く者。呆然とする者。目の前で潰される者。あの日、人類は霊長ではなく……弱き獣の一種となった。 ＞ 年齢：15+2D6 ＞ (15+2) ＞ 年齢：17歳"
 rands = [

--- a/test/data/ColossalHunter.toml
+++ b/test/data/ColossalHunter.toml
@@ -12,6 +12,8 @@ rands = [
 game_system = "ColossalHunter"
 input = "CH"
 output = "(3CH) ＞ 16[6,5,5] ＞ 16 ＞ クリティカル"
+success = true
+critical = true
 rands = [
   { sides = 6, value = 6 },
   { sides = 6, value = 5 },
@@ -22,6 +24,8 @@ rands = [
 game_system = "ColossalHunter"
 input = "CH+1"
 output = "(3CH+1) ＞ 15[6,4,5]+1 ＞ 16 ＞ クリティカル"
+success = true
+critical = true
 rands = [
   { sides = 6, value = 6 },
   { sides = 6, value = 4 },
@@ -42,6 +46,8 @@ rands = [
 game_system = "ColossalHunter"
 input = "CH"
 output = "(3CH) ＞ 5[1,2,2] ＞ 5 ＞ ファンブル"
+failure = true
+fumble = true
 rands = [
   { sides = 6, value = 1 },
   { sides = 6, value = 2 },
@@ -52,6 +58,8 @@ rands = [
 game_system = "ColossalHunter"
 input = "CH+1"
 output = "(3CH+1) ＞ 5[1,2,2]+1 ＞ 6 ＞ ファンブル"
+failure = true
+fumble = true
 rands = [
   { sides = 6, value = 1 },
   { sides = 6, value = 2 },
@@ -62,6 +70,7 @@ rands = [
 game_system = "ColossalHunter"
 input = "CH>=18"
 output = "(3CH>=18) ＞ 15[6,4,5] ＞ 15 ＞ 失敗"
+failure = true
 rands = [
   { sides = 6, value = 6 },
   { sides = 6, value = 4 },
@@ -72,6 +81,8 @@ rands = [
 game_system = "ColossalHunter"
 input = "CH>=18"
 output = "(3CH>=18) ＞ 16[6,5,5] ＞ 16 ＞ クリティカル"
+success = true
+critical = true
 rands = [
   { sides = 6, value = 6 },
   { sides = 6, value = 5 },
@@ -82,6 +93,8 @@ rands = [
 game_system = "ColossalHunter"
 input = "CH+1>=18"
 output = "(3CH+1>=18) ＞ 15[6,4,5]+1 ＞ 16 ＞ クリティカル"
+success = true
+critical = true
 rands = [
   { sides = 6, value = 6 },
   { sides = 6, value = 4 },
@@ -92,6 +105,7 @@ rands = [
 game_system = "ColossalHunter"
 input = "CH>=3"
 output = "(3CH>=3) ＞ 6[1,2,3] ＞ 6 ＞ 成功"
+success = true
 rands = [
   { sides = 6, value = 1 },
   { sides = 6, value = 2 },
@@ -102,6 +116,8 @@ rands = [
 game_system = "ColossalHunter"
 input = "CH>=3"
 output = "(3CH>=3) ＞ 5[1,2,2] ＞ 5 ＞ ファンブル"
+failure = true
+fumble = true
 rands = [
   { sides = 6, value = 1 },
   { sides = 6, value = 2 },
@@ -112,6 +128,8 @@ rands = [
 game_system = "ColossalHunter"
 input = "CH+1>=3"
 output = "(3CH+1>=3) ＞ 5[1,2,2]+1 ＞ 6 ＞ ファンブル"
+failure = true
+fumble = true
 rands = [
   { sides = 6, value = 1 },
   { sides = 6, value = 2 },
@@ -122,6 +140,8 @@ rands = [
 game_system = "ColossalHunter"
 input = "CH+11>=3"
 output = "(3CH+11>=3) ＞ 5[1,2,2]+11 ＞ 16 ＞ ファンブル"
+failure = true
+fumble = true
 rands = [
   { sides = 6, value = 1 },
   { sides = 6, value = 2 },


### PR DESCRIPTION
#423 コロッサルハンターに対応

※`nCH`に対応してそうなロジックだったが、最初期から`prefix`の指定ミス？で利用できない状態だった。
https://github.com/bcdice/BCDice/blob/ffa352a7c8efc109fa1461a57a4e4b71d79ee1f3/src/diceBot/ColossalHunter.rb
攻撃判定のダイスを増やす能力が存在するため、使用できるように。