### PR TITLE
[Satasupe] Result対応

### DIFF
--- a/lib/bcdice/game_system/Satasupe.rb
+++ b/lib/bcdice/game_system/Satasupe.rb
@@ -129,6 +129,7 @@ module BCDice
 
         return Result.new.tap do |r|
           r.text = result
+          r.success = !is_fumble && min_suc > 0 && total_suc >= min_suc
           r.failure = is_fumble
           r.critical = is_critical
           r.fumble = is_fumble

--- a/lib/bcdice/game_system/Satasupe.rb
+++ b/lib/bcdice/game_system/Satasupe.rb
@@ -64,7 +64,7 @@ module BCDice
         debug("eval_game_system_specific_command begin string", command)
 
         result = checkRoll(command)
-        return result unless result.empty?
+        return result unless result.nil?
 
         debug("判定ロールではなかった")
 
@@ -81,13 +81,13 @@ module BCDice
         debug("checkRoll begin string", string)
 
         m = /^(\d+)R>=(\d+)(\[(\d+)?(,|,\d+)?(,\d+(S)?)?\])?$/i.match(string)
-        return '' unless m
+        return nil unless m
 
         roll_times = m[1].to_i
         target = m[2].to_i
         params = m[3]
 
-        min_suc, fumble, critical, isCriticalStop = getRollParams(params)
+        min_suc, fumble, critical, is_critical_stop = get_roll_params(params)
 
         result = ""
 
@@ -104,8 +104,8 @@ module BCDice
         end
 
         if fumble >= 6
-          result += "#{getJudgeInfo(target, fumble, critical)} ＞ ファンブル率が6を超えたため自動失敗！"
-          return result
+          result += "#{get_judge_info(target, fumble, critical)} ＞ ファンブル率が6を超えたため自動失敗！"
+          return Result.failure(result)
         end
 
         if target < 5
@@ -113,23 +113,38 @@ module BCDice
           target = 5
         end
 
-        dice_str, total_suc, isCritical, isFumble = checkRollLoop(roll_times, min_suc, target, critical, fumble, isCriticalStop)
+        dice_str, total_suc, is_critical, is_fumble = check_roll_loop(roll_times, min_suc, target, critical, fumble, is_critical_stop)
 
-        result += "#{getJudgeInfo(target, fumble, critical)} ＞ #{dice_str} ＞ 成功度#{total_suc}"
+        result += "#{get_judge_info(target, fumble, critical)} ＞ #{dice_str} ＞ 成功度#{total_suc}"
 
-        if isFumble
+        if is_fumble
           result += " ＞ ファンブル"
         end
 
-        if isCritical && (total_suc > 0)
+        if is_critical && (total_suc > 0)
           result += " ＞ 必殺発動可能！"
         end
 
+        is_success = false
+        is_failure = is_fumble
+        # 目標成功度が設定されており、ファンブルしておらず、成功度が目標成功度より高ければ成功
+        if min_suc > 0 && !is_fumble
+          is_success = total_suc >= min_suc
+          is_failure = !is_success
+        end
+
         debug('checkRoll result result', result)
-        return result
+
+        return Result.new.tap do |r|
+          r.text = result
+          r.success = is_success
+          r.failure = is_failure
+          r.critical = is_critical
+          r.fumble = is_fumble
+        end
       end
 
-      def getRollParams(params)
+      def get_roll_params(params)
         min_suc = 0
         fumble = 1
         critical = 13
@@ -154,19 +169,14 @@ module BCDice
         return min_suc, fumble, critical, isCriticalStop
       end
 
-      def getJudgeInfo(target, fumble, critical)
-        "【難易度#{target}、ファンブル率#{fumble}#{getcriticalString(critical)}】"
+      def get_judge_info(target, fumble, critical)
+        return "【難易度#{target}、ファンブル率#{fumble}、必殺#{critical == 13 ? 'なし' : critical.to_s}】"
       end
 
-      def getcriticalString(critical)
-        criticalString = (critical == 13 ? "なし" : critical.to_s)
-        return "、必殺#{criticalString}"
-      end
-
-      def checkRollLoop(roll_times, min_suc, target, critical, fumble, isCriticalStop)
+      def check_roll_loop(roll_times, min_suc, target, critical, fumble, is_critical_stop)
         dice_str = ''
-        isFumble = false
-        isCritical = false
+        is_fumble = false
+        is_critical = false
         total_suc = 0
 
         roll_times.times do |_i|
@@ -193,22 +203,22 @@ module BCDice
           total_suc += dice_suc
 
           if critical <= d1 + d2
-            isCritical = true
+            is_critical = true
             dice_str += "『必殺！』"
           end
 
           if (d1 == d2) && (d1 <= fumble) # ファンブルの確認
-            isFumble = true
-            isCritical = false
+            is_fumble = true
+            is_critical = false
             break
           end
 
-          if isCritical && isCriticalStop # 必殺止めの確認
+          if is_critical && is_critical_stop # 必殺止めの確認
             break
           end
         end
 
-        return dice_str, total_suc, isCritical, isFumble
+        return dice_str, total_suc, is_critical, is_fumble
       end
 
       def check_seigou(string)

--- a/lib/bcdice/game_system/Satasupe.rb
+++ b/lib/bcdice/game_system/Satasupe.rb
@@ -125,20 +125,11 @@ module BCDice
           result += " ＞ 必殺発動可能！"
         end
 
-        is_success = false
-        is_failure = is_fumble
-        # 目標成功度が設定されており、ファンブルしておらず、成功度が目標成功度より高ければ成功
-        if min_suc > 0 && !is_fumble
-          is_success = total_suc >= min_suc
-          is_failure = !is_success
-        end
-
         debug('checkRoll result result', result)
 
         return Result.new.tap do |r|
           r.text = result
-          r.success = is_success
-          r.failure = is_failure
+          r.failure = is_fumble
           r.critical = is_critical
           r.fumble = is_fumble
         end

