### PR TITLE
Command::Parserでコマンドの前後の数値をパースできるようにする

### DIFF
--- a/lib/bcdice/command/parsed.rb
+++ b/lib/bcdice/command/parsed.rb
@@ -7,6 +7,12 @@ module BCDice
       attr_accessor :command
 
       # @return [Integer, nil]
+      attr_accessor :prefix_number
+
+      # @return [Integer, nil]
+      attr_accessor :suffix_number
+
+      # @return [Integer, nil]
       attr_accessor :critical
 
       # @return [Integer, nil]
@@ -29,6 +35,8 @@ module BCDice
       attr_writer :question_target
 
       def initialize
+        @prefix_number = nil
+        @suffix_number = nil
         @critical = nil
         @fumble = nil
         @dollar = nil
@@ -53,11 +61,11 @@ module BCDice
 
         case suffix_position
         when :after_command
-          [@command, c, f, d, m, @cmp_op, target].join()
+          [@prefix_number, @command, @suffix_number, c, f, d, m, @cmp_op, target].join()
         when :after_modify_number
-          [@command, m, c, f, d, @cmp_op, target].join()
+          [@prefix_number, @command, @suffix_number, m, c, f, d, @cmp_op, target].join()
         when :after_target_number
-          [@command, m, @cmp_op, target, c, f, d].join()
+          [@prefix_number, @command, @suffix_number, m, @cmp_op, target, c, f, d].join()
         end
       end
     end

--- a/test/test_command_parser.rb
+++ b/test/test_command_parser.rb
@@ -162,4 +162,88 @@ class TestCommandParser < Test::Unit::TestCase
     assert_equal(:>=, parsed.cmp_op)
     assert_true(parsed.question_target?)
   end
+
+  def test_command_with_regexp
+    parser = BCDice::Command::Parser.new(/\d+ABC\d+/, round_type: BCDice::RoundType::FLOOR)
+    parsed = parser.parse("10ABC412>=40")
+
+    assert_equal("10ABC412", parsed.command)
+    assert_equal(:>=, parsed.cmp_op)
+    assert_equal(40, parsed.target_number)
+  end
+
+  def test_prefix_number
+    @parser.has_prefix_number
+    parsed = @parser.parse("2LL")
+
+    assert_equal("LL", parsed.command)
+    assert_equal(2, parsed.prefix_number)
+    assert_equal(nil, parsed.suffix_number)
+  end
+
+  def test_no_prefix_number
+    @parser.has_prefix_number
+    assert_nil(@parser.parse("LL"))
+    assert_nil(@parser.parse("LL6"))
+  end
+
+  def test_optional_prefix_number
+    @parser.enable_prefix_number
+
+    assert_equal(2, @parser.parse("2LL").prefix_number)
+    assert_equal(nil, @parser.parse("LL").prefix_number)
+  end
+
+  def test_suffix_number
+    @parser.has_suffix_number
+    parsed = @parser.parse("LL6")
+
+    assert_equal("LL", parsed.command)
+    assert_equal(nil, parsed.prefix_number)
+    assert_equal(6, parsed.suffix_number)
+  end
+
+  def test_no_suffix_number
+    @parser.has_suffix_number
+    assert_nil(@parser.parse("LL"))
+    assert_nil(@parser.parse("2LL"))
+  end
+
+  def test_optional_suffix_number
+    @parser.enable_suffix_number
+
+    assert_equal(10, @parser.parse("LL10").suffix_number)
+    assert_equal(nil, @parser.parse("LL").suffix_number)
+  end
+
+  def test_prefix_suffix_number
+    @parser.has_prefix_number
+           .has_suffix_number
+    parsed = @parser.parse("3LL10<=10+34")
+
+    assert_equal("LL", parsed.command)
+    assert_equal(3, parsed.prefix_number)
+    assert_equal(10, parsed.suffix_number)
+    assert_equal("3LL10<=44", parsed.to_s)
+  end
+
+  def test_no_prefix_suffix_number
+    @parser.has_prefix_number
+           .has_suffix_number
+
+    assert_nil(@parser.parse("LL"))
+    assert_nil(@parser.parse("4LL"))
+    assert_nil(@parser.parse("LL5"))
+  end
+
+  def test_prefix_suffix_number_with_regexp
+    parser = BCDice::Command::Parser.new(/[A-Z_]+/, round_type: BCDice::RoundType::FLOOR)
+                                    .has_prefix_number
+                                    .has_suffix_number
+    parsed = parser.parse("16N_B62")
+
+    assert_equal("N_B", parsed.command)
+    assert_equal(16, parsed.prefix_number)
+    assert_equal(62, parsed.suffix_number)
+  end
 end


### PR DESCRIPTION
`2NX13>=10` のようなコマンドをCommand::Parserで扱う際に `NX` の前後の数値を取得しやすいようにします。

## `Command::Parsed`の新しい要素
- `Parsed#prefix_number`
  - `Command::Parser#command`の直前にある数値
- `Parsed#suffix_number`
  - `Command::Parser#command`の直後にある数値

## `Command::Parse`の追加オプション
- `Parser#has_prefix_number`
  - prefix_numberがパースされることを**強制**する
- `Parser#has_suffix_number`
  - suffix_numberがパースされることを**強制**する
- `Parser#enable_prefix_number`
  - prefix_numberがパースされることを**許可**する
- `Parser#enable_suffix_number`
  - suffix_numberがパースされることを**許可**する
  
 ## 経緯
` Command::Parser.new(/\d+D6/)` などとすると、`0D6`に対して `"0D6".to_i`が6になってしまうことがわかり、パーサー側で自動判別できた方が良いだろうという話になった。 `0d`はRubyで10進数の接頭辞として扱われる。

Ref: https://docs.ruby-lang.org/ja/latest/method/String/i/to_i.html