### PR TITLE
[GardenOrder] Result対応およびファンブル境界,連続攻撃の修正

### DIFF
--- a/lib/bcdice/game_system/GardenOrder.rb
+++ b/lib/bcdice/game_system/GardenOrder.rb
@@ -59,7 +59,9 @@ module BCDice
       def check_roll_repeat_attack(success_rate, repeat_count, critical_border)
         success_rate_per_one = success_rate / repeat_count
         # 連続攻撃は最終的な成功率が50%以上であることが必要 cf. p217
-        return "エラー。最終的な成功率が50％未満です。" if repeat_count > 1 && success_rate_per_one < 50
+        if repeat_count > 1 && success_rate_per_one < 50
+          return "D100<=#{success_rate_per_one}@#{critical_border} ＞ 連続攻撃は成功率が50％以上必要です"
+        end
 
         check_roll(success_rate_per_one, critical_border)
       end

--- a/lib/bcdice/game_system/ScreamHighSchool.rb
+++ b/lib/bcdice/game_system/ScreamHighSchool.rb
@@ -73,13 +73,13 @@ module BCDice
 
         dice_value = @randomizer.roll_once(100)
         result = get_check_result(dice_value, success_rate, critical_border, fumble_border)
-        title, supplementary = get_supplementary(command_type, result)
+        title, supplementary = get_supplementary(command_type, result.text)
         unless supplementary.empty?
           supplementary = "（#{supplementary}）"
         end
 
-        text = "#{title}判定 D100<=#{success_rate}@#{critical_border} ＞ #{dice_value} ＞ #{result}#{supplementary}"
-        return text
+        result.text = "#{title}判定 D100<=#{success_rate}@#{critical_border} ＞ #{dice_value} ＞ #{result.text}#{supplementary}"
+        return result
       end
 
       def get_supplementary(command_type, result)

--- a/test/data/AceKillerGene.toml
+++ b/test/data/AceKillerGene.toml
@@ -2,6 +2,7 @@
 game_system = "AceKillerGene"
 input = "AK50"
 output = "D100<=50@10 ＞ 50 ＞ 成功"
+success = true
 rands = [
   { sides = 100, value = 50 },
 ]
