### PR TITLE
BattleTech: PPCコマンドの構文解析を修正する

### DIFF
--- a/lib/bcdice/game_system/BattleTech.rb
+++ b/lib/bcdice/game_system/BattleTech.rb
@@ -117,7 +117,7 @@ module BCDice
       LRM_LIMIT = 5
 
       def getHitResult(count, damageFunc, tail)
-        m = /([LCR][LU]?)?(\+\d+)?>=(\d+)/.match(tail)
+        m = /\A([LCR][LU]?)?(\+\d+)?>=(\d+)/.match(tail)
         return nil unless m
 
         side = m[1] || 'C'
@@ -336,7 +336,7 @@ module BCDice
         # TODO: 攻撃を表すクラスに変える
 
         # "PPC" 以降の部位指定
-        side = parse_result.command[2..-1]
+        side = parse_result.command[3..-1]
 
         modifier = Format.modifier(parse_result.modify_number)
         target = parse_result.target_number

--- a/test/data/BattleTech.toml
+++ b/test/data/BattleTech.toml
@@ -168,13 +168,16 @@ rands = [
 game_system = "BattleTech"
 input = "PPCLU>=11"
 output = """
-12[6,6]>=11 ＞ 命中 ＞ [6] 頭 10点
- ＞ 1回命中 命中箇所：頭(1回) 10点 ＞ 合計ダメージ 10点"""
+12[6,6]>=11 ＞ 命中 ＞ [1] 左胴 10点
+ ＞ 1回命中 命中箇所：左胴(1回) 10点 ＞ 合計ダメージ 10点"""
 success = true
 rands = [
+  # 2D6 命中判定
   { sides = 6, value = 6 },
   { sides = 6, value = 6 },
-  { sides = 6, value = 6 },
+
+  # 1D6 部位
+  { sides = 6, value = 1 },
 ]
 
 [[ test ]]


### PR DESCRIPTION
バトルテックの `PPC` コマンドの部位指定取り出しで、該当部分の開始位置を間違えていたのを修正しました（テストケースも、誤りで落ちるように変えました）。また、`getHitResult` の正規表現マッチが甘く、結果的に正しく解釈されてしまうのを修正しました（問題が見つかりにくくなるため）。