--- a/test/data/Satasupe.toml
+++ b/test/data/Satasupe.toml
@@ -29,6 +29,8 @@ rands = [
 game_system = "Satasupe"
 input = "10r>=7"
 output = "【難易度7、ファンブル率1、必殺なし】 ＞ 1[4,4]+1[4,4]+0[4,2]+1[5,3]+0[2,4]+1[5,3]+1[6,4]+1[1,6]+0[1,1] ＞ 成功度6 ＞ ファンブル"
+failure = true
+fumble = true
 rands = [
   { sides = 6, value = 4 },
   { sides = 6, value = 4 },
@@ -135,6 +137,8 @@ rands = [
 game_system = "Satasupe"
 input = "10r>=7"
 output = "【難易度7、ファンブル率1、必殺なし】 ＞ 1[1,6]+1[4,3]+1[3,6]+1[6,3]+1[4,3]+1[6,6]+0[3,2]+0[2,1]+0[1,1] ＞ 成功度6 ＞ ファンブル"
+failure = true
+fumble = true
 rands = [
   { sides = 6, value = 1 },
   { sides = 6, value = 6 },
@@ -268,6 +272,7 @@ rands = [
 game_system = "Satasupe"
 input = "8R>=7[3,3]"
 output = "【難易度7、ファンブル率3、必殺なし】 ＞ 1[1,6]+1[6,6]+0[3,1]+1[4,4] ＞ 成功度3"
+success = true
 rands = [
   { sides = 6, value = 1 },
   { sides = 6, value = 6 },
@@ -283,6 +288,7 @@ rands = [
 game_system = "Satasupe"
 input = "8R>=7[3,3]"
 output = "【難易度7、ファンブル率3、必殺なし】 ＞ 0[2,4]+0[5,1]+1[6,6]+1[5,2]+0[1,3]+0[2,3]+1[6,3] ＞ 成功度3"
+success = true
 rands = [
   { sides = 6, value = 2 },
   { sides = 6, value = 4 },
@@ -304,6 +310,8 @@ rands = [
 game_system = "Satasupe"
 input = "8R>=7[3,3]"
 output = "【難易度7、ファンブル率3、必殺なし】 ＞ 0[2,2] ＞ 成功度0 ＞ ファンブル"
+failure = true
+fumble = true
 rands = [
   { sides = 6, value = 2 },
   { sides = 6, value = 2 },
@@ -313,6 +321,8 @@ rands = [
 game_system = "Satasupe"
 input = "8R>=7[3,3]"
 output = "【難易度7、ファンブル率3、必殺なし】 ＞ 1[6,4]+0[3,3] ＞ 成功度1 ＞ ファンブル"
+failure = true
+fumble = true
 rands = [
   { sides = 6, value = 6 },
   { sides = 6, value = 4 },
@@ -324,6 +334,7 @@ rands = [
 game_system = "Satasupe"
 input = "8R>=7[3,3]"
 output = "【難易度7、ファンブル率3、必殺なし】 ＞ 1[4,6]+1[3,4]+1[3,5] ＞ 成功度3"
+success = true
 rands = [
   { sides = 6, value = 4 },
   { sides = 6, value = 6 },
@@ -337,6 +348,7 @@ rands = [
 game_system = "Satasupe"
 input = "8R>=7[3,3]"
 output = "【難易度7、ファンブル率3、必殺なし】 ＞ 1[5,2]+1[3,4]+1[6,5] ＞ 成功度3"
+success = true
 rands = [
   { sides = 6, value = 5 },
   { sides = 6, value = 2 },
@@ -350,6 +362,7 @@ rands = [
 game_system = "Satasupe"
 input = "8R>=7[3,3]"
 output = "【難易度7、ファンブル率3、必殺なし】 ＞ 1[6,2]+0[1,4]+1[4,4]+1[5,2] ＞ 成功度3"
+success = true
 rands = [
   { sides = 6, value = 6 },
   { sides = 6, value = 2 },
@@ -365,6 +378,7 @@ rands = [
 game_system = "Satasupe"
 input = "8R>=7[3,3]"
 output = "【難易度7、ファンブル率3、必殺なし】 ＞ 1[5,2]+1[2,6]+1[4,4] ＞ 成功度3"
+success = true
 rands = [
   { sides = 6, value = 5 },
   { sides = 6, value = 2 },
@@ -378,6 +392,8 @@ rands = [
 game_system = "Satasupe"
 input = "8R>=7[3,3]"
 output = "【難易度7、ファンブル率3、必殺なし】 ＞ 0[2,1]+0[2,2] ＞ 成功度0 ＞ ファンブル"
+failure = true
+fumble = true
 rands = [
   { sides = 6, value = 2 },
   { sides = 6, value = 1 },
@@ -389,6 +405,7 @@ rands = [
 game_system = "Satasupe"
 input = "8R>=7[3,3]"
 output = "【難易度7、ファンブル率3、必殺なし】 ＞ 1[4,5]+0[1,2]+0[4,1]+0[2,3]+0[4,2]+1[6,5]+0[2,1]+0[2,4] ＞ 成功度2"
+failure = true
 rands = [
   { sides = 6, value = 4 },
   { sides = 6, value = 5 },
@@ -412,6 +429,7 @@ rands = [
 game_system = "Satasupe"
 input = "10r>=5[5]"
 output = "【難易度5、ファンブル率1、必殺なし】 ＞ 1[4,5]+1[6,6]+0[2,2]+1[3,5]+0[1,2]+1[3,3]+1[5,3] ＞ 成功度5"
+success = true
 rands = [
   { sides = 6, value = 4 },
   { sides = 6, value = 5 },
@@ -433,6 +451,7 @@ rands = [
 game_system = "Satasupe"
 input = "10r>=5[5]"
 output = "【難易度5、ファンブル率1、必殺なし】 ＞ 1[6,6]+1[2,3]+1[4,5]+1[5,5]+0[1,3]+1[5,2] ＞ 成功度5"
+success = true
 rands = [
   { sides = 6, value = 6 },
   { sides = 6, value = 6 },
@@ -452,6 +471,7 @@ rands = [
 game_system = "Satasupe"
 input = "10r>=5[5]"
 output = "【難易度5、ファンブル率1、必殺なし】 ＞ 0[3,1]+1[1,6]+1[6,1]+1[5,6]+1[5,3]+1[5,4] ＞ 成功度5"
+success = true
 rands = [
   { sides = 6, value = 3 },
   { sides = 6, value = 1 },
@@ -471,6 +491,7 @@ rands = [
 game_system = "Satasupe"
 input = "10r>=5[5]"
 output = "【難易度5、ファンブル率1、必殺なし】 ＞ 1[4,5]+1[3,4]+1[5,1]+1[6,2]+1[4,2] ＞ 成功度5"
+success = true
 rands = [
   { sides = 6, value = 4 },
   { sides = 6, value = 5 },
@@ -488,6 +509,8 @@ rands = [
 game_system = "Satasupe"
 input = "10r>=5[5]"
 output = "【難易度5、ファンブル率1、必殺なし】 ＞ 1[5,1]+1[1,6]+0[1,2]+1[3,6]+1[6,5]+0[1,1] ＞ 成功度4 ＞ ファンブル"
+failure = true
+fumble = true
 rands = [
   { sides = 6, value = 5 },
   { sides = 6, value = 1 },
@@ -507,6 +530,7 @@ rands = [
 game_system = "Satasupe"
 input = "10r>=5[5]"
 output = "【難易度5、ファンブル率1、必殺なし】 ＞ 1[2,4]+1[4,1]+1[5,5]+1[4,5]+1[4,6] ＞ 成功度5"
+success = true
 rands = [
   { sides = 6, value = 2 },
   { sides = 6, value = 4 },
@@ -524,6 +548,7 @@ rands = [
 game_system = "Satasupe"
 input = "10r>=5[5]"
 output = "【難易度5、ファンブル率1、必殺なし】 ＞ 1[2,5]+1[6,2]+1[5,4]+1[5,3]+1[1,5] ＞ 成功度5"
+success = true
 rands = [
   { sides = 6, value = 2 },
   { sides = 6, value = 5 },
@@ -541,6 +566,7 @@ rands = [
 game_system = "Satasupe"
 input = "10r>=5[5]"
 output = "【難易度5、ファンブル率1、必殺なし】 ＞ 1[2,6]+1[4,2]+1[6,2]+1[2,6]+1[6,5] ＞ 成功度5"
+success = true
 rands = [
   { sides = 6, value = 2 },
   { sides = 6, value = 6 },
@@ -558,6 +584,7 @@ rands = [
 game_system = "Satasupe"
 input = "10r>=5[5]"
 output = "【難易度5、ファンブル率1、必殺なし】 ＞ 1[6,4]+1[6,5]+0[2,1]+1[1,6]+1[5,4]+1[4,1] ＞ 成功度5"
+success = true
 rands = [
   { sides = 6, value = 6 },
   { sides = 6, value = 4 },
@@ -577,6 +604,7 @@ rands = [
 game_system = "Satasupe"
 input = "10r>=5[5]"
 output = "【難易度5、ファンブル率1、必殺なし】 ＞ 1[5,5]+1[6,6]+1[1,6]+1[2,3]+1[5,4] ＞ 成功度5"
+success = true
 rands = [
   { sides = 6, value = 5 },
   { sides = 6, value = 5 },
@@ -594,6 +622,8 @@ rands = [
 game_system = "Satasupe"
 input = "8R>=7[,3]"
 output = "【難易度7、ファンブル率3、必殺なし】 ＞ 0[4,2]+1[3,6]+1[1,6]+0[4,2]+0[2,2] ＞ 成功度2 ＞ ファンブル"
+failure = true
+fumble = true
 rands = [
   { sides = 6, value = 4 },
   { sides = 6, value = 2 },
@@ -726,6 +756,8 @@ rands = [
 game_system = "Satasupe"
 input = "8R>=7[,3]"
 output = "【難易度7、ファンブル率3、必殺なし】 ＞ 1[6,5]+1[6,3]+1[2,5]+0[2,2] ＞ 成功度3 ＞ ファンブル"
+failure = true
+fumble = true
 rands = [
   { sides = 6, value = 6 },
   { sides = 6, value = 5 },
@@ -741,6 +773,8 @@ rands = [
 game_system = "Satasupe"
 input = "8R>=7[,3]"
 output = "【難易度7、ファンブル率3、必殺なし】 ＞ 1[5,6]+1[2,5]+1[5,4]+1[5,6]+1[3,5]+1[6,4]+0[1,1] ＞ 成功度6 ＞ ファンブル"
+failure = true
+fumble = true
 rands = [
   { sides = 6, value = 5 },
   { sides = 6, value = 6 },
@@ -762,6 +796,8 @@ rands = [
 game_system = "Satasupe"
 input = "8R>=7[,3]"
 output = "【難易度7、ファンブル率3、必殺なし】 ＞ 1[3,4]+0[1,5]+0[1,1] ＞ 成功度1 ＞ ファンブル"
+failure = true
+fumble = true
 rands = [
   { sides = 6, value = 3 },
   { sides = 6, value = 4 },
@@ -775,6 +811,8 @@ rands = [
 game_system = "Satasupe"
 input = "8R>=7[,3]"
 output = "【難易度7、ファンブル率3、必殺なし】 ＞ 0[2,2] ＞ 成功度0 ＞ ファンブル"
+failure = true
+fumble = true
 rands = [
   { sides = 6, value = 2 },
   { sides = 6, value = 2 },
@@ -784,6 +822,8 @@ rands = [
 game_system = "Satasupe"
 input = "8R>=7[3,3]"
 output = "【難易度7、ファンブル率3、必殺なし】 ＞ 0[3,3] ＞ 成功度0 ＞ ファンブル"
+failure = true
+fumble = true
 rands = [
   { sides = 6, value = 3 },
   { sides = 6, value = 3 },
@@ -997,6 +1037,8 @@ rands = [
 game_system = "Satasupe"
 input = "5R>=5"
 output = "【難易度5、ファンブル率1、必殺なし】 ＞ 1[6,5]+1[2,6]+0[1,1] ＞ 成功度2 ＞ ファンブル"
+failure = true
+fumble = true
 rands = [
   { sides = 6, value = 6 },
   { sides = 6, value = 5 },
@@ -1008,8 +1050,10 @@ rands = [
 
 [[ test ]]
 game_system = "Satasupe"
-input = "5R>=5[10,2]"
+input = "5R>=5[,2]"
 output = "【難易度5、ファンブル率2、必殺なし】 ＞ 1[4,3]+1[2,4]+1[6,3]+0[2,2] ＞ 成功度3 ＞ ファンブル"
+failure = true
+fumble = true
 rands = [
   { sides = 6, value = 4 },
   { sides = 6, value = 3 },
@@ -1023,7 +1067,7 @@ rands = [
 
 [[ test ]]
 game_system = "Satasupe"
-input = "5R>=5[10,2]"
+input = "5R>=5[,2]"
 output = "【難易度5、ファンブル率2、必殺なし】 ＞ 1[5,5]+1[5,3]+0[1,2]+0[2,1]+1[6,3] ＞ 成功度3"
 rands = [
   { sides = 6, value = 5 },
@@ -1040,8 +1084,10 @@ rands = [
 
 [[ test ]]
 game_system = "Satasupe"
-input = "5R>=5[10,2]"
+input = "5R>=5[,2]"
 output = "【難易度5、ファンブル率2、必殺なし】 ＞ 1[5,3]+1[4,6]+1[3,5]+1[4,5]+0[1,1] ＞ 成功度4 ＞ ファンブル"
+failure = true
+fumble = true
 rands = [
   { sides = 6, value = 5 },
   { sides = 6, value = 3 },
@@ -1057,7 +1103,7 @@ rands = [
 
 [[ test ]]
 game_system = "Satasupe"
-input = "5R>=5[10,2]"
+input = "5R>=5[,2]"
 output = "【難易度5、ファンブル率2、必殺なし】 ＞ 1[5,3]+1[6,5]+1[3,3]+1[4,4]+1[6,5] ＞ 成功度5"
 rands = [
   { sides = 6, value = 5 },
@@ -1074,7 +1120,7 @@ rands = [
 
 [[ test ]]
 game_system = "Satasupe"
-input = "5R>=5[10,2]"
+input = "5R>=5[,2]"
 output = "【難易度5、ファンブル率2、必殺なし】 ＞ 1[6,2]+1[6,3]+1[1,5]+1[2,5]+1[6,3] ＞ 成功度5"
 rands = [
   { sides = 6, value = 6 },
@@ -1091,7 +1137,7 @@ rands = [
 
 [[ test ]]
 game_system = "Satasupe"
-input = "5R>=5[10,2]"
+input = "5R>=5[,2]"
 output = "【難易度5、ファンブル率2、必殺なし】 ＞ 1[4,5]+1[6,3]+1[5,5]+1[1,6]+1[3,6] ＞ 成功度5"
 rands = [
   { sides = 6, value = 4 },
@@ -1108,7 +1154,7 @@ rands = [
 
 [[ test ]]
 game_system = "Satasupe"
-input = "5R>=5[10,2]"
+input = "5R>=5[,2]"
 output = "【難易度5、ファンブル率2、必殺なし】 ＞ 1[4,5]+1[3,5]+1[3,3]+0[1,2]+1[3,4] ＞ 成功度4"
 rands = [
   { sides = 6, value = 4 },
@@ -1125,7 +1171,7 @@ rands = [
 
 [[ test ]]
 game_system = "Satasupe"
-input = "5R>=5[10,2]"
+input = "5R>=5[,2]"
 output = "【難易度5、ファンブル率2、必殺なし】 ＞ 1[5,2]+1[3,4]+1[4,1]+0[1,2]+1[2,3] ＞ 成功度4"
 rands = [
   { sides = 6, value = 5 },
@@ -1142,7 +1188,7 @@ rands = [
 
 [[ test ]]
 game_system = "Satasupe"
-input = "5R>=5[10,2]"
+input = "5R>=5[,2]"
 output = "【難易度5、ファンブル率2、必殺なし】 ＞ 1[6,5]+1[6,4]+1[3,3]+0[3,1]+1[3,4] ＞ 成功度4"
 rands = [
   { sides = 6, value = 6 },
@@ -1159,8 +1205,10 @@ rands = [
 
 [[ test ]]
 game_system = "Satasupe"
-input = "5R>=5[10,2]"
+input = "5R>=5[,2]"
 output = "【難易度5、ファンブル率2、必殺なし】 ＞ 1[1,4]+1[2,6]+0[2,1]+1[5,2]+0[1,1] ＞ 成功度3 ＞ ファンブル"
+failure = true
+fumble = true
 rands = [
   { sides = 6, value = 1 },
   { sides = 6, value = 4 },
@@ -1176,8 +1224,9 @@ rands = [
 
 [[ test ]]
 game_system = "Satasupe"
-input = "5R>=5[10,2,7]"
+input = "5R>=5[,2,7]"
 output = "【難易度5、ファンブル率2、必殺7】 ＞ 1[6,5]『必殺！』+1[6,4]『必殺！』+1[3,3]+0[3,1]+1[3,4]『必殺！』 ＞ 成功度4 ＞ 必殺発動可能！"
+critical = true
 rands = [
   { sides = 6, value = 6 },
   { sides = 6, value = 5 },
@@ -1193,8 +1242,10 @@ rands = [
 
 [[ test ]]
 game_system = "Satasupe"
-input = "5R>=5[10,2,7]"
+input = "5R>=5[,2,7]"
 output = "【難易度5、ファンブル率2、必殺7】 ＞ 1[1,4]+1[2,6]『必殺！』+0[2,1]+1[5,2]『必殺！』+0[1,1] ＞ 成功度3 ＞ ファンブル"
+failure = true
+fumble = true
 rands = [
   { sides = 6, value = 1 },
   { sides = 6, value = 4 },
@@ -1210,20 +1261,23 @@ rands = [
 
 [[ test ]]
 game_system = "Satasupe"
-input = "5R>=5[10,6,7]"
+input = "5R>=5[,6,7]"
 output = "【難易度5、ファンブル率6、必殺7】 ＞ ファンブル率が6を超えたため自動失敗！"
+failure = true
 rands = []
 
 [[ test ]]
 game_system = "Satasupe"
-input = "5R>=5[10,6]"
+input = "5R>=5[,6]"
 output = "【難易度5、ファンブル率6、必殺なし】 ＞ ファンブル率が6を超えたため自動失敗！"
+failure = true
 rands = []
 
 [[ test ]]
 game_system = "Satasupe"
-input = "5R>=5[10,2,7S]"
+input = "5R>=5[,2,7S]"
 output = "【難易度5、ファンブル率2、必殺7】 ＞ 1[6,5]『必殺！』 ＞ 成功度1 ＞ 必殺発動可能！"
+critical = true
 rands = [
   { sides = 6, value = 6 },
   { sides = 6, value = 5 },
@@ -1231,8 +1285,9 @@ rands = [
 
 [[ test ]]
 game_system = "Satasupe"
-input = "5R>=5[10,2,7s]"
+input = "5R>=5[,2,7s]"
 output = "【難易度5、ファンブル率2、必殺7】 ＞ 1[6,5]『必殺！』 ＞ 成功度1 ＞ 必殺発動可能！"
+critical = true
 rands = [
   { sides = 6, value = 6 },
   { sides = 6, value = 5 },
@@ -1240,8 +1295,9 @@ rands = [
 
 [[ test ]]
 game_system = "Satasupe"
-input = "5R>=5[10,2,7S]"
+input = "5R>=5[,2,7S]"
 output = "【難易度5、ファンブル率2、必殺7】 ＞ 1[1,4]+1[2,6]『必殺！』 ＞ 成功度2 ＞ 必殺発動可能！"
+critical = true
 rands = [
   { sides = 6, value = 1 },
   { sides = 6, value = 4 },
@@ -1251,14 +1307,16 @@ rands = [
 
 [[ test ]]
 game_system = "Satasupe"
-input = "5R>=5[10,6,7S]"
+input = "5R>=5[,6,7S]"
 output = "【難易度5、ファンブル率6、必殺7】 ＞ ファンブル率が6を超えたため自動失敗！"
+failure = true
 rands = []
 
 [[ test ]]
 game_system = "Satasupe"
-input = "5R>=5[10,2,7S] mokeke"
+input = "5R>=5[,2,7S] mokeke"
 output = "【難易度5、ファンブル率2、必殺7】 ＞ 1[1,4]+1[2,6]『必殺！』 ＞ 成功度2 ＞ 必殺発動可能！"
+critical = true
 rands = [
   { sides = 6, value = 1 },
   { sides = 6, value = 4 },

--- a/test/data/Satasupe.toml
+++ b/test/data/Satasupe.toml
@@ -272,6 +272,7 @@ rands = [
 game_system = "Satasupe"
 input = "8R>=7[3,3]"
 output = "【難易度7、ファンブル率3、必殺なし】 ＞ 1[1,6]+1[6,6]+0[3,1]+1[4,4] ＞ 成功度3"
+success = true
 rands = [
   { sides = 6, value = 1 },
   { sides = 6, value = 6 },
@@ -287,6 +288,7 @@ rands = [
 game_system = "Satasupe"
 input = "8R>=7[3,3]"
 output = "【難易度7、ファンブル率3、必殺なし】 ＞ 0[2,4]+0[5,1]+1[6,6]+1[5,2]+0[1,3]+0[2,3]+1[6,3] ＞ 成功度3"
+success = true
 rands = [
   { sides = 6, value = 2 },
   { sides = 6, value = 4 },
@@ -332,6 +334,7 @@ rands = [
 game_system = "Satasupe"
 input = "8R>=7[3,3]"
 output = "【難易度7、ファンブル率3、必殺なし】 ＞ 1[4,6]+1[3,4]+1[3,5] ＞ 成功度3"
+success = true
 rands = [
   { sides = 6, value = 4 },
   { sides = 6, value = 6 },
@@ -345,6 +348,7 @@ rands = [
 game_system = "Satasupe"
 input = "8R>=7[3,3]"
 output = "【難易度7、ファンブル率3、必殺なし】 ＞ 1[5,2]+1[3,4]+1[6,5] ＞ 成功度3"
+success = true
 rands = [
   { sides = 6, value = 5 },
   { sides = 6, value = 2 },
@@ -358,6 +362,7 @@ rands = [
 game_system = "Satasupe"
 input = "8R>=7[3,3]"
 output = "【難易度7、ファンブル率3、必殺なし】 ＞ 1[6,2]+0[1,4]+1[4,4]+1[5,2] ＞ 成功度3"
+success = true
 rands = [
   { sides = 6, value = 6 },
   { sides = 6, value = 2 },
@@ -373,6 +378,7 @@ rands = [
 game_system = "Satasupe"
 input = "8R>=7[3,3]"
 output = "【難易度7、ファンブル率3、必殺なし】 ＞ 1[5,2]+1[2,6]+1[4,4] ＞ 成功度3"
+success = true
 rands = [
   { sides = 6, value = 5 },
   { sides = 6, value = 2 },
@@ -422,6 +428,7 @@ rands = [
 game_system = "Satasupe"
 input = "10r>=5[5]"
 output = "【難易度5、ファンブル率1、必殺なし】 ＞ 1[4,5]+1[6,6]+0[2,2]+1[3,5]+0[1,2]+1[3,3]+1[5,3] ＞ 成功度5"
+success = true
 rands = [
   { sides = 6, value = 4 },
   { sides = 6, value = 5 },
@@ -443,6 +450,7 @@ rands = [
 game_system = "Satasupe"
 input = "10r>=5[5]"
 output = "【難易度5、ファンブル率1、必殺なし】 ＞ 1[6,6]+1[2,3]+1[4,5]+1[5,5]+0[1,3]+1[5,2] ＞ 成功度5"
+success = true
 rands = [
   { sides = 6, value = 6 },
   { sides = 6, value = 6 },
@@ -462,6 +470,7 @@ rands = [
 game_system = "Satasupe"
 input = "10r>=5[5]"
 output = "【難易度5、ファンブル率1、必殺なし】 ＞ 0[3,1]+1[1,6]+1[6,1]+1[5,6]+1[5,3]+1[5,4] ＞ 成功度5"
+success = true
 rands = [
   { sides = 6, value = 3 },
   { sides = 6, value = 1 },
@@ -481,6 +490,7 @@ rands = [
 game_system = "Satasupe"
 input = "10r>=5[5]"
 output = "【難易度5、ファンブル率1、必殺なし】 ＞ 1[4,5]+1[3,4]+1[5,1]+1[6,2]+1[4,2] ＞ 成功度5"
+success = true
 rands = [
   { sides = 6, value = 4 },
   { sides = 6, value = 5 },
@@ -519,6 +529,7 @@ rands = [
 game_system = "Satasupe"
 input = "10r>=5[5]"
 output = "【難易度5、ファンブル率1、必殺なし】 ＞ 1[2,4]+1[4,1]+1[5,5]+1[4,5]+1[4,6] ＞ 成功度5"
+success = true
 rands = [
   { sides = 6, value = 2 },
   { sides = 6, value = 4 },
@@ -536,6 +547,7 @@ rands = [
 game_system = "Satasupe"
 input = "10r>=5[5]"
 output = "【難易度5、ファンブル率1、必殺なし】 ＞ 1[2,5]+1[6,2]+1[5,4]+1[5,3]+1[1,5] ＞ 成功度5"
+success = true
 rands = [
   { sides = 6, value = 2 },
   { sides = 6, value = 5 },
@@ -553,6 +565,7 @@ rands = [
 game_system = "Satasupe"
 input = "10r>=5[5]"
 output = "【難易度5、ファンブル率1、必殺なし】 ＞ 1[2,6]+1[4,2]+1[6,2]+1[2,6]+1[6,5] ＞ 成功度5"
+success = true
 rands = [
   { sides = 6, value = 2 },
   { sides = 6, value = 6 },
@@ -570,6 +583,7 @@ rands = [
 game_system = "Satasupe"
 input = "10r>=5[5]"
 output = "【難易度5、ファンブル率1、必殺なし】 ＞ 1[6,4]+1[6,5]+0[2,1]+1[1,6]+1[5,4]+1[4,1] ＞ 成功度5"
+success = true
 rands = [
   { sides = 6, value = 6 },
   { sides = 6, value = 4 },
@@ -589,6 +603,7 @@ rands = [
 game_system = "Satasupe"
 input = "10r>=5[5]"
 output = "【難易度5、ファンブル率1、必殺なし】 ＞ 1[5,5]+1[6,6]+1[1,6]+1[2,3]+1[5,4] ＞ 成功度5"
+success = true
 rands = [
   { sides = 6, value = 5 },
   { sides = 6, value = 5 },

--- a/test/data/Satasupe.toml
+++ b/test/data/Satasupe.toml
@@ -399,7 +399,6 @@ rands = [
 game_system = "Satasupe"
 input = "8R>=7[3,3]"
 output = "【難易度7、ファンブル率3、必殺なし】 ＞ 1[4,5]+0[1,2]+0[4,1]+0[2,3]+0[4,2]+1[6,5]+0[2,1]+0[2,4] ＞ 成功度2"
-failure = true
 rands = [
   { sides = 6, value = 4 },
   { sides = 6, value = 5 },
@@ -1054,7 +1053,6 @@ rands = [
 game_system = "Satasupe"
 input = "5R>=5[10,2]"
 output = "【難易度5、ファンブル率2、必殺なし】 ＞ 1[5,5]+1[5,3]+0[1,2]+0[2,1]+1[6,3] ＞ 成功度3"
-failure = true
 rands = [
   { sides = 6, value = 5 },
   { sides = 6, value = 5 },
@@ -1091,7 +1089,6 @@ rands = [
 game_system = "Satasupe"
 input = "5R>=5[10,2]"
 output = "【難易度5、ファンブル率2、必殺なし】 ＞ 1[5,3]+1[6,5]+1[3,3]+1[4,4]+1[6,5] ＞ 成功度5"
-failure = true
 rands = [
   { sides = 6, value = 5 },
   { sides = 6, value = 3 },
@@ -1109,7 +1106,6 @@ rands = [
 game_system = "Satasupe"
 input = "5R>=5[10,2]"
 output = "【難易度5、ファンブル率2、必殺なし】 ＞ 1[6,2]+1[6,3]+1[1,5]+1[2,5]+1[6,3] ＞ 成功度5"
-failure = true
 rands = [
   { sides = 6, value = 6 },
   { sides = 6, value = 2 },
@@ -1127,7 +1123,6 @@ rands = [
 game_system = "Satasupe"
 input = "5R>=5[10,2]"
 output = "【難易度5、ファンブル率2、必殺なし】 ＞ 1[4,5]+1[6,3]+1[5,5]+1[1,6]+1[3,6] ＞ 成功度5"
-failure = true
 rands = [
   { sides = 6, value = 4 },
   { sides = 6, value = 5 },
@@ -1145,7 +1140,6 @@ rands = [
 game_system = "Satasupe"
 input = "5R>=5[10,2]"
 output = "【難易度5、ファンブル率2、必殺なし】 ＞ 1[4,5]+1[3,5]+1[3,3]+0[1,2]+1[3,4] ＞ 成功度4"
-failure = true
 rands = [
   { sides = 6, value = 4 },
   { sides = 6, value = 5 },
@@ -1163,7 +1157,6 @@ rands = [
 game_system = "Satasupe"
 input = "5R>=5[10,2]"
 output = "【難易度5、ファンブル率2、必殺なし】 ＞ 1[5,2]+1[3,4]+1[4,1]+0[1,2]+1[2,3] ＞ 成功度4"
-failure = true
 rands = [
   { sides = 6, value = 5 },
   { sides = 6, value = 2 },
@@ -1181,7 +1174,6 @@ rands = [
 game_system = "Satasupe"
 input = "5R>=5[10,2]"
 output = "【難易度5、ファンブル率2、必殺なし】 ＞ 1[6,5]+1[6,4]+1[3,3]+0[3,1]+1[3,4] ＞ 成功度4"
-failure = true
 rands = [
   { sides = 6, value = 6 },
   { sides = 6, value = 5 },

--- a/test/data/Satasupe.toml
+++ b/test/data/Satasupe.toml
@@ -272,7 +272,6 @@ rands = [
 game_system = "Satasupe"
 input = "8R>=7[3,3]"
 output = "【難易度7、ファンブル率3、必殺なし】 ＞ 1[1,6]+1[6,6]+0[3,1]+1[4,4] ＞ 成功度3"
-success = true
 rands = [
   { sides = 6, value = 1 },
   { sides = 6, value = 6 },
@@ -288,7 +287,6 @@ rands = [
 game_system = "Satasupe"
 input = "8R>=7[3,3]"
 output = "【難易度7、ファンブル率3、必殺なし】 ＞ 0[2,4]+0[5,1]+1[6,6]+1[5,2]+0[1,3]+0[2,3]+1[6,3] ＞ 成功度3"
-success = true
 rands = [
   { sides = 6, value = 2 },
   { sides = 6, value = 4 },
@@ -334,7 +332,6 @@ rands = [
 game_system = "Satasupe"
 input = "8R>=7[3,3]"
 output = "【難易度7、ファンブル率3、必殺なし】 ＞ 1[4,6]+1[3,4]+1[3,5] ＞ 成功度3"
-success = true
 rands = [
   { sides = 6, value = 4 },
   { sides = 6, value = 6 },
@@ -348,7 +345,6 @@ rands = [
 game_system = "Satasupe"
 input = "8R>=7[3,3]"
 output = "【難易度7、ファンブル率3、必殺なし】 ＞ 1[5,2]+1[3,4]+1[6,5] ＞ 成功度3"
-success = true
 rands = [
   { sides = 6, value = 5 },
   { sides = 6, value = 2 },
@@ -362,7 +358,6 @@ rands = [
 game_system = "Satasupe"
 input = "8R>=7[3,3]"
 output = "【難易度7、ファンブル率3、必殺なし】 ＞ 1[6,2]+0[1,4]+1[4,4]+1[5,2] ＞ 成功度3"
-success = true
 rands = [
   { sides = 6, value = 6 },
   { sides = 6, value = 2 },
@@ -378,7 +373,6 @@ rands = [
 game_system = "Satasupe"
 input = "8R>=7[3,3]"
 output = "【難易度7、ファンブル率3、必殺なし】 ＞ 1[5,2]+1[2,6]+1[4,4] ＞ 成功度3"
-success = true
 rands = [
   { sides = 6, value = 5 },
   { sides = 6, value = 2 },
@@ -429,7 +423,6 @@ rands = [
 game_system = "Satasupe"
 input = "10r>=5[5]"
 output = "【難易度5、ファンブル率1、必殺なし】 ＞ 1[4,5]+1[6,6]+0[2,2]+1[3,5]+0[1,2]+1[3,3]+1[5,3] ＞ 成功度5"
-success = true
 rands = [
   { sides = 6, value = 4 },
   { sides = 6, value = 5 },
@@ -451,7 +444,6 @@ rands = [
 game_system = "Satasupe"
 input = "10r>=5[5]"
 output = "【難易度5、ファンブル率1、必殺なし】 ＞ 1[6,6]+1[2,3]+1[4,5]+1[5,5]+0[1,3]+1[5,2] ＞ 成功度5"
-success = true
 rands = [
   { sides = 6, value = 6 },
   { sides = 6, value = 6 },
@@ -471,7 +463,6 @@ rands = [
 game_system = "Satasupe"
 input = "10r>=5[5]"
 output = "【難易度5、ファンブル率1、必殺なし】 ＞ 0[3,1]+1[1,6]+1[6,1]+1[5,6]+1[5,3]+1[5,4] ＞ 成功度5"
-success = true
 rands = [
   { sides = 6, value = 3 },
   { sides = 6, value = 1 },
@@ -491,7 +482,6 @@ rands = [
 game_system = "Satasupe"
 input = "10r>=5[5]"
 output = "【難易度5、ファンブル率1、必殺なし】 ＞ 1[4,5]+1[3,4]+1[5,1]+1[6,2]+1[4,2] ＞ 成功度5"
-success = true
 rands = [
   { sides = 6, value = 4 },
   { sides = 6, value = 5 },
@@ -530,7 +520,6 @@ rands = [
 game_system = "Satasupe"
 input = "10r>=5[5]"
 output = "【難易度5、ファンブル率1、必殺なし】 ＞ 1[2,4]+1[4,1]+1[5,5]+1[4,5]+1[4,6] ＞ 成功度5"
-success = true
 rands = [
   { sides = 6, value = 2 },
   { sides = 6, value = 4 },
@@ -548,7 +537,6 @@ rands = [
 game_system = "Satasupe"
 input = "10r>=5[5]"
 output = "【難易度5、ファンブル率1、必殺なし】 ＞ 1[2,5]+1[6,2]+1[5,4]+1[5,3]+1[1,5] ＞ 成功度5"
-success = true
 rands = [
   { sides = 6, value = 2 },
   { sides = 6, value = 5 },
@@ -566,7 +554,6 @@ rands = [
 game_system = "Satasupe"
 input = "10r>=5[5]"
 output = "【難易度5、ファンブル率1、必殺なし】 ＞ 1[2,6]+1[4,2]+1[6,2]+1[2,6]+1[6,5] ＞ 成功度5"
-success = true
 rands = [
   { sides = 6, value = 2 },
   { sides = 6, value = 6 },
@@ -584,7 +571,6 @@ rands = [
 game_system = "Satasupe"
 input = "10r>=5[5]"
 output = "【難易度5、ファンブル率1、必殺なし】 ＞ 1[6,4]+1[6,5]+0[2,1]+1[1,6]+1[5,4]+1[4,1] ＞ 成功度5"
-success = true
 rands = [
   { sides = 6, value = 6 },
   { sides = 6, value = 4 },
@@ -604,7 +590,6 @@ rands = [
 game_system = "Satasupe"
 input = "10r>=5[5]"
 output = "【難易度5、ファンブル率1、必殺なし】 ＞ 1[5,5]+1[6,6]+1[1,6]+1[2,3]+1[5,4] ＞ 成功度5"
-success = true
 rands = [
   { sides = 6, value = 5 },
   { sides = 6, value = 5 },
@@ -1050,7 +1035,7 @@ rands = [
 
 [[ test ]]
 game_system = "Satasupe"
-input = "5R>=5[,2]"
+input = "5R>=5[10,2]"
 output = "【難易度5、ファンブル率2、必殺なし】 ＞ 1[4,3]+1[2,4]+1[6,3]+0[2,2] ＞ 成功度3 ＞ ファンブル"
 failure = true
 fumble = true
@@ -1067,8 +1052,9 @@ rands = [
 
 [[ test ]]
 game_system = "Satasupe"
-input = "5R>=5[,2]"
+input = "5R>=5[10,2]"
 output = "【難易度5、ファンブル率2、必殺なし】 ＞ 1[5,5]+1[5,3]+0[1,2]+0[2,1]+1[6,3] ＞ 成功度3"
+failure = true
 rands = [
   { sides = 6, value = 5 },
   { sides = 6, value = 5 },
@@ -1084,7 +1070,7 @@ rands = [
 
 [[ test ]]
 game_system = "Satasupe"
-input = "5R>=5[,2]"
+input = "5R>=5[10,2]"
 output = "【難易度5、ファンブル率2、必殺なし】 ＞ 1[5,3]+1[4,6]+1[3,5]+1[4,5]+0[1,1] ＞ 成功度4 ＞ ファンブル"
 failure = true
 fumble = true
@@ -1103,8 +1089,9 @@ rands = [
 
 [[ test ]]
 game_system = "Satasupe"
-input = "5R>=5[,2]"
+input = "5R>=5[10,2]"
 output = "【難易度5、ファンブル率2、必殺なし】 ＞ 1[5,3]+1[6,5]+1[3,3]+1[4,4]+1[6,5] ＞ 成功度5"
+failure = true
 rands = [
   { sides = 6, value = 5 },
   { sides = 6, value = 3 },
@@ -1120,8 +1107,9 @@ rands = [
 
 [[ test ]]
 game_system = "Satasupe"
-input = "5R>=5[,2]"
+input = "5R>=5[10,2]"
 output = "【難易度5、ファンブル率2、必殺なし】 ＞ 1[6,2]+1[6,3]+1[1,5]+1[2,5]+1[6,3] ＞ 成功度5"
+failure = true
 rands = [
   { sides = 6, value = 6 },
   { sides = 6, value = 2 },
@@ -1137,8 +1125,9 @@ rands = [
 
 [[ test ]]
 game_system = "Satasupe"
-input = "5R>=5[,2]"
+input = "5R>=5[10,2]"
 output = "【難易度5、ファンブル率2、必殺なし】 ＞ 1[4,5]+1[6,3]+1[5,5]+1[1,6]+1[3,6] ＞ 成功度5"
+failure = true
 rands = [
   { sides = 6, value = 4 },
   { sides = 6, value = 5 },
@@ -1154,8 +1143,9 @@ rands = [
 
 [[ test ]]
 game_system = "Satasupe"
-input = "5R>=5[,2]"
+input = "5R>=5[10,2]"
 output = "【難易度5、ファンブル率2、必殺なし】 ＞ 1[4,5]+1[3,5]+1[3,3]+0[1,2]+1[3,4] ＞ 成功度4"
+failure = true
 rands = [
   { sides = 6, value = 4 },
   { sides = 6, value = 5 },
@@ -1171,8 +1161,9 @@ rands = [
 
 [[ test ]]
 game_system = "Satasupe"
-input = "5R>=5[,2]"
+input = "5R>=5[10,2]"
 output = "【難易度5、ファンブル率2、必殺なし】 ＞ 1[5,2]+1[3,4]+1[4,1]+0[1,2]+1[2,3] ＞ 成功度4"
+failure = true
 rands = [
   { sides = 6, value = 5 },
   { sides = 6, value = 2 },
@@ -1188,8 +1179,9 @@ rands = [
 
 [[ test ]]
 game_system = "Satasupe"
-input = "5R>=5[,2]"
+input = "5R>=5[10,2]"
 output = "【難易度5、ファンブル率2、必殺なし】 ＞ 1[6,5]+1[6,4]+1[3,3]+0[3,1]+1[3,4] ＞ 成功度4"
+failure = true
 rands = [
   { sides = 6, value = 6 },
   { sides = 6, value = 5 },
@@ -1205,7 +1197,7 @@ rands = [
 
 [[ test ]]
 game_system = "Satasupe"
-input = "5R>=5[,2]"
+input = "5R>=5[10,2]"
 output = "【難易度5、ファンブル率2、必殺なし】 ＞ 1[1,4]+1[2,6]+0[2,1]+1[5,2]+0[1,1] ＞ 成功度3 ＞ ファンブル"
 failure = true
 fumble = true
@@ -1224,7 +1216,7 @@ rands = [
 
 [[ test ]]
 game_system = "Satasupe"
-input = "5R>=5[,2,7]"
+input = "5R>=5[10,2,7]"
 output = "【難易度5、ファンブル率2、必殺7】 ＞ 1[6,5]『必殺！』+1[6,4]『必殺！』+1[3,3]+0[3,1]+1[3,4]『必殺！』 ＞ 成功度4 ＞ 必殺発動可能！"
 critical = true
 rands = [
@@ -1242,7 +1234,7 @@ rands = [
 
 [[ test ]]
 game_system = "Satasupe"
-input = "5R>=5[,2,7]"
+input = "5R>=5[10,2,7]"
 output = "【難易度5、ファンブル率2、必殺7】 ＞ 1[1,4]+1[2,6]『必殺！』+0[2,1]+1[5,2]『必殺！』+0[1,1] ＞ 成功度3 ＞ ファンブル"
 failure = true
 fumble = true
@@ -1261,21 +1253,21 @@ rands = [
 
 [[ test ]]
 game_system = "Satasupe"
-input = "5R>=5[,6,7]"
+input = "5R>=5[10,6,7]"
 output = "【難易度5、ファンブル率6、必殺7】 ＞ ファンブル率が6を超えたため自動失敗！"
 failure = true
 rands = []
 
 [[ test ]]
 game_system = "Satasupe"
-input = "5R>=5[,6]"
+input = "5R>=5[10,6]"
 output = "【難易度5、ファンブル率6、必殺なし】 ＞ ファンブル率が6を超えたため自動失敗！"
 failure = true
 rands = []
 
 [[ test ]]
 game_system = "Satasupe"
-input = "5R>=5[,2,7S]"
+input = "5R>=5[10,2,7S]"
 output = "【難易度5、ファンブル率2、必殺7】 ＞ 1[6,5]『必殺！』 ＞ 成功度1 ＞ 必殺発動可能！"
 critical = true
 rands = [
@@ -1285,7 +1277,7 @@ rands = [
 
 [[ test ]]
 game_system = "Satasupe"
-input = "5R>=5[,2,7s]"
+input = "5R>=5[10,2,7s]"
 output = "【難易度5、ファンブル率2、必殺7】 ＞ 1[6,5]『必殺！』 ＞ 成功度1 ＞ 必殺発動可能！"
 critical = true
 rands = [
@@ -1295,7 +1287,7 @@ rands = [
 
 [[ test ]]
 game_system = "Satasupe"
-input = "5R>=5[,2,7S]"
+input = "5R>=5[10,2,7S]"
 output = "【難易度5、ファンブル率2、必殺7】 ＞ 1[1,4]+1[2,6]『必殺！』 ＞ 成功度2 ＞ 必殺発動可能！"
 critical = true
 rands = [
@@ -1307,14 +1299,14 @@ rands = [
 
 [[ test ]]
 game_system = "Satasupe"
-input = "5R>=5[,6,7S]"
+input = "5R>=5[10,6,7S]"
 output = "【難易度5、ファンブル率6、必殺7】 ＞ ファンブル率が6を超えたため自動失敗！"
 failure = true
 rands = []
 
 [[ test ]]
 game_system = "Satasupe"
-input = "5R>=5[,2,7S] mokeke"
+input = "5R>=5[10,2,7S] mokeke"
 output = "【難易度5、ファンブル率2、必殺7】 ＞ 1[1,4]+1[2,6]『必殺！』 ＞ 成功度2 ＞ 必殺発動可能！"
 critical = true
 rands = [


### PR DESCRIPTION
Satasupeに対する #423 対応です。

このシステムのダイスにおいては、「目標成功度」はあくまでダイスの振り足しを止める成功度という指定で、必ずしもこれが判定の成否の閾値となる成功度とは限らず、現在は振り手にとっての成功失敗を判断する情報がないため、基本的に `success` , `failure` と断定できるもの以外は、どちらも指定しないようにしています

`failure` が指定されるのは「ファンブル値が6以上となった自動失敗」および「ファンブルした場合に `fumble` と一緒にセットされる」場合で、 `success` がセットされるのは「目標成功度に達した場合」です。