@@ -10,6 +11,7 @@ rands = [
 game_system = "AceKillerGene"
 input = "AK50"
 output = "D100<=50@10 ＞ 51 ＞ 失敗"
+failure = true
 rands = [
   { sides = 100, value = 51 },
 ]
@@ -18,6 +20,7 @@ rands = [
 game_system = "AceKillerGene"
 input = "AK50"
 output = "D100<=50@10 ＞ 95 ＞ 失敗"
+failure = true
 rands = [
   { sides = 100, value = 95 },
 ]
@@ -26,6 +29,8 @@ rands = [
 game_system = "AceKillerGene"
 input = "AK50"
 output = "D100<=50@10 ＞ 96 ＞ ファンブル"
+failure = true
+fumble = true
 rands = [
   { sides = 100, value = 96 },
 ]
@@ -34,6 +39,8 @@ rands = [
 game_system = "AceKillerGene"
 input = "AK96"
 output = "D100<=96@19 ＞ 96 ＞ ファンブル"
+failure = true
+fumble = true
 rands = [
   { sides = 100, value = 96 },
 ]
@@ -42,6 +49,8 @@ rands = [
 game_system = "AceKillerGene"
 input = "AK99"
 output = "D100<=99@19 ＞ 96 ＞ ファンブル"
+failure = true
+fumble = true
 rands = [
   { sides = 100, value = 96 },
 ]
@@ -50,6 +59,7 @@ rands = [
 game_system = "AceKillerGene"
 input = "AK100"
 output = "D100<=100@20 ＞ 96 ＞ 成功"
+success = true
 rands = [
   { sides = 100, value = 96 },
 ]
@@ -58,6 +68,7 @@ rands = [
 game_system = "AceKillerGene"
 input = "AK100"
 output = "D100<=100@20 ＞ 98 ＞ 成功"
+success = true
 rands = [
   { sides = 100, value = 98 },
 ]
@@ -66,6 +77,8 @@ rands = [
 game_system = "AceKillerGene"
 input = "AK100"
 output = "D100<=100@20 ＞ 99 ＞ ファンブル"
+failure = true
+fumble = true
 rands = [
   { sides = 100, value = 99 },
 ]
@@ -74,6 +87,7 @@ rands = [
 game_system = "AceKillerGene"
 input = "AK50"
 output = "D100<=50@10 ＞ 11 ＞ 成功"
+success = true
 rands = [
   { sides = 100, value = 11 },
 ]
@@ -82,6 +96,8 @@ rands = [
 game_system = "AceKillerGene"
 input = "AK50"
 output = "D100<=50@10 ＞ 10 ＞ クリティカル"
+success = true
+critical = true
 rands = [
   { sides = 100, value = 10 },
 ]
@@ -89,7 +105,9 @@ rands = [
 [[ test ]]
 game_system = "AceKillerGene"
 input = "AK500"
-output = "D100<=500@100 ＞ 100 ＞ クリティカル"
+output = "D100<=500@100 ＞ 100 ＞ ファンブル"
+failure = true
+fumble = true
 rands = [
   { sides = 100, value = 100 },
 ]
@@ -98,6 +116,7 @@ rands = [
 game_system = "AceKillerGene"
 input = "AK0"
 output = "D100<=0@1 ＞ 2 ＞ 失敗"
+failure = true
 rands = [
   { sides = 100, value = 2 },
 ]
@@ -106,6 +125,8 @@ rands = [
 game_system = "AceKillerGene"
 input = "AK0"
 output = "D100<=0@1 ＞ 1 ＞ クリティカル"
+success = true
+critical = true
 rands = [
   { sides = 100, value = 1 },
 ]
@@ -114,6 +135,7 @@ rands = [
 game_system = "AceKillerGene"
 input = "AK50"
 output = "D100<=50@10 ＞ 11 ＞ 成功"
+success = true
 rands = [
   { sides = 100, value = 11 },
 ]
@@ -122,6 +144,8 @@ rands = [
 game_system = "AceKillerGene"
 input = "AK50@11"
 output = "D100<=50@11 ＞ 11 ＞ クリティカル"
+success = true
+critical = true
 rands = [
   { sides = 100, value = 11 },
 ]
@@ -130,14 +154,35 @@ rands = [
 game_system = "AceKillerGene"
 input = "AK50@11"
 output = "D100<=50@11 ＞ 12 ＞ 成功"
+success = true
 rands = [
   { sides = 100, value = 12 },
 ]
 
 [[ test ]]
 game_system = "AceKillerGene"
+input = "AK50@5"
+output = "D100<=50@5 ＞ 10 ＞ 成功"
+success = true
+rands = [
+  { sides = 100, value = 10 },
+]
+
+[[ test ]]
+game_system = "AceKillerGene"
+input = "AK50@5"
+output = "D100<=50@5 ＞ 5 ＞ クリティカル"
+success = true
+critical = true
+rands = [
+  { sides = 100, value = 5 },
+]
+
+[[ test ]]
+game_system = "AceKillerGene"
 input = "AK100/2"
 output = "D100<=50@20 ＞ 50 ＞ 成功"
+success = true
 rands = [
   { sides = 100, value = 50 },
 ]
@@ -146,6 +191,7 @@ rands = [
 game_system = "AceKillerGene"
 input = "AK100/2"
 output = "D100<=50@20 ＞ 51 ＞ 失敗"
+failure = true
 rands = [
   { sides = 100, value = 51 },
 ]
@@ -154,6 +200,8 @@ rands = [
 game_system = "AceKillerGene"
 input = "AK100/2"
 output = "D100<=50@20 ＞ 96 ＞ ファンブル"
+failure = true
+fumble = true
 rands = [
   { sides = 100, value = 96 },
 ]
@@ -162,6 +210,7 @@ rands = [
 game_system = "AceKillerGene"
 input = "AK100/2"
 output = "D100<=50@20 ＞ 21 ＞ 成功"
+success = true
 rands = [
   { sides = 100, value = 21 },
 ]
@@ -170,6 +219,8 @@ rands = [
 game_system = "AceKillerGene"
 input = "AK100/2"
 output = "D100<=50@20 ＞ 20 ＞ クリティカル"
+success = true
+critical = true
 rands = [
   { sides = 100, value = 20 },
 ]
@@ -178,6 +229,7 @@ rands = [
 game_system = "AceKillerGene"
 input = "AK150/2"
 output = "D100<=75@30 ＞ 51 ＞ 成功"
+success = true
 rands = [
   { sides = 100, value = 51 },
 ]
@@ -186,6 +238,8 @@ rands = [
 game_system = "AceKillerGene"
 input = "AK150/2"
 output = "D100<=75@30 ＞ 30 ＞ クリティカル"
+success = true
+critical = true
 rands = [
   { sides = 100, value = 30 },
 ]
@@ -194,8 +248,52 @@ rands = [
 game_system = "AceKillerGene"
 input = "AK150/3"
 output = "D100<=50@30 ＞ 51 ＞ 失敗"
+failure = true
 rands = [
   { sides = 100, value = 51 },
+]
+
+[[ test ]]
+game_system = "AceKillerGene"
+input = "AK179/3"
+output = "D100<=59@35 ＞ 60 ＞ 失敗"
+failure = true
+rands = [
+  { sides = 100, value = 60 },
+]
+
+[[ test ]]
+game_system = "AceKillerGene"
+input = "AK179/3"
+output = "D100<=59@35 ＞ 59 ＞ 成功"
+success = true
+rands = [
+  { sides = 100, value = 59 },
+]
+
+[[ test ]]
+game_system = "AceKillerGene"
+input = "AK179/3"
+output = "D100<=59@35 ＞ 35 ＞ クリティカル"
+success = true
+critical = true
+rands = [
+  { sides = 100, value = 35 },
+]
+
+[[ test ]]
+game_system = "AceKillerGene"
+input = "AK99/2"
+output = "エラー。最終的な成功率が50％未満です。"
+rands = []
+
+[[ test ]]
+game_system = "AceKillerGene"
+input = "AK(99/2)"
+output = "D100<=49@9 ＞ 10 ＞ 成功"
+success = true
+rands = [
+  { sides = 100, value = 10 },
 ]
 
 [[ test ]]
@@ -256,6 +354,8 @@ rands = []
 game_system = "AceKillerGene"
 input = "AK(20-20)"
 output = "D100<=0@1 ＞ 1 ＞ クリティカル"
+success = true
+critical = true
 rands = [
   { sides = 100, value = 1 },
 ]
@@ -264,6 +364,8 @@ rands = [
 game_system = "AceKillerGene"
 input = "AK(20-50)"
 output = "D100<=0@1 ＞ 1 ＞ クリティカル"
+success = true
+critical = true
 rands = [
   { sides = 100, value = 1 },
 ]

--- a/test/data/AceKillerGene.toml
+++ b/test/data/AceKillerGene.toml
@@ -284,7 +284,7 @@ rands = [
 [[ test ]]
 game_system = "AceKillerGene"
 input = "AK99/2"
-output = "エラー。最終的な成功率が50％未満です。"
+output = "D100<=49@19 ＞ 連続攻撃は成功率が50％以上必要です"
 rands = []
 
 [[ test ]]

--- a/test/data/GardenOrder.toml
+++ b/test/data/GardenOrder.toml
@@ -284,7 +284,7 @@ rands = [
 [[ test ]]
 game_system = "GardenOrder"
 input = "GO99/2"
-output = "エラー。最終的な成功率が50％未満です。"
+output = "D100<=49@19 ＞ 連続攻撃は成功率が50％以上必要です"
 rands = []
 
 [[ test ]]

--- a/test/data/GardenOrder.toml
+++ b/test/data/GardenOrder.toml
@@ -2,6 +2,7 @@
 game_system = "GardenOrder"
 input = "GO50"
 output = "D100<=50@10 ＞ 50 ＞ 成功"
+success = true
 rands = [
   { sides = 100, value = 50 },
 ]
@@ -10,6 +11,7 @@ rands = [
 game_system = "GardenOrder"
 input = "GO50"
 output = "D100<=50@10 ＞ 51 ＞ 失敗"
+failure = true
 rands = [
   { sides = 100, value = 51 },
 ]
@@ -18,6 +20,7 @@ rands = [
 game_system = "GardenOrder"
 input = "GO50"
 output = "D100<=50@10 ＞ 95 ＞ 失敗"
+failure = true
 rands = [
   { sides = 100, value = 95 },
 ]
@@ -26,6 +29,8 @@ rands = [
 game_system = "GardenOrder"
 input = "GO50"
 output = "D100<=50@10 ＞ 96 ＞ ファンブル"
+failure = true
+fumble = true
 rands = [
   { sides = 100, value = 96 },
 ]
@@ -34,6 +39,8 @@ rands = [
 game_system = "GardenOrder"
 input = "GO96"
 output = "D100<=96@19 ＞ 96 ＞ ファンブル"
+failure = true
+fumble = true
 rands = [
   { sides = 100, value = 96 },
 ]
@@ -42,6 +49,8 @@ rands = [
 game_system = "GardenOrder"
 input = "GO99"
 output = "D100<=99@19 ＞ 96 ＞ ファンブル"
+failure = true
+fumble = true
 rands = [
   { sides = 100, value = 96 },
 ]
@@ -50,6 +59,7 @@ rands = [
 game_system = "GardenOrder"
 input = "GO100"
 output = "D100<=100@20 ＞ 96 ＞ 成功"
+success = true
 rands = [
   { sides = 100, value = 96 },
 ]
@@ -58,6 +68,7 @@ rands = [
 game_system = "GardenOrder"
 input = "GO100"
 output = "D100<=100@20 ＞ 98 ＞ 成功"
+success = true
 rands = [
   { sides = 100, value = 98 },
 ]
@@ -66,6 +77,8 @@ rands = [
 game_system = "GardenOrder"
 input = "GO100"
 output = "D100<=100@20 ＞ 99 ＞ ファンブル"
+failure = true
+fumble = true
 rands = [
   { sides = 100, value = 99 },
 ]
@@ -74,6 +87,7 @@ rands = [
 game_system = "GardenOrder"
 input = "GO50"
 output = "D100<=50@10 ＞ 11 ＞ 成功"
+success = true
 rands = [
   { sides = 100, value = 11 },
 ]
@@ -82,6 +96,8 @@ rands = [
 game_system = "GardenOrder"
 input = "GO50"
 output = "D100<=50@10 ＞ 10 ＞ クリティカル"
+success = true
+critical = true
 rands = [
   { sides = 100, value = 10 },
 ]
@@ -89,7 +105,9 @@ rands = [
 [[ test ]]
 game_system = "GardenOrder"
 input = "GO500"
-output = "D100<=500@100 ＞ 100 ＞ クリティカル"
+output = "D100<=500@100 ＞ 100 ＞ ファンブル"
+failure = true
+fumble = true
 rands = [
   { sides = 100, value = 100 },
 ]
@@ -98,6 +116,7 @@ rands = [
 game_system = "GardenOrder"
 input = "GO0"
 output = "D100<=0@1 ＞ 2 ＞ 失敗"
+failure = true
 rands = [
   { sides = 100, value = 2 },
 ]
@@ -106,6 +125,8 @@ rands = [
 game_system = "GardenOrder"
 input = "GO0"
 output = "D100<=0@1 ＞ 1 ＞ クリティカル"
+success = true
+critical = true
 rands = [
   { sides = 100, value = 1 },
 ]
@@ -114,6 +135,7 @@ rands = [
 game_system = "GardenOrder"
 input = "GO50"
 output = "D100<=50@10 ＞ 11 ＞ 成功"
+success = true
 rands = [
   { sides = 100, value = 11 },
 ]
@@ -122,6 +144,8 @@ rands = [
 game_system = "GardenOrder"
 input = "GO50@11"
 output = "D100<=50@11 ＞ 11 ＞ クリティカル"
+success = true
+critical = true
 rands = [
   { sides = 100, value = 11 },
 ]
@@ -130,14 +154,35 @@ rands = [
 game_system = "GardenOrder"
 input = "GO50@11"
 output = "D100<=50@11 ＞ 12 ＞ 成功"
+success = true
 rands = [
   { sides = 100, value = 12 },
 ]
 
 [[ test ]]
 game_system = "GardenOrder"
+input = "GO50@5"
+output = "D100<=50@5 ＞ 10 ＞ 成功"
+success = true
+rands = [
+  { sides = 100, value = 10 },
+]
+
+[[ test ]]
+game_system = "GardenOrder"
+input = "GO50@5"
+output = "D100<=50@5 ＞ 5 ＞ クリティカル"
+success = true
+critical = true
+rands = [
+  { sides = 100, value = 5 },
+]
+
+[[ test ]]
+game_system = "GardenOrder"
 input = "GO100/2"
 output = "D100<=50@20 ＞ 50 ＞ 成功"
+success = true
 rands = [
   { sides = 100, value = 50 },
 ]
@@ -146,6 +191,7 @@ rands = [
 game_system = "GardenOrder"
 input = "GO100/2"
 output = "D100<=50@20 ＞ 51 ＞ 失敗"
+failure = true
 rands = [
   { sides = 100, value = 51 },
 ]
@@ -154,6 +200,8 @@ rands = [
 game_system = "GardenOrder"
 input = "GO100/2"
 output = "D100<=50@20 ＞ 96 ＞ ファンブル"
+failure = true
+fumble = true
 rands = [
   { sides = 100, value = 96 },
 ]
@@ -162,6 +210,7 @@ rands = [
 game_system = "GardenOrder"
 input = "GO100/2"
 output = "D100<=50@20 ＞ 21 ＞ 成功"
+success = true
 rands = [
   { sides = 100, value = 21 },
 ]
@@ -170,6 +219,8 @@ rands = [
 game_system = "GardenOrder"
 input = "GO100/2"
 output = "D100<=50@20 ＞ 20 ＞ クリティカル"
+success = true
+critical = true
 rands = [
   { sides = 100, value = 20 },
 ]
@@ -178,6 +229,7 @@ rands = [
 game_system = "GardenOrder"
 input = "GO150/2"
 output = "D100<=75@30 ＞ 51 ＞ 成功"
+success = true
 rands = [
   { sides = 100, value = 51 },
 ]
@@ -186,6 +238,8 @@ rands = [
 game_system = "GardenOrder"
 input = "GO150/2"
 output = "D100<=75@30 ＞ 30 ＞ クリティカル"
+success = true
+critical = true
 rands = [
   { sides = 100, value = 30 },
 ]
@@ -194,8 +248,52 @@ rands = [
 game_system = "GardenOrder"
 input = "GO150/3"
 output = "D100<=50@30 ＞ 51 ＞ 失敗"
+failure = true
 rands = [
   { sides = 100, value = 51 },
+]
+
+[[ test ]]
+game_system = "GardenOrder"
+input = "GO179/3"
+output = "D100<=59@35 ＞ 60 ＞ 失敗"
+failure = true
+rands = [
+  { sides = 100, value = 60 },
+]
+
+[[ test ]]
+game_system = "GardenOrder"
+input = "GO179/3"
+output = "D100<=59@35 ＞ 59 ＞ 成功"
+success = true
+rands = [
+  { sides = 100, value = 59 },
+]
+
+[[ test ]]
+game_system = "GardenOrder"
+input = "GO179/3"
+output = "D100<=59@35 ＞ 35 ＞ クリティカル"
+success = true
+critical = true
+rands = [
+  { sides = 100, value = 35 },
+]
+
+[[ test ]]
+game_system = "GardenOrder"
+input = "GO99/2"
+output = "エラー。最終的な成功率が50％未満です。"
+rands = []
+
+[[ test ]]
+game_system = "GardenOrder"
+input = "GO(99/2)"
+output = "D100<=49@9 ＞ 10 ＞ 成功"
+success = true
+rands = [
+  { sides = 100, value = 10 },
 ]
 
 [[ test ]]
@@ -256,6 +354,8 @@ rands = []
 game_system = "GardenOrder"
 input = "GO(20-20)"
 output = "D100<=0@1 ＞ 1 ＞ クリティカル"
+success = true
+critical = true
 rands = [
   { sides = 100, value = 1 },
 ]
@@ -264,6 +364,8 @@ rands = [
 game_system = "GardenOrder"
 input = "GO(20-50)"
 output = "D100<=0@1 ＞ 1 ＞ クリティカル"
+success = true
+critical = true
 rands = [
   { sides = 100, value = 1 },
 ]

--- a/test/data/ScreamHighSchool.toml
+++ b/test/data/ScreamHighSchool.toml
@@ -2,6 +2,7 @@
 game_system = "ScreamHighSchool"
 input = "SH50"
 output = "D100<=50@10 ＞ 50 ＞ 成功"
+success = true
 rands = [
   { sides = 100, value = 50 },
 ]
@@ -10,6 +11,7 @@ rands = [
 game_system = "ScreamHighSchool"
 input = "SH50"
 output = "D100<=50@10 ＞ 51 ＞ 失敗"
+failure = true
 rands = [
   { sides = 100, value = 51 },
 ]
@@ -18,6 +20,7 @@ rands = [
 game_system = "ScreamHighSchool"
 input = "SH50"
 output = "D100<=50@10 ＞ 95 ＞ 失敗"
+failure = true
 rands = [
   { sides = 100, value = 95 },
 ]
@@ -26,6 +29,8 @@ rands = [
 game_system = "ScreamHighSchool"
 input = "SH50"
 output = "D100<=50@10 ＞ 96 ＞ ファンブル"
+failure = true
+fumble = true
 rands = [
   { sides = 100, value = 96 },
 ]
@@ -34,6 +39,8 @@ rands = [
 game_system = "ScreamHighSchool"
 input = "SH96"
 output = "D100<=96@19 ＞ 96 ＞ ファンブル"
+failure = true
+fumble = true
 rands = [
   { sides = 100, value = 96 },
 ]
@@ -42,6 +49,8 @@ rands = [
 game_system = "ScreamHighSchool"
 input = "SH99"
 output = "D100<=99@19 ＞ 96 ＞ ファンブル"
+failure = true
+fumble = true
 rands = [
   { sides = 100, value = 96 },
 ]
@@ -50,6 +59,7 @@ rands = [
 game_system = "ScreamHighSchool"
 input = "SH100"
 output = "D100<=100@20 ＞ 96 ＞ 成功"
+success = true
 rands = [
   { sides = 100, value = 96 },
 ]
@@ -58,6 +68,7 @@ rands = [
 game_system = "ScreamHighSchool"
 input = "SH100"
 output = "D100<=100@20 ＞ 98 ＞ 成功"
+success = true
 rands = [
   { sides = 100, value = 98 },
 ]
@@ -66,6 +77,8 @@ rands = [
 game_system = "ScreamHighSchool"
 input = "SH100"
 output = "D100<=100@20 ＞ 99 ＞ ファンブル"
+failure = true
+fumble = true
 rands = [
   { sides = 100, value = 99 },
 ]
@@ -74,6 +87,7 @@ rands = [
 game_system = "ScreamHighSchool"
 input = "SH50"
 output = "D100<=50@10 ＞ 11 ＞ 成功"
+success = true
 rands = [
   { sides = 100, value = 11 },
 ]
@@ -82,6 +96,8 @@ rands = [
 game_system = "ScreamHighSchool"
 input = "SH50"
 output = "D100<=50@10 ＞ 10 ＞ クリティカル"
+success = true
+critical = true
 rands = [
   { sides = 100, value = 10 },
 ]
@@ -89,7 +105,9 @@ rands = [
 [[ test ]]
 game_system = "ScreamHighSchool"
 input = "SH500"
-output = "D100<=500@100 ＞ 100 ＞ クリティカル"
+output = "D100<=500@100 ＞ 100 ＞ ファンブル"
+failure = true
+fumble = true
 rands = [
   { sides = 100, value = 100 },
 ]
@@ -98,6 +116,7 @@ rands = [
 game_system = "ScreamHighSchool"
 input = "SH0"
 output = "D100<=0@1 ＞ 2 ＞ 失敗"
+failure = true
 rands = [
   { sides = 100, value = 2 },
 ]
@@ -106,6 +125,8 @@ rands = [
 game_system = "ScreamHighSchool"
 input = "SH0"
 output = "D100<=0@1 ＞ 1 ＞ クリティカル"
+success = true
+critical = true
 rands = [
   { sides = 100, value = 1 },
 ]
@@ -114,6 +135,7 @@ rands = [
 game_system = "ScreamHighSchool"
 input = "SH50"
 output = "D100<=50@10 ＞ 11 ＞ 成功"
+success = true
 rands = [
   { sides = 100, value = 11 },
 ]
@@ -122,6 +144,8 @@ rands = [
 game_system = "ScreamHighSchool"
 input = "SH50@11"
 output = "D100<=50@11 ＞ 11 ＞ クリティカル"
+success = true
+critical = true
 rands = [
   { sides = 100, value = 11 },
 ]
@@ -130,14 +154,35 @@ rands = [
 game_system = "ScreamHighSchool"
 input = "SH50@11"
 output = "D100<=50@11 ＞ 12 ＞ 成功"
+success = true
 rands = [
   { sides = 100, value = 12 },
 ]
 
 [[ test ]]
 game_system = "ScreamHighSchool"
+input = "SH50@5"
+output = "D100<=50@5 ＞ 10 ＞ 成功"
+success = true
+rands = [
+  { sides = 100, value = 10 },
+]
+
+[[ test ]]
+game_system = "ScreamHighSchool"
+input = "SH50@5"
+output = "D100<=50@5 ＞ 5 ＞ クリティカル"
+success = true
+critical = true
+rands = [
+  { sides = 100, value = 5 },
+]
+
+[[ test ]]
+game_system = "ScreamHighSchool"
 input = "SH100/2"
 output = "D100<=50@20 ＞ 50 ＞ 成功"
+success = true
 rands = [
   { sides = 100, value = 50 },
 ]
@@ -146,6 +191,7 @@ rands = [
 game_system = "ScreamHighSchool"
 input = "SH100/2"
 output = "D100<=50@20 ＞ 51 ＞ 失敗"
+failure = true
 rands = [
   { sides = 100, value = 51 },
 ]
@@ -154,6 +200,8 @@ rands = [
 game_system = "ScreamHighSchool"
 input = "SH100/2"
 output = "D100<=50@20 ＞ 96 ＞ ファンブル"
+failure = true
+fumble = true
 rands = [
   { sides = 100, value = 96 },
 ]
@@ -162,6 +210,7 @@ rands = [
 game_system = "ScreamHighSchool"
 input = "SH100/2"
 output = "D100<=50@20 ＞ 21 ＞ 成功"
+success = true
 rands = [
   { sides = 100, value = 21 },
 ]
@@ -170,6 +219,8 @@ rands = [
 game_system = "ScreamHighSchool"
 input = "SH100/2"
 output = "D100<=50@20 ＞ 20 ＞ クリティカル"
+success = true
+critical = true
 rands = [
   { sides = 100, value = 20 },
 ]
@@ -178,6 +229,7 @@ rands = [
 game_system = "ScreamHighSchool"
 input = "SH150/2"
 output = "D100<=75@30 ＞ 51 ＞ 成功"
+success = true
 rands = [
   { sides = 100, value = 51 },
 ]
@@ -186,6 +238,8 @@ rands = [
 game_system = "ScreamHighSchool"
 input = "SH150/2"
 output = "D100<=75@30 ＞ 30 ＞ クリティカル"
+success = true
+critical = true
 rands = [
   { sides = 100, value = 30 },
 ]
@@ -194,6 +248,7 @@ rands = [
 game_system = "ScreamHighSchool"
 input = "SH150/3"
 output = "D100<=50@30 ＞ 51 ＞ 失敗"
+failure = true
 rands = [
   { sides = 100, value = 51 },
 ]
@@ -202,6 +257,7 @@ rands = [
 game_system = "ScreamHighSchool"
 input = "SH153/3"
 output = "D100<=51@30 ＞ 51 ＞ 成功"
+success = true
 rands = [
   { sides = 100, value = 51 },
 ]
@@ -210,6 +266,7 @@ rands = [
 game_system = "ScreamHighSchool"
 input = "SH155/3"
 output = "D100<=51@31 ＞ 51 ＞ 成功"
+success = true
 rands = [
   { sides = 100, value = 51 },
 ]
@@ -218,6 +275,7 @@ rands = [
 game_system = "ScreamHighSchool"
 input = "SH152/3@44"
 output = "D100<=50@44 ＞ 51 ＞ 失敗"
+failure = true
 rands = [
   { sides = 100, value = 51 },
 ]
@@ -226,6 +284,8 @@ rands = [
 game_system = "ScreamHighSchool"
 input = "SH152/3@51"
 output = "D100<=50@51 ＞ 51 ＞ クリティカル"
+success = true
+critical = true
 rands = [
   { sides = 100, value = 51 },
 ]
@@ -234,6 +294,7 @@ rands = [
 game_system = "ScreamHighSchool"
 input = "SHS100"
 output = "D100<=100@20 ＞ 97 ＞ 成功"
+success = true
 rands = [
   { sides = 100, value = 97 },
 ]
@@ -243,6 +304,7 @@ game_system = "ScreamHighSchool"
 input = "SSH100"
 output = "D100<=100@20 ＞ 96 ＞ 成功"
 secret = true
+success = true
 rands = [
   { sides = 100, value = 96 },
 ]
@@ -252,6 +314,7 @@ game_system = "ScreamHighSchool"
 input = "SSHS100"
 output = "D100<=100@20 ＞ 97 ＞ 成功"
 secret = true
+success = true
 rands = [
   { sides = 100, value = 97 },
 ]
@@ -314,6 +377,7 @@ rands = []
 game_system = "ScreamHighSchool"
 input = "EM50"
 output = "感情判定 D100<=50@10 ＞ 51 ＞ 失敗（次に行う判定の成功率に-20%、呪縛+1点）"
+failure = true
 rands = [
   { sides = 100, value = 51 },
 ]
@@ -322,6 +386,7 @@ rands = [
 game_system = "ScreamHighSchool"
 input = "EM50"
 output = "感情判定 D100<=50@10 ＞ 50 ＞ 成功（次に行う判定の成功率に+30%）"
+success = true
 rands = [
   { sides = 100, value = 50 },
 ]
@@ -330,6 +395,8 @@ rands = [
 game_system = "ScreamHighSchool"
 input = "EM50"
 output = "感情判定 D100<=50@10 ＞ 96 ＞ ファンブル（次に行う判定の成功率に-50%、呪縛+1D5点）"
+failure = true
+fumble = true
 rands = [
   { sides = 100, value = 96 },
 ]
@@ -338,6 +405,8 @@ rands = [
 game_system = "ScreamHighSchool"
 input = "EM50@15"
 output = "感情判定 D100<=50@15 ＞ 14 ＞ クリティカル（次に行う判定の成功率に+50%）"
+success = true
+critical = true
 rands = [
   { sides = 100, value = 14 },
 ]
@@ -346,6 +415,7 @@ rands = [
 game_system = "ScreamHighSchool"
 input = "TR60"
 output = "性格傾向判定 D100<=60@12 ＞ 61 ＞ 失敗（反対側の性格傾向で再判定する。あるいは、もしこれがその再判定の結果であればプレイヤーが性格傾向を選択する）"
+failure = true
 rands = [
   { sides = 100, value = 61 },
 ]
@@ -354,6 +424,7 @@ rands = [
 game_system = "ScreamHighSchool"
 input = "TR60"
 output = "性格傾向判定 D100<=60@12 ＞ 60 ＞ 成功（判定した性格傾向に従う）"
+success = true
 rands = [
   { sides = 100, value = 60 },
 ]
@@ -362,6 +433,8 @@ rands = [
 game_system = "ScreamHighSchool"
 input = "TR60"
 output = "性格傾向判定 D100<=60@12 ＞ 97 ＞ ファンブル（反対側の性格傾向に従い、呪縛+1D5点する。あるいは、もしこれが失敗後の再判定の結果だった場合、PCは混乱し行動を放棄するか逃げ出す。呪縛+2点）"
+failure = true
+fumble = true
 rands = [
   { sides = 100, value = 97 },
 ]
@@ -370,6 +443,8 @@ rands = [
 game_system = "ScreamHighSchool"
 input = "TR60@18"
 output = "性格傾向判定 D100<=60@18 ＞ 17 ＞ クリティカル（判定した性格傾向に従う）"
+success = true
+critical = true
 rands = [
   { sides = 100, value = 17 },
 ]
@@ -378,6 +453,7 @@ rands = [
 game_system = "ScreamHighSchool"
 input = "FE70"
 output = "恐怖判定 D100<=70@14 ＞ 71 ＞ 失敗（ショックを受けた。恐怖判定効果表の失敗側の値分、呪縛が上昇する）"
+failure = true
 rands = [
   { sides = 100, value = 71 },
 ]
@@ -386,6 +462,7 @@ rands = [
 game_system = "ScreamHighSchool"
 input = "FE70"
 output = "恐怖判定 D100<=70@14 ＞ 70 ＞ 成功（ショックを受け流した。恐怖判定効果表の成功側の値分、呪縛が上昇する）"
+success = true
 rands = [
   { sides = 100, value = 70 },
 ]
@@ -394,6 +471,8 @@ rands = [
 game_system = "ScreamHighSchool"
 input = "FE70"
 output = "恐怖判定 D100<=70@14 ＞ 98 ＞ ファンブル（深いショックを受けた。恐怖判定効果表の失敗側の値分に加え、さらに1D5点分、呪縛が上昇する）"
+failure = true
+fumble = true
 rands = [
   { sides = 100, value = 98 },
 ]
@@ -402,6 +481,8 @@ rands = [
 game_system = "ScreamHighSchool"
 input = "FE70@19"
 output = "恐怖判定 D100<=70@19 ＞ 19 ＞ クリティカル（何もショックを受けなかった）"
+success = true
+critical = true
 rands = [
   { sides = 100, value = 19 },
 ]
@@ -410,6 +491,7 @@ rands = [
 game_system = "ScreamHighSchool"
 input = "SH(50+30)"
 output = "D100<=80@16 ＞ 70 ＞ 成功"
+success = true
 rands = [
   { sides = 100, value = 70 },
 ]
@@ -418,6 +500,8 @@ rands = [
 game_system = "ScreamHighSchool"
 input = "SH(50+50)"
 output = "D100<=100@20 ＞ 20 ＞ クリティカル"
+success = true
+critical = true
 rands = [
   { sides = 100, value = 20 },
 ]
@@ -426,6 +510,7 @@ rands = [
 game_system = "ScreamHighSchool"
 input = "SH(50-20)"
 output = "D100<=30@6 ＞ 50 ＞ 失敗"
+failure = true
 rands = [
   { sides = 100, value = 50 },
 ]
@@ -434,6 +519,8 @@ rands = [
 game_system = "ScreamHighSchool"
 input = "SH(20-20)"
 output = "D100<=0@1 ＞ 1 ＞ クリティカル"
+success = true
+critical = true
 rands = [
   { sides = 100, value = 1 },
 ]
@@ -442,6 +529,8 @@ rands = [
 game_system = "ScreamHighSchool"
 input = "SH(20-50)"
 output = "D100<=0@1 ＞ 1 ＞ クリティカル"
+success = true
+critical = true
 rands = [
   { sides = 100, value = 1 },
 ]
@@ -450,6 +539,8 @@ rands = [
 game_system = "ScreamHighSchool"
 input = "FE(10-50)@3"
 output = "恐怖判定 D100<=0@3 ＞ 3 ＞ クリティカル（何もショックを受けなかった）"
+success = true
+critical = true
 rands = [
   { sides = 100, value = 3 },
 ]


### PR DESCRIPTION
#423 GardenOrder: ガーデンオーダーのResult対応になります。

ついでに以下の2点に関して修正しています。

- ファンブルとクリティカルが同時に発生した場合はファンブルが優先される (cf. p175)
- 連続攻撃判定で最終的な成功率が50％に満たないものはエラーとして返す (cf. p217)