### PR TITLE
[StellarKnights] 【アタック判定】のダイス数に 0 が指定された場合を考慮

### DIFF
--- a/lib/bcdice/game_system/StellarKnights.rb
+++ b/lib/bcdice/game_system/StellarKnights.rb
@@ -114,7 +114,7 @@ module BCDice
           output += " ＞ [#{dices.join(',')}]"
         end
 
-        if defence.nil?
+        if defence.nil? || dices.empty?
           success = false
           failure = false
         else

--- a/lib/bcdice/game_system/StellarKnights.rb
+++ b/lib/bcdice/game_system/StellarKnights.rb
@@ -101,7 +101,7 @@ module BCDice
         dice_text = dices.join(",")
 
         output = "(#{command}) ＞ #{dice_text}"
-        output += "ダイスが 0 個です" if dices.empty?
+        output += "ダイスが 0 個です（アタック判定が発生しません）" if dices.empty?
 
         # FAQによると、ダイスの置き換えは宣言された順番に適用されていく
         dice_change_rules = parse_dice_change_rules(dice_change_text)

--- a/lib/bcdice/game_system/StellarKnights.rb
+++ b/lib/bcdice/game_system/StellarKnights.rb
@@ -95,13 +95,15 @@ module BCDice
       # @param [Integer | nil] defence
       # @param [String] dice_change_text
       # @param [String] command
-      # @return [String]
+      # @return [Result, String]
       def resolute_action(num_dices, defence, dice_change_text, command)
         dices = @randomizer.roll_barabara(num_dices, 6).sort
         dice_text = dices.join(",")
 
         output = "(#{command}) ＞ #{dice_text}"
-        output += "ダイスが 0 個です（アタック判定が発生しません）" if dices.empty?
+        if dices.empty?
+          return output + "ダイスが 0 個です（アタック判定が発生しません）"
+        end
 
         # FAQによると、ダイスの置き換えは宣言された順番に適用されていく
         dice_change_rules = parse_dice_change_rules(dice_change_text)
@@ -109,12 +111,12 @@ module BCDice
           dices.map! { |val| val == rule[:from] ? rule[:to] : val }
         end
 
-        unless dice_change_rules.empty? || dices.empty?
+        unless dice_change_rules.empty?
           dices.sort!
           output += " ＞ [#{dices.join(',')}]"
         end
 
-        if defence.nil? || dices.empty?
+        if defence.nil?
           success = false
           failure = false
         else

--- a/lib/bcdice/game_system/StellarKnights.rb
+++ b/lib/bcdice/game_system/StellarKnights.rb
@@ -101,6 +101,7 @@ module BCDice
         dice_text = dices.join(",")
 
         output = "(#{command}) ＞ #{dice_text}"
+        output += "ダイスが 0 個です" if dices.empty?
 
         # FAQによると、ダイスの置き換えは宣言された順番に適用されていく
         dice_change_rules = parse_dice_change_rules(dice_change_text)
@@ -108,7 +109,7 @@ module BCDice
           dices.map! { |val| val == rule[:from] ? rule[:to] : val }
         end
 
-        unless dice_change_rules.empty?
+        unless dice_change_rules.empty? || dices.empty?
           dices.sort!
           output += " ＞ [#{dices.join(',')}]"
         end

--- a/test/data/StellarKnights.toml
+++ b/test/data/StellarKnights.toml
@@ -42,8 +42,7 @@ rands = [
 [[ test ]]
 game_system = "StellarKnights"
 input = "0SK6"
-output = "(0SK6) ＞ ダイスが 0 個です ＞ 成功数: 0"
-failure = true
+output = "(0SK6) ＞ ダイスが 0 個です"
 rands = []
 
 [[ test ]]
@@ -93,8 +92,7 @@ rands = []
 [[ test ]]
 game_system = "StellarKnights"
 input = "0SK4,1>6"
-output = "(0SK4,1>6) ＞ ダイスが 0 個です ＞ 成功数: 0"
-failure = true
+output = "(0SK4,1>6) ＞ ダイスが 0 個です"
 rands = []
 
 [[ test ]]

--- a/test/data/StellarKnights.toml
+++ b/test/data/StellarKnights.toml
@@ -11,6 +11,12 @@ rands = [
 
 [[ test ]]
 game_system = "StellarKnights"
+input = "0SK"
+output = "(0SK) ＞ ダイスが 0 個です"
+rands = []
+
+[[ test ]]
+game_system = "StellarKnights"
 input = "5SK3"
 output = "(5SK3) ＞ 2,3,5,6,6 ＞ 成功数: 4"
 success = true
@@ -32,6 +38,13 @@ rands = [
   { sides = 6, value = 3 },
   { sides = 6, value = 2 },
 ]
+
+[[ test ]]
+game_system = "StellarKnights"
+input = "0SK6"
+output = "(0SK6) ＞ ダイスが 0 個です ＞ 成功数: 0"
+failure = true
+rands = []
 
 [[ test ]]
 game_system = "StellarKnights"
@@ -70,6 +83,19 @@ rands = [
   { sides = 6, value = 5 },
   { sides = 6, value = 6 },
 ]
+
+[[ test ]]
+game_system = "StellarKnights"
+input = "0SK,1>6"
+output = "(0SK,1>6) ＞ ダイスが 0 個です"
+rands = []
+
+[[ test ]]
+game_system = "StellarKnights"
+input = "0SK4,1>6"
+output = "(0SK4,1>6) ＞ ダイスが 0 個です ＞ 成功数: 0"
+failure = true
+rands = []
 
 [[ test ]]
 game_system = "StellarKnights"

--- a/test/data/StellarKnights.toml
+++ b/test/data/StellarKnights.toml
@@ -12,7 +12,7 @@ rands = [
 [[ test ]]
 game_system = "StellarKnights"
 input = "0SK"
-output = "(0SK) ＞ ダイスが 0 個です"
+output = "(0SK) ＞ ダイスが 0 個です（アタック判定が発生しません）"
 rands = []
 
 [[ test ]]
@@ -42,7 +42,7 @@ rands = [
 [[ test ]]
 game_system = "StellarKnights"
 input = "0SK6"
-output = "(0SK6) ＞ ダイスが 0 個です"
+output = "(0SK6) ＞ ダイスが 0 個です（アタック判定が発生しません）"
 rands = []
 
 [[ test ]]
@@ -86,13 +86,13 @@ rands = [
 [[ test ]]
 game_system = "StellarKnights"
 input = "0SK,1>6"
-output = "(0SK,1>6) ＞ ダイスが 0 個です"
+output = "(0SK,1>6) ＞ ダイスが 0 個です（アタック判定が発生しません）"
 rands = []
 
 [[ test ]]
 game_system = "StellarKnights"
 input = "0SK4,1>6"
-output = "(0SK4,1>6) ＞ ダイスが 0 個です"
+output = "(0SK4,1>6) ＞ ダイスが 0 個です（アタック判定が発生しません）"
 rands = []
 
 [[ test ]]


### PR DESCRIPTION
# 内容

　【アタック判定】のダイス数に 0 が指定された場合、メッセージでその旨を表示する。

# 背景

　今までは結果文字列が `"(0SK) ＞ "` のようになって、不自然かつ不親切だったので。