### PR TITLE
NinjaSlayer: repeatコマンド使用時のバグを修正する

### DIFF
--- a/lib/bcdice/common_command/barabara_dice/node.rb
+++ b/lib/bcdice/common_command/barabara_dice/node.rb
@@ -43,8 +43,8 @@ module BCDice
             Result.new.tap do |r|
               r.secret = @secret
               r.text = sequence.join(" ＞ ")
-              r.rands = randomizer.rand_results
-              r.detailed_rands = randomizer.detailed_rand_results
+              r.last_dice_list_list = dice_list_list
+              r.last_dice_list = dice_list
               r.success_num = success_num
             end
           end

--- a/lib/bcdice/common_command/barabara_dice/result.rb
+++ b/lib/bcdice/common_command/barabara_dice/result.rb
@@ -7,6 +7,10 @@ module BCDice
     module BarabaraDice
       # バラバラロールの結果を表すクラス
       class Result < ::BCDice::Result
+        # @return [Array<Array<Integer>>] 出目のグループの配列
+        attr_accessor :last_dice_list_list
+        # @return [Array<Integer>] すべての出目が格納される配列
+        attr_accessor :last_dice_list
         # @return [Integer] 成功数
         attr_accessor :success_num
 
@@ -14,6 +18,8 @@ module BCDice
         def initialize(text = nil)
           super(text)
 
+          @last_dice_list_list = []
+          @last_dice_list = []
           @success_num = 0
         end
       end

--- a/lib/bcdice/game_system/NinjaSlayer.rb
+++ b/lib/bcdice/game_system/NinjaSlayer.rb
@@ -176,8 +176,7 @@ module BCDice
         command = bRollCommand(at.num, at.difficulty)
         roll_result = BCDice::CommonCommand::BarabaraDice.eval(command, self, @randomizer)
 
-        values = roll_result.rands.map { |v, _| v }
-        num_of_max_values = values.count(6)
+        num_of_max_values = roll_result.last_dice_list.count(6)
 
         parts = [roll_result.text]
 
@@ -195,7 +194,7 @@ module BCDice
         command = bRollCommand(el.num, el.difficulty)
         roll_result = BCDice::CommonCommand::BarabaraDice.eval(command, self, @randomizer)
 
-        values = roll_result.rands.map { |v, _| v }
+        values = roll_result.last_dice_list
         num_of_max_values = values.count(6)
         sum_of_true_values = values.count { |v| v >= el.difficulty }
 

--- a/test/data/NinjaSlayer.toml
+++ b/test/data/NinjaSlayer.toml
@@ -376,12 +376,46 @@ rands = [
 [[ test ]]
 game_system = "NinjaSlayer"
 input = "AT4"
+output = "(4B6>=4) ＞ 1,1,1,1 ＞ 成功数0"
+rands = [
+  { sides = 6, value = 1 },
+  { sides = 6, value = 1 },
+  { sides = 6, value = 1 },
+  { sides = 6, value = 1 },
+]
+
+[[ test ]]
+game_system = "NinjaSlayer"
+input = "AT4"
 output = "(4B6>=4) ＞ 2,2,6,6 ＞ 成功数2 ＞ サツバツ!!"
 rands = [
   { sides = 6, value = 2 },
   { sides = 6, value = 2 },
   { sides = 6, value = 6 },
   { sides = 6, value = 6 },
+]
+
+[[ test ]]
+game_system = "NinjaSlayer"
+input = "x2 AT4 繰り返し実行で蓄積した出目を用いて判断しない"
+output = """
+#1
+(4B6>=4) ＞ 2,2,6,6 ＞ 成功数2 ＞ サツバツ!!
+
+#2
+(4B6>=4) ＞ 1,1,1,1 ＞ 成功数0"""
+rands = [
+  # 1回目
+  { sides = 6, value = 2 },
+  { sides = 6, value = 2 },
+  { sides = 6, value = 6 },
+  { sides = 6, value = 6 },
+
+  # 2回目
+  { sides = 6, value = 1 },
+  { sides = 6, value = 1 },
+  { sides = 6, value = 1 },
+  { sides = 6, value = 1 },
 ]
 
 [[ test ]]
@@ -464,12 +498,46 @@ rands = [
 [[ test ]]
 game_system = "NinjaSlayer"
 input = "EL4"
+output = "(4B6>=4) ＞ 1,1,1,1 ＞ 成功数0"
+rands = [
+  { sides = 6, value = 1 },
+  { sides = 6, value = 1 },
+  { sides = 6, value = 1 },
+  { sides = 6, value = 1 },
+]
+
+[[ test ]]
+game_system = "NinjaSlayer"
+input = "EL4"
 output = "(4B6>=4) ＞ 2,2,2,6 ＞ 成功数1 + 1 ＞ 2"
 rands = [
   { sides = 6, value = 2 },
   { sides = 6, value = 2 },
   { sides = 6, value = 2 },
   { sides = 6, value = 6 },
+]
+
+[[ test ]]
+game_system = "NinjaSlayer"
+input = "x2 EL4 繰り返し実行で蓄積した出目を用いて判断しない"
+output = """
+#1
+(4B6>=4) ＞ 2,2,2,6 ＞ 成功数1 + 1 ＞ 2
+
+#2
+(4B6>=4) ＞ 1,1,1,1 ＞ 成功数0"""
+rands = [
+  # 1回目
+  { sides = 6, value = 2 },
+  { sides = 6, value = 2 },
+  { sides = 6, value = 2 },
+  { sides = 6, value = 6 },
+
+  # 2回目
+  { sides = 6, value = 1 },
+  { sides = 6, value = 1 },
+  { sides = 6, value = 1 },
+  { sides = 6, value = 1 },
 ]
 
 [[ test ]]


### PR DESCRIPTION
ニンジャスレイヤーTRPGの `AT`、`EL` コマンドに存在した、`repeat` コマンドで繰り返し実行した場合のバグを修正しました。

# 症状

これまで `repeat` コマンドで繰り返し実行した場合に、後の方の回で出目が悪い場合でも、意図せず「サツバツ！」等が表示される場合がありました。

# 原因

https://github.com/bcdice/BCDice/blob/7c0b4e7c4cc617d8b096b1a27c86b5947d8aed5e/lib/bcdice/game_system/NinjaSlayer.rb#L177-L179

上記の部分で、複数回の実行で蓄積された出目を取り、「サツバツ！」等の判定を行っていました。`BarabaraDice::Result#rands` には、複数回の実行結果が蓄積される `Randomizer#rand_results` の値が入ります。#335 で私がこの部分を実装したときに `repeat` を考慮し忘れていたため、 `Randomizer#rand_results` を使ってしまいました。

# 対策

`BarabaraDice::Result` に、最後に振ったときの出目を記録する以下のメンバを加えました。

* `last_dice_list_list`：出目のグループの配列（例：`[[1, 3], [5, 2]]`）
* `last_dice_list`：すべての出目の配列（例：`[1, 3, 5, 2]`）

NinjaSlayer側では、`BarabaraDice::Result#last_dice_list` を使うように変更しました。関連するテストケースも追加しました。