### PR TITLE
BattleTech: Randomizer#rand_results を使わない

### DIFF
--- a/lib/bcdice/game_system/BattleTech.rb
+++ b/lib/bcdice/game_system/BattleTech.rb
@@ -336,7 +336,7 @@ module BCDice
 
         values = @randomizer.roll_barabara(2, 6)
         sum = values.sum
-        values_str = @randomizer.rand_results.map(&:first).join(",")
+        values_str = values.join(",")
         sum_and_values = "#{sum}[#{values_str}]"
 
         success = sum >= target


### PR DESCRIPTION
https://github.com/bcdice/BCDice/pull/445#discussion_r625448651 の修正漏れを直しました。繰り返し実行時に出目が蓄積される `Randomizer#rand_results` を使わないようにします。