### PR TITLE
1つのTOMLファイルには1つのgame_systemのみを許容

### DIFF
--- a/test/data/DoubleCross_Korean.toml
+++ b/test/data/DoubleCross_Korean.toml
@@ -2049,7 +2049,7 @@ rands = [
 ]
 
 [[ test ]]
-game_system = "DoubleCross"
+game_system = "DoubleCross:Korean"
 input = "5DX(8-1)-(2-1)"
 output = "(5DX7-1) ＞ 10[5,6,6,7,8]+10[1,9]+5[5]-1 ＞ 24"
 critical = true

--- a/test/data/Dracurouge_Korean.toml
+++ b/test/data/Dracurouge_Korean.toml
@@ -383,7 +383,7 @@ rands = [
 ]
 
 [[ test ]]
-game_system = "Dracurouge"
+game_system = "Dracurouge:Korean"
 input = "HRT"
 output = "異端の反応表(11) ＞ 異端卿：床を睨み意識を何とか保つ／ヴルコラク：己の頭をかきむしる／ナハツェーラ：生きたものをじっと見つめる／カルンシュタイン：姿が霧に包まれぼやける／グリマルキン：その場で居眠りする／ストリガ：翼をきつく閉じて怯える／メリュジーヌ：ぼんやりと遠くを眺める／フォーン：より退廃的な衣装をまとう／ホムンクルス：苦しそうに咳き込みながら膝をつく／エナメルム：人形の虚ろな表情からは何もわからない／サングィナリエ：怒りや欲望で、顔が怪物のように醜くゆがむ／アールヴ：平然と場の空気を無視した発言をする／ヴィーヴル：周囲の者は、圧迫感と居心地の悪さを感じる／ルーガルー：巨大な狼の姿となって、警戒も露にうなる／アルラウネ：不満を漏らしたり、軽い我儘を言ったりする／フリッガ：その影が巨大な蜘蛛となって、蠢く"
 rands = [
@@ -392,7 +392,7 @@ rands = [
 ]
 
 [[ test ]]
-game_system = "Dracurouge"
+game_system = "Dracurouge:Korean"
 input = "HRT"
 output = "異端の反応表(36) ＞ 異端卿：恐ろしい目で他者を見る／ヴルコラク：決意した顔で、正面を見る／ナハツェーラ：手の中に髑髏を具現化する／カルンシュタイン：豪奢な衣装を具現化してまとう／グリマルキン：他者にじゃれつく／ストリガ：周囲に無数の小鳥が集まる／メリュジーヌ：他者に下半身を絡め抱きしめる／フォーン：他者を口説き始める／ホムンクルス：ほんのかすかな笑顔が浮かぶ／エナメルム：断片的に、かつての魂の記憶が蘇る／サングィナリエ：余裕のある不敵な笑みを浮かべる／アールヴ：誰かの振る舞いに嘆息し、大いに感動を覚える／ヴィーヴル：その姿が一瞬、巨大な龍に見える／ルーガルー：目を閉じて、故郷たる自然に思いを馳せる／アルラウネ：己に咲く花を摘み、誰かに手渡す（瞬時に再生）／フリッガ：誰かに、狂気の如き恋心を抱き始める"
 rands = [
@@ -401,7 +401,7 @@ rands = [
 ]
 
 [[ test ]]
-game_system = "Dracurouge"
+game_system = "Dracurouge:Korean"
 input = "HRT"
 output = "異端の反応表(41) ＞ 野伏：露骨に、騎士から距離をとる／流浪：呆れた様子でため息をつく／密使：周りを値踏みする目で見る／魔女：誰もいないところに話しかける／剣士：騎士の礼儀作法を嘲笑い、茶化す／検体：肉体が異形化しようとするように、波打つ"
 rands = [
@@ -410,7 +410,7 @@ rands = [
 ]
 
 [[ test ]]
-game_system = "Dracurouge"
+game_system = "Dracurouge:Korean"
 input = "HRT"
 output = "異端の反応表(66) ＞ 野伏：己の土地について語る／流浪：他者に異郷の珍しい品を渡す／密使：他者に積極的に話しかける／魔女：手の中に青白い炎を具現化する／剣士：かつての戦いや冒険について語る／検体：誰かに、己の苦しみからの助けを求める"
 rands = [
@@ -419,7 +419,7 @@ rands = [
 ]
 
 [[ test ]]
-game_system = "Dracurouge"
+game_system = "Dracurouge:Korean"
 input = "HRTLS"
 output = "異端の反応表(11) ＞ 異端卿：床を睨み意識を何とか保つ"
 rands = [
@@ -428,7 +428,7 @@ rands = [
 ]
 
 [[ test ]]
-game_system = "Dracurouge"
+game_system = "Dracurouge:Korean"
 input = "HRTLS"
 output = "異端の反応表(36) ＞ 異端卿：恐ろしい目で他者を見る"
 rands = [
@@ -437,7 +437,7 @@ rands = [
 ]
 
 [[ test ]]
-game_system = "Dracurouge"
+game_system = "Dracurouge:Korean"
 input = "HRTLS"
 output = "異端の反応表(41) ＞ 密使：周りを値踏みする目で見る"
 rands = [
@@ -446,7 +446,7 @@ rands = [
 ]
 
 [[ test ]]
-game_system = "Dracurouge"
+game_system = "Dracurouge:Korean"
 input = "HRTLS"
 output = "異端の反応表(66) ＞ 密使：他者に積極的に話しかける"
 rands = [
@@ -455,7 +455,7 @@ rands = [
 ]
 
 [[ test ]]
-game_system = "Dracurouge"
+game_system = "Dracurouge:Korean"
 input = "HRTVW"
 output = "異端の反応表(11) ＞ ヴルコラク：己の頭をかきむしる"
 rands = [
@@ -464,7 +464,7 @@ rands = [
 ]
 
 [[ test ]]
-game_system = "Dracurouge"
+game_system = "Dracurouge:Korean"
 input = "HRTVW"
 output = "異端の反応表(36) ＞ ヴルコラク：決意した顔で、正面を見る"
 rands = [
@@ -473,7 +473,7 @@ rands = [
 ]
 
 [[ test ]]
-game_system = "Dracurouge"
+game_system = "Dracurouge:Korean"
 input = "HRTVW"
 output = "異端の反応表(41) ＞ 野伏：露骨に、騎士から距離をとる"
 rands = [
@@ -482,7 +482,7 @@ rands = [
 ]
 
 [[ test ]]
-game_system = "Dracurouge"
+game_system = "Dracurouge:Korean"
 input = "HRTVW"
 output = "異端の反応表(66) ＞ 野伏：己の土地について語る"
 rands = [
@@ -491,7 +491,7 @@ rands = [
 ]
 
 [[ test ]]
-game_system = "Dracurouge"
+game_system = "Dracurouge:Korean"
 input = "HRTNN"
 output = "異端の反応表(11) ＞ ナハツェーラ：生きたものをじっと見つめる"
 rands = [
@@ -500,7 +500,7 @@ rands = [
 ]
 
 [[ test ]]
-game_system = "Dracurouge"
+game_system = "Dracurouge:Korean"
 input = "HRTNN"
 output = "異端の反応表(36) ＞ ナハツェーラ：手の中に髑髏を具現化する"
 rands = [
@@ -509,7 +509,7 @@ rands = [
 ]
 
 [[ test ]]
-game_system = "Dracurouge"
+game_system = "Dracurouge:Korean"
 input = "HRTNN"
 output = "異端の反応表(41) ＞ 流浪：呆れた様子でため息をつく"
 rands = [
@@ -518,7 +518,7 @@ rands = [
 ]
 
 [[ test ]]
-game_system = "Dracurouge"
+game_system = "Dracurouge:Korean"
 input = "HRTNN"
 output = "異端の反応表(66) ＞ 流浪：他者に異郷の珍しい品を渡す"
 rands = [
@@ -527,7 +527,7 @@ rands = [
 ]
 
 [[ test ]]
-game_system = "Dracurouge"
+game_system = "Dracurouge:Korean"
 input = "HRTKS"
 output = "異端の反応表(11) ＞ カルンシュタイン：姿が霧に包まれぼやける"
 rands = [
@@ -536,7 +536,7 @@ rands = [
 ]
 
 [[ test ]]
-game_system = "Dracurouge"
+game_system = "Dracurouge:Korean"
 input = "HRTKS"
 output = "異端の反応表(36) ＞ カルンシュタイン：豪奢な衣装を具現化してまとう"
 rands = [
@@ -545,7 +545,7 @@ rands = [
 ]
 
 [[ test ]]
-game_system = "Dracurouge"
+game_system = "Dracurouge:Korean"
 input = "HRTKS"
 output = "異端の反応表(41) ＞ 密使：周りを値踏みする目で見る"
 rands = [
@@ -554,7 +554,7 @@ rands = [
 ]
 
 [[ test ]]
-game_system = "Dracurouge"
+game_system = "Dracurouge:Korean"
 input = "HRTKS"
 output = "異端の反応表(66) ＞ 密使：他者に積極的に話しかける"
 rands = [
@@ -563,7 +563,7 @@ rands = [
 ]
 
 [[ test ]]
-game_system = "Dracurouge"
+game_system = "Dracurouge:Korean"
 input = "HRTGH"
 output = "異端の反応表(11) ＞ グリマルキン：その場で居眠りする"
 rands = [
@@ -572,7 +572,7 @@ rands = [
 ]
 
 [[ test ]]
-game_system = "Dracurouge"
+game_system = "Dracurouge:Korean"
 input = "HRTGH"
 output = "異端の反応表(41) ＞ 魔女：誰もいないところに話しかける"
 rands = [
@@ -581,7 +581,7 @@ rands = [
 ]
 
 [[ test ]]
-game_system = "Dracurouge"
+game_system = "Dracurouge:Korean"
 input = "HRTGH"
 output = "異端の反応表(66) ＞ 魔女：手の中に青白い炎を具現化する"
 rands = [
@@ -590,7 +590,7 @@ rands = [
 ]
 
 [[ test ]]
-game_system = "Dracurouge"
+game_system = "Dracurouge:Korean"
 input = "HRTSN"
 output = "異端の反応表(11) ＞ ストリガ：翼をきつく閉じて怯える"
 rands = [
@@ -599,7 +599,7 @@ rands = [
 ]
 
 [[ test ]]
-game_system = "Dracurouge"
+game_system = "Dracurouge:Korean"
 input = "HRTSN"
 output = "異端の反応表(36) ＞ ストリガ：周囲に無数の小鳥が集まる"
 rands = [
@@ -608,7 +608,7 @@ rands = [
 ]
 
 [[ test ]]
-game_system = "Dracurouge"
+game_system = "Dracurouge:Korean"
 input = "HRTSN"
 output = "異端の反応表(41) ＞ 流浪：呆れた様子でため息をつく"
 rands = [
@@ -617,7 +617,7 @@ rands = [
 ]
 
 [[ test ]]
-game_system = "Dracurouge"
+game_system = "Dracurouge:Korean"
 input = "HRTSN"
 output = "異端の反応表(66) ＞ 流浪：他者に異郷の珍しい品を渡す"
 rands = [
@@ -626,7 +626,7 @@ rands = [
 ]
 
 [[ test ]]
-game_system = "Dracurouge"
+game_system = "Dracurouge:Korean"
 input = "HRTMH"
 output = "異端の反応表(11) ＞ メリュジーヌ：ぼんやりと遠くを眺める"
 rands = [
@@ -635,7 +635,7 @@ rands = [
 ]
 
 [[ test ]]
-game_system = "Dracurouge"
+game_system = "Dracurouge:Korean"
 input = "HRTMH"
 output = "異端の反応表(36) ＞ メリュジーヌ：他者に下半身を絡め抱きしめる"
 rands = [
@@ -644,7 +644,7 @@ rands = [
 ]
 
 [[ test ]]
-game_system = "Dracurouge"
+game_system = "Dracurouge:Korean"
 input = "HRTMH"
 output = "異端の反応表(41) ＞ 魔女：誰もいないところに話しかける"
 rands = [
@@ -653,7 +653,7 @@ rands = [
 ]
 
 [[ test ]]
-game_system = "Dracurouge"
+game_system = "Dracurouge:Korean"
 input = "HRTMH"
 output = "異端の反応表(66) ＞ 魔女：手の中に青白い炎を具現化する"
 rands = [
@@ -662,7 +662,7 @@ rands = [
 ]
 
 [[ test ]]
-game_system = "Dracurouge"
+game_system = "Dracurouge:Korean"
 input = "HRTFW"
 output = "異端の反応表(11) ＞ フォーン：より退廃的な衣装をまとう"
 rands = [
@@ -671,7 +671,7 @@ rands = [
 ]
 
 [[ test ]]
-game_system = "Dracurouge"
+game_system = "Dracurouge:Korean"
 input = "HRTFW"
 output = "異端の反応表(36) ＞ フォーン：他者を口説き始める"
 rands = [
@@ -680,7 +680,7 @@ rands = [
 ]
 
 [[ test ]]
-game_system = "Dracurouge"
+game_system = "Dracurouge:Korean"
 input = "HRTFW"
 output = "異端の反応表(41) ＞ 野伏：露骨に、騎士から距離をとる"
 rands = [
@@ -689,7 +689,7 @@ rands = [
 ]
 
 [[ test ]]
-game_system = "Dracurouge"
+game_system = "Dracurouge:Korean"
 input = "HRTFW"
 output = "異端の反応表(66) ＞ 野伏：己の土地について語る"
 rands = [
@@ -698,7 +698,7 @@ rands = [
 ]
 
 [[ test ]]
-game_system = "Dracurouge"
+game_system = "Dracurouge:Korean"
 input = "HRTEF"
 output = "異端の反応表(11) ＞ エナメルム：人形の虚ろな表情からは何もわからない"
 rands = [
@@ -707,7 +707,7 @@ rands = [
 ]
 
 [[ test ]]
-game_system = "Dracurouge"
+game_system = "Dracurouge:Korean"
 input = "HRTEF"
 output = "異端の反応表(36) ＞ エナメルム：断片的に、かつての魂の記憶が蘇る"
 rands = [
@@ -716,7 +716,7 @@ rands = [
 ]
 
 [[ test ]]
-game_system = "Dracurouge"
+game_system = "Dracurouge:Korean"
 input = "HRTEF"
 output = "異端の反応表(41) ＞ 剣士：騎士の礼儀作法を嘲笑い、茶化す"
 rands = [
@@ -725,7 +725,7 @@ rands = [
 ]
 
 [[ test ]]
-game_system = "Dracurouge"
+game_system = "Dracurouge:Korean"
 input = "HRTEF"
 output = "異端の反応表(66) ＞ 剣士：かつての戦いや冒険について語る"
 rands = [
@@ -734,7 +734,7 @@ rands = [
 ]
 
 [[ test ]]
-game_system = "Dracurouge"
+game_system = "Dracurouge:Korean"
 input = "HRTHX"
 output = "異端の反応表(11) ＞ ホムンクルス：苦しそうに咳き込みながら膝をつく"
 rands = [
@@ -743,7 +743,7 @@ rands = [
 ]
 
 [[ test ]]
-game_system = "Dracurouge"
+game_system = "Dracurouge:Korean"
 input = "HRTHX"
 output = "異端の反応表(36) ＞ ホムンクルス：ほんのかすかな笑顔が浮かぶ"
 rands = [
@@ -752,7 +752,7 @@ rands = [
 ]
 
 [[ test ]]
-game_system = "Dracurouge"
+game_system = "Dracurouge:Korean"
 input = "HRTHX"
 output = "異端の反応表(41) ＞ 検体：肉体が異形化しようとするように、波打つ"
 rands = [
@@ -761,7 +761,7 @@ rands = [
 ]
 
 [[ test ]]
-game_system = "Dracurouge"
+game_system = "Dracurouge:Korean"
 input = "HRTHX"
 output = "異端の反応表(66) ＞ 検体：誰かに、己の苦しみからの助けを求める"
 rands = [
@@ -770,7 +770,7 @@ rands = [
 ]
 
 [[ test ]]
-game_system = "Dracurouge"
+game_system = "Dracurouge:Korean"
 input = "HRTS2X"
 output = "異端の反応表(11) ＞ サングィナリエ：怒りや欲望で、顔が怪物のように醜くゆがむ"
 rands = [
@@ -779,7 +779,7 @@ rands = [
 ]
 
 [[ test ]]
-game_system = "Dracurouge"
+game_system = "Dracurouge:Korean"
 input = "HRTS2X"
 output = "異端の反応表(36) ＞ サングィナリエ：余裕のある不敵な笑みを浮かべる"
 rands = [
@@ -788,7 +788,7 @@ rands = [
 ]
 
 [[ test ]]
-game_system = "Dracurouge"
+game_system = "Dracurouge:Korean"
 input = "HRTAX"
 output = "異端の反応表(11) ＞ アールヴ：平然と場の空気を無視した発言をする"
 rands = [
@@ -797,7 +797,7 @@ rands = [
 ]
 
 [[ test ]]
-game_system = "Dracurouge"
+game_system = "Dracurouge:Korean"
 input = "HRTAX"
 output = "異端の反応表(36) ＞ アールヴ：誰かの振る舞いに嘆息し、大いに感動を覚える"
 rands = [
@@ -806,7 +806,7 @@ rands = [
 ]
 
 [[ test ]]
-game_system = "Dracurouge"
+game_system = "Dracurouge:Korean"
 input = "HRTV2X"
 output = "異端の反応表(11) ＞ ヴィーヴル：周囲の者は、圧迫感と居心地の悪さを感じる"
 rands = [
@@ -815,7 +815,7 @@ rands = [
 ]
 
 [[ test ]]
-game_system = "Dracurouge"
+game_system = "Dracurouge:Korean"
 input = "HRTV2X"
 output = "異端の反応表(36) ＞ ヴィーヴル：その姿が一瞬、巨大な龍に見える"
 rands = [
@@ -824,7 +824,7 @@ rands = [
 ]
 
 [[ test ]]
-game_system = "Dracurouge"
+game_system = "Dracurouge:Korean"
 input = "HRTL2X"
 output = "異端の反応表(11) ＞ ルーガルー：巨大な狼の姿となって、警戒も露にうなる"
 rands = [
@@ -833,7 +833,7 @@ rands = [
 ]
 
 [[ test ]]
-game_system = "Dracurouge"
+game_system = "Dracurouge:Korean"
 input = "HRTL2X"
 output = "異端の反応表(36) ＞ ルーガルー：目を閉じて、故郷たる自然に思いを馳せる"
 rands = [
@@ -842,7 +842,7 @@ rands = [
 ]
 
 [[ test ]]
-game_system = "Dracurouge"
+game_system = "Dracurouge:Korean"
 input = "HRTA2X"
 output = "異端の反応表(11) ＞ アルラウネ：不満を漏らしたり、軽い我儘を言ったりする"
 rands = [
@@ -851,7 +851,7 @@ rands = [
 ]
 
 [[ test ]]
-game_system = "Dracurouge"
+game_system = "Dracurouge:Korean"
 input = "HRTA2X"
 output = "異端の反応表(36) ＞ アルラウネ：己に咲く花を摘み、誰かに手渡す（瞬時に再生）"
 rands = [
@@ -860,7 +860,7 @@ rands = [
 ]
 
 [[ test ]]
-game_system = "Dracurouge"
+game_system = "Dracurouge:Korean"
 input = "HRTF2X"
 output = "異端の反応表(11) ＞ フリッガ：その影が巨大な蜘蛛となって、蠢く"
 rands = [
@@ -869,7 +869,7 @@ rands = [
 ]
 
 [[ test ]]
-game_system = "Dracurouge"
+game_system = "Dracurouge:Korean"
 input = "HRTF2X"
 output = "異端の反応表(36) ＞ フリッガ：誰かに、狂気の如き恋心を抱き始める"
 rands = [
@@ -878,7 +878,7 @@ rands = [
 ]
 
 [[ test ]]
-game_system = "Dracurouge"
+game_system = "Dracurouge:Korean"
 input = "ECS"
 output = "拡張・堕落の兆し表(11) ＞ 完全なる堕落：あなたは〔壁の華〕となり、いずれかの堕落者となる。その〔幕〕の終了後にセッションから退場する。（基本247ページ参照）"
 rands = [
@@ -887,7 +887,7 @@ rands = [
 ]
 
 [[ test ]]
-game_system = "Dracurouge"
+game_system = "Dracurouge:Korean"
 input = "ECS"
 output = "拡張・堕落の兆し表(65) ＞ 月光欲：屋根があると不快感を感じる。なるべく月光を浴びられる場所でいたい。宮廷でも庭園やバルコニーを好むだろう。"
 rands = [
@@ -896,7 +896,7 @@ rands = [
 ]
 
 [[ test ]]
-game_system = "Dracurouge"
+game_system = "Dracurouge:Korean"
 input = "ECS"
 output = "拡張・堕落の兆し表(66) ＞ 幸運：自覚するような兆しはないようだが……己を戒めねばなるまい。貴卿は今や堕落の瀬戸際にいると自覚せよ。"
 rands = [
@@ -906,7 +906,7 @@ rands = [
 
 
 [[ test ]]
-game_system = "Dracurouge"
+game_system = "Dracurouge:Korean"
 input = "CO"
 output = "叙勲表(11) ＞ 堕落の血：貴卿は堕落者に襲われ、その結果……騎士となった。貴卿に流れるは堕落した血なのだ。 ＞ 叙勲年齢：7+1D6×1D6 ＞ (7+6×6) ＞ 叙勲年齢：43年"
 rands = [
@@ -917,7 +917,7 @@ rands = [
 ]
 
 [[ test ]]
-game_system = "Dracurouge"
+game_system = "Dracurouge:Korean"
 input = "CO"
 output = "叙勲表(23) ＞ 矮小なる主：叙勲と共にものの見方は変わる。叙勲後、主がくだらない存在と見えた。貴卿は主のもとを離れた。 ＞ 叙勲年齢：7+1D6×1D6 ＞ (7+5×2) ＞ 叙勲年齢：17年"
 rands = [
@@ -928,7 +928,7 @@ rands = [
 ]
 
 [[ test ]]
-game_system = "Dracurouge"
+game_system = "Dracurouge:Korean"
 input = "CO"
 output = "叙勲表(66) ＞ 始祖の寵愛：貴卿は、始祖その人の寵愛を得た。真祖ドラクルに最も近しい、誇るべき身の一人となったのだ。 ＞ 叙勲年齢：7+1D6×1D6 ＞ (7+1×1) ＞ 叙勲年齢：8年"
 rands = [
@@ -939,7 +939,7 @@ rands = [
 ]
 
 [[ test ]]
-game_system = "Dracurouge"
+game_system = "Dracurouge:Korean"
 input = "CA"
 output = "叙勲後表(11) ＞ 滅亡：貴卿の領地は敵に滅ぼされた。守るべき民は絶え、名誉は失われた。彼の者らを許すわけにはいかない。 ＞ 騎士歴：2D6×10 ＞ (12×10) ＞ 騎士歴：120年"
 rands = [
@@ -950,7 +950,7 @@ rands = [
 ]
 
 [[ test ]]
-game_system = "Dracurouge"
+game_system = "Dracurouge:Korean"
 input = "CA"
 output = "叙勲後表(34) ＞ 失恋：愛深きゆえに貴卿は愛を捨てた。……捨てきってはいないかもしれないが、捨てたと信じた。 ＞ 騎士歴：2D6×10 ＞ (7×10) ＞ 騎士歴：70年"
 rands = [
@@ -961,7 +961,7 @@ rands = [
 ]
 
 [[ test ]]
-game_system = "Dracurouge"
+game_system = "Dracurouge:Korean"
 input = "CA"
 output = "叙勲後表(66) ＞ 伝説：貴卿は未だ偉業わずかなれど、その逸話は伝説の域。すでに吟遊詩人らの歌にさえ歌われている。 ＞ 騎士歴：1D6×1D6 ＞ (1×1) ＞ 騎士歴：1年"
 rands = [
@@ -972,7 +972,7 @@ rands = [
 ]
 
 [[ test ]]
-game_system = "Dracurouge"
+game_system = "Dracurouge:Korean"
 input = "ST"
 output = "原風景表(11) ＞ 虐待：あの地獄のような日々で、貴卿がされてきたことを思えば……騎士となっても、人を見る目は暗い。"
 rands = [
@@ -981,7 +981,7 @@ rands = [
 ]
 
 [[ test ]]
-game_system = "Dracurouge"
+game_system = "Dracurouge:Korean"
 input = "ST"
 output = "原風景表(66) ＞ 運命の子：貴卿の生まれた折、旅の賢者が訪れた。貴卿はきっと伝説に残る騎士となるだろう。そう約束されているのだ。"
 rands = [
@@ -990,7 +990,7 @@ rands = [
 ]
 
 [[ test ]]
-game_system = "Dracurouge"
+game_system = "Dracurouge:Korean"
 input = "PN"
 output = "受難表(11) ＞ 地獄：騎士らによって、御身は一度は地獄に封じられた。何とか脱出できたのは、幸運以外のなにものでもあるまい。"
 rands = [
@@ -999,7 +999,7 @@ rands = [
 ]
 
 [[ test ]]
-game_system = "Dracurouge"
+game_system = "Dracurouge:Korean"
 input = "PN"
 output = "受難表(66) ＞ 井の中の蛙：己こそ最強と思っていた御身だが……一人の騎士を見て、全ては崩れた。まだまだ、世界は広い。"
 rands = [
@@ -1008,7 +1008,7 @@ rands = [
 ]
 
 [[ test ]]
-game_system = "Dracurouge"
+game_system = "Dracurouge:Korean"
 input = "OS"
 output = "原罪表(11) ＞ 虐待：あの地獄のような日々で、御身がされてきたことを思えば……誰も彼も、常夜国すべて等しく呪うしかない。 ＞ 外見年齢：7+1D6×1D6 ＞ (7+1×1) ＞ 外見年齢：8年"
 rands = [
@@ -1019,7 +1019,7 @@ rands = [
 ]
 
 [[ test ]]
-game_system = "Dracurouge"
+game_system = "Dracurouge:Korean"
 input = "OS"
 output = "原罪表(66) ＞ 神童：御身は有り余る才を持って生まれた。騎士になるかと思われていたのだが……。 ＞ 外見年齢：7+1D6×1D6 ＞ (7+6×6) ＞ 外見年齢：43年"
 rands = [
@@ -1030,7 +1030,7 @@ rands = [
 ]
 
 [[ test ]]
-game_system = "Dracurouge"
+game_system = "Dracurouge:Korean"
 input = "RS"
 output = "近況表(11) ＞ 悪夢：眠りにつくたび、受難の記憶が蘇る。御身の心は晴れず、忌まわしい悪夢がつきまとい続けているのだ。 ＞ 活動年数：2D6×10 ＞ (2×10) ＞ 活動年数：20年"
 rands = [
@@ -1041,7 +1041,7 @@ rands = [
 ]
 
 [[ test ]]
-game_system = "Dracurouge"
+game_system = "Dracurouge:Korean"
 input = "RS"
 output = "近況表(33) ＞ 新米：御身は未だ、異端となったばかり。得た力に振り回され、受難にも懲りず（古き異端は選択できない）。 ＞ 活動年数：1 ＞ (1) ＞ 活動年数：1年"
 rands = [
@@ -1050,7 +1050,7 @@ rands = [
 ]
 
 [[ test ]]
-game_system = "Dracurouge"
+game_system = "Dracurouge:Korean"
 input = "RS"
 output = "近況表(66) ＞ 伝説：御身は異端なれど、常夜国の歴史に少なからず関わってきた。吟遊詩人にも歌われる伝説の存在だ。 ＞ 活動年数：3D6×50 ＞ (18×50) ＞ 活動年数：900年"
 rands = [
@@ -1062,7 +1062,7 @@ rands = [
 ]
 
 [[ test ]]
-game_system = "Dracurouge"
+game_system = "Dracurouge:Korean"
 input = "PP"
 output = "平和な過去表(11) ＞ 乱暴者：短気で、気性が荒く、ついつい手が出て乱暴を働いてしまう。故郷での評判はあまりよくない。今はどうだろう？ ＞ 外見年齢：8+2D6 ＞ (8+2) ＞ 外見年齢：10年"
 rands = [
@@ -1073,7 +1073,7 @@ rands = [
 ]
 
 [[ test ]]
-game_system = "Dracurouge"
+game_system = "Dracurouge:Korean"
 input = "PP"
 output = "平和な過去表(33) ＞ 好奇心：気を引くものがあれば、目を向ける。秘密とあれば暴かずにいられない。知らぬままでは、済ませられぬのだ。 ＞ 外見年齢：9+2D6 ＞ (9+6) ＞ 外見年齢：15年"
 rands = [
@@ -1084,7 +1084,7 @@ rands = [
 ]
 
 [[ test ]]
-game_system = "Dracurouge"
+game_system = "Dracurouge:Korean"
 input = "PP"
 output = "平和な過去表(66) ＞ 血統を遺す身：伴侶を得て、子を為し、家庭を築いた。その血は、御身が民ならざる身となった今も脈絡と続いている。 ＞ 外見年齢：12+4D6 ＞ (12+24) ＞ 外見年齢：36年"
 rands = [

--- a/test/data/LogHorizon_Korean.toml
+++ b/test/data/LogHorizon_Korean.toml
@@ -1023,7 +1023,7 @@ output = "GTRS ＞ CRを指定してください"
 rands = []
 
 [[ test ]]
-game_system = "LogHorizon"
+game_system = "LogHorizon:Korean"
 input = "ESTL1"
 output = "イースタル探索表(7[1,1])\n香りに誘われて：\n　小さな街道沿いで、商隊が〈走り茸〉にまとわりつかれている。\n　奴らを追い払うと、商隊のリーダーがお礼にと人数分の「干した〈走り松茸〉[換金](40G)」をくれる。\n　追われていた理由はこれだったらしい。"
 rands = [
@@ -1032,7 +1032,7 @@ rands = [
 ]
 
 [[ test ]]
-game_system = "LogHorizon"
+game_system = "LogHorizon:Korean"
 input = "CTRSE1"
 output = "金銭財宝表（拡張）(7[1,1]) ＞ 35G"
 rands = [
@@ -1041,7 +1041,7 @@ rands = [
 ]
 
 [[ test ]]
-game_system = "LogHorizon"
+game_system = "LogHorizon:Korean"
 input = "CTRSE30"
 output = "金銭財宝表（拡張）(162[6,6]) ＞ 1600G"
 rands = [
@@ -1050,7 +1050,7 @@ rands = [
 ]
 
 [[ test ]]
-game_system = "LogHorizon"
+game_system = "LogHorizon:Korean"
 input = "CTRSE30+1 +α検証"
 output = "金銭財宝表（拡張）(163[6,6]) ＞ 1430G&200G"
 rands = [
@@ -1059,7 +1059,7 @@ rands = [
 ]
 
 [[ test ]]
-game_system = "LogHorizon"
+game_system = "LogHorizon:Korean"
 input = "CTRSE32+1 +α検証"
 output = "金銭財宝表（拡張）(173[6,6]) ＞ 1430G&400G"
 rands = [
@@ -1068,7 +1068,7 @@ rands = [
 ]
 
 [[ test ]]
-game_system = "LogHorizon"
+game_system = "LogHorizon:Korean"
 input = "CTRSE35 上限"
 output = "金銭財宝表（拡張）(187[6,6]) ＞ 1500G&600G"
 rands = [
@@ -1077,7 +1077,7 @@ rands = [
 ]
 
 [[ test ]]
-game_system = "LogHorizon"
+game_system = "LogHorizon:Korean"
 input = "CTRSE1-1 下限範囲外"
 output = "金銭財宝表（拡張）(6[1,1]) ＞ 6以下の出目は未定義です"
 rands = [
@@ -1086,7 +1086,7 @@ rands = [
 ]
 
 [[ test ]]
-game_system = "LogHorizon"
+game_system = "LogHorizon:Korean"
 input = "CTRSE35+1 上限範囲外"
 output = "金銭財宝表（拡張）(188[6,6]) ＞ 188以上の出目は未定義です"
 rands = [
@@ -1095,25 +1095,25 @@ rands = [
 ]
 
 [[ test ]]
-game_system = "LogHorizon"
+game_system = "LogHorizon:Korean"
 input = "CTRSE+100 任意の出目"
 output = "金銭財宝表（拡張）(100) ＞ 640G"
 rands = []
 
 [[ test ]]
-game_system = "LogHorizon"
+game_system = "LogHorizon:Korean"
 input = "CTRSE1+100$ 出目を7固定"
 output = "金銭財宝表（拡張）(112[7]) ＞ 790G"
 rands = []
 
 [[ test ]]
-game_system = "LogHorizon"
+game_system = "LogHorizon:Korean"
 input = "CTRSE"
 output = "CTRSE ＞ CRを指定してください"
 rands = []
 
 [[ test ]]
-game_system = "LogHorizon"
+game_system = "LogHorizon:Korean"
 input = "MTRSE1"
 output = "魔法素材財宝表（拡張）(7[1,1]) ＞ 魔触媒2[魔触媒2](20G)&魔触媒1[魔触媒1](15G)"
 rands = [
@@ -1122,7 +1122,7 @@ rands = [
 ]
 
 [[ test ]]
-game_system = "LogHorizon"
+game_system = "LogHorizon:Korean"
 input = "MTRSE30"
 output = "魔法素材財宝表（拡張）(162[6,6]) ＞ 陽喰い鳥の嘴[コア素材](1640G)"
 rands = [
@@ -1131,7 +1131,7 @@ rands = [
 ]
 
 [[ test ]]
-game_system = "LogHorizon"
+game_system = "LogHorizon:Korean"
 input = "MTRSE35"
 output = "魔法素材財宝表（拡張）(187[6,6]) ＞ 魔触媒30[魔触媒30](820G)&輝くメガネ[換金](680G)&600G"
 rands = [
@@ -1140,7 +1140,7 @@ rands = [
 ]
 
 [[ test ]]
-game_system = "LogHorizon"
+game_system = "LogHorizon:Korean"
 input = "ITRSE1"
 output = "換金アイテム財宝表（拡張）(7[1,1]) ＞ 破れた書籍[換金](30G)"
 rands = [
@@ -1149,7 +1149,7 @@ rands = [
 ]
 
 [[ test ]]
-game_system = "LogHorizon"
+game_system = "LogHorizon:Korean"
 input = "ITRSE30"
 output = "換金アイテム財宝表（拡張）(162[6,6]) ＞ 藍玉の腕輪[換金](1600G)"
 rands = [
@@ -1158,7 +1158,7 @@ rands = [
 ]
 
 [[ test ]]
-game_system = "LogHorizon"
+game_system = "LogHorizon:Korean"
 input = "ITRSE35"
 output = "換金アイテム財宝表（拡張）(187[6,6]) ＞ しゃべる姿見[換金](1500G)&600G"
 rands = [
@@ -1167,7 +1167,7 @@ rands = [
 ]
 
 [[ test ]]
-game_system = "LogHorizon"
+game_system = "LogHorizon:Korean"
 input = "OTRSE1"
 output = "そのほか財宝表（拡張）(7[1,1]) ＞ 百科事典(40G)"
 rands = [
@@ -1176,7 +1176,7 @@ rands = [
 ]
 
 [[ test ]]
-game_system = "LogHorizon"
+game_system = "LogHorizon:Korean"
 input = "OTRSE30"
 output = "そのほか財宝表（拡張）(162[6,6]) ＞ ウルミン(1900G)"
 rands = [
@@ -1185,7 +1185,7 @@ rands = [
 ]
 
 [[ test ]]
-game_system = "LogHorizon"
+game_system = "LogHorizon:Korean"
 input = "OTRSE35"
 output = "そのほか財宝表（拡張）(187[6,6]) ＞ 竜手甲[破損](1650G)&600G"
 rands = [

--- a/test/test_game_system_commands.rb
+++ b/test/test_game_system_commands.rb
@@ -45,6 +45,12 @@ class TestGameSystemCommands < Test::Unit::TestCase
       filename_base = File.basename(filename, ".toml")
       data = Tomlrb.load_file(filename, symbolize_keys: true)
 
+      systems = data[:test].map { |t| t[:game_system] }.uniq
+      unless systems.count == 1
+        warn("Multiple game_system (#{systems.join(',')}) in #{filename}.")
+        exit(1)
+      end
+
       data[:test].each.with_index(1) do |test_case, index|
         test_case[:filename] = filename
         test_case[:output] = nil if test_case[:output].empty? # TOMLではnilを表現できないので空文字で代用


### PR DESCRIPTION
* 1つのTOMLに複数のgame_systemがある場合、テストを失敗させる。
* このテストで判明した指定ミスを訂正

Memo:
特に多言語対応時の修正漏れが大きいので、今後方針変更があっても多言語ファイルに関してはこのテストがほしいかと思います。