### PR TITLE
[Cthulhu7th] 目標値が100以上の場合でも100ファンする

### DIFF
--- a/lib/bcdice/game_system/Cthulhu7th.rb
+++ b/lib/bcdice/game_system/Cthulhu7th.rb
@@ -105,10 +105,10 @@ module BCDice
 
           if total == 1
             ResultLevel.new(:critical)
-          elsif total <= difficulty
-            ResultLevel.new(:success)
           elsif total >= fumble
             ResultLevel.new(:fumble)
+          elsif total <= difficulty
+            ResultLevel.new(:success)
           else
             ResultLevel.new(:failure)
           end
@@ -119,14 +119,14 @@ module BCDice
 
           if total == 1
             ResultLevel.new(:critical)
+          elsif total >= fumble
+            ResultLevel.new(:fumble)
           elsif total <= (difficulty / 5)
             ResultLevel.new(:extreme_success)
           elsif total <= (difficulty / 2)
             ResultLevel.new(:hard_success)
           elsif total <= difficulty
             ResultLevel.new(:regular_success)
-          elsif total >= fumble
-            ResultLevel.new(:fumble)
           else
             ResultLevel.new(:failure)
           end

--- a/test/data/Cthulhu7th.toml
+++ b/test/data/Cthulhu7th.toml
@@ -446,6 +446,28 @@ rands = [
 
 [[ test ]]
 game_system = "Cthulhu7th"
+input = "CC<=100"
+output = "(1D100<=100) ボーナス・ペナルティダイス[0] ＞ 100 ＞ 100 ＞ ファンブル"
+fumble = true
+failure = true
+rands = [
+  { sides = 10, value = 10 },
+  { sides = 10, value = 10 },
+]
+
+[[ test ]]
+game_system = "Cthulhu7th"
+input = "CC<=150"
+output = "(1D100<=150) ボーナス・ペナルティダイス[0] ＞ 100 ＞ 100 ＞ ファンブル"
+fumble = true
+failure = true
+rands = [
+  { sides = 10, value = 10 },
+  { sides = 10, value = 10 },
+]
+
+[[ test ]]
+game_system = "Cthulhu7th"
 input = "CC<=53r"
 output = "(1D100<=53) ボーナス・ペナルティダイス[0] ＞ 53 ＞ 53 ＞ 成功"
 success = true
@@ -577,6 +599,28 @@ fumble = true
 rands = [
   { sides = 10, value = 9 },
   { sides = 10, value = 6 },
+]
+
+[[ test ]]
+game_system = "Cthulhu7th"
+input = "CC<=100r"
+output = "(1D100<=100) ボーナス・ペナルティダイス[0] ＞ 100 ＞ 100 ＞ ファンブル"
+fumble = true
+failure = true
+rands = [
+  { sides = 10, value = 10 },
+  { sides = 10, value = 10 },
+]
+
+[[ test ]]
+game_system = "Cthulhu7th"
+input = "CC<=300h"
+output = "(1D100<=150) ボーナス・ペナルティダイス[0] ＞ 100 ＞ 100 ＞ ファンブル"
+fumble = true
+failure = true
+rands = [
+  { sides = 10, value = 10 },
+  { sides = 10, value = 10 },
 ]
 
 [[ test ]]


### PR DESCRIPTION
fix #475

新クトゥルフでは目標値100以上についての細則がないが、パルプクトゥルフには細則があるとのこと。