### PR TITLE
choiceの複数選択と連続要素略記

### DIFF
--- a/lib/bcdice/common_command/choice.rb
+++ b/lib/bcdice/common_command/choice.rb
@@ -116,6 +116,10 @@ module BCDice
           items.push(last_item.delete_suffix(SUFFIX[type]))
 
           items = items.map(&:strip).reject(&:empty?)
+          if items.size == 1
+            items = parse_multi_item_shorthand(items.first)
+          end
+
           if items.empty? || items.size < takes
             return nil
           end
@@ -126,6 +130,40 @@ module BCDice
             takes: takes,
             items: items
           )
+        end
+
+        def parse_multi_item_shorthand(str)
+          parse_multi_nums_shorthand(str) || parse_multi_chars_shorthand(str) || []
+        end
+
+        def parse_multi_nums_shorthand(str)
+          m = /^(\d+)-(\d+)$/.match(str)
+          unless m
+            return nil
+          end
+
+          first = m[1].to_i
+          last = m[2].to_i
+          if first > last
+            return nil
+          end
+
+          return first.upto(last).to_a
+        end
+
+        def parse_multi_chars_shorthand(str)
+          m = /^([a-z])-([a-z])$/.match(str) || /^([A-Z])-([A-Z])$/.match(str)
+          unless m
+            return nil
+          end
+
+          first = m[1]
+          last = m[2]
+          if first > last
+            return nil
+          end
+
+          return first.upto(last).to_a
         end
       end
 

--- a/lib/bcdice/common_command/choice.rb
+++ b/lib/bcdice/common_command/choice.rb
@@ -29,6 +29,17 @@ module BCDice
     #   choice A,B X,Y -> "A,B" と "X,Y" から選ぶ
     #   choice(A[], B[], C[]) -> "A[]", "B[]", "C[]" から選ぶ
     #   choice[A(), B(), C()] -> "A()", "B()", "C()" から選ぶ
+    #
+    # "choise"の後に数を指定することで、列挙した要素から重複なしで複数個を選ぶ
+    #   choice2[A,B,C] -> "A", "B", "C" から重複なしで2個選ぶ
+    #
+    # 指定したい要素が「AからD」のように連続する項目の場合に「A-D」と省略して記述できる
+    # 略記の展開はアルファベット1文字もしくは数字の範囲に限り、略記1つを指定したときのみ展開される
+    #   choice[A-D] -> choice[A,B,C,D] と等価
+    #   choice[b-g] -> choice[b,c,d,e,f,g] と等価
+    #   choice[3-7] -> choice[3,4,5,6,7] と等価
+    #   choice[A-D,Z] -> 展開されない。 "A-D", "Z" から選ぶ
+    #   choice[D-A] -> 展開されない。
     class Choice
       PREFIX_PATTERN = /choice/.freeze
 

--- a/test/data/choice.toml
+++ b/test/data/choice.toml
@@ -153,3 +153,86 @@ game_system = "DiceBot"
 input = "choice3[abc,def] とる数が多い"
 output = ""
 rands = []
+
+[[ test ]]
+game_system = "DiceBot"
+input = "choice[A-F] 複数要素の省略形"
+output = "(choice[A,B,C,D,E,F]) ＞ C"
+rands = [
+  { sides = 6, value = 3 },
+]
+
+[[ test ]]
+game_system = "DiceBot"
+input = "choice[c-g] 複数要素の省略形"
+output = "(choice[c,d,e,f,g]) ＞ g"
+rands = [
+  { sides = 5, value = 5 },
+]
+
+[[ test ]]
+game_system = "DiceBot"
+input = "choice[3-10] 複数要素の省略形"
+output = "(choice[3,4,5,6,7,8,9,10]) ＞ 10"
+rands = [
+  { sides = 8, value = 8 },
+]
+
+# 複数要素の省略形 空白区切り
+[[ test ]]
+game_system = "DiceBot"
+input = "choice A-F"
+output = "(choice A B C D E F) ＞ C"
+rands = [
+  { sides = 6, value = 3 },
+]
+
+[[ test ]]
+game_system = "DiceBot"
+input = "choice(A-F) 複数要素の省略形 カッコ区切り"
+output = "(choice(A,B,C,D,E,F)) ＞ C"
+rands = [
+  { sides = 6, value = 3 },
+]
+
+[[ test ]]
+game_system = "DiceBot"
+input = "choice[F-A] 大小関係が逆"
+output = ""
+rands = []
+
+[[ test ]]
+game_system = "DiceBot"
+input = "choice[g-c] 大小関係が逆"
+output = ""
+rands = []
+
+[[ test ]]
+game_system = "DiceBot"
+input = "choice[10-3] 大小関係が逆"
+output = ""
+rands = []
+
+[[ test ]]
+game_system = "DiceBot"
+input = "choice[a-zz] 複数文字では省略にならない"
+output = ""
+rands = []
+
+[[ test ]]
+game_system = "DiceBot"
+input = "choice[A-F, Z] こういうケースでは展開しない"
+output = "(choice[A-F,Z]) ＞ A-F"
+rands = [
+  { sides = 2, value = 1 },
+]
+
+[[ test ]]
+game_system = "DiceBot"
+input = "choice3[A-F] 複数選択との混合"
+output = "(choice3[A,B,C,D,E,F]) ＞ C, F, A"
+rands = [
+  { sides = 6, value = 3 },
+  { sides = 5, value = 5 },
+  { sides = 4, value = 1 },
+]

--- a/test/data/choice.toml
+++ b/test/data/choice.toml
@@ -134,6 +134,25 @@ rands = [
 
 [[ test ]]
 game_system = "DiceBot"
+input = "choice2(a,b,c) かっこ区切り"
+output = "(choice2(a,b,c)) ＞ a, b"
+rands = [
+  { sides = 3, value = 1 },
+  { sides = 2, value = 1 },
+]
+
+# 空白区切り
+[[ test ]]
+game_system = "DiceBot"
+input = "choice2 a b c"
+output = "(choice2 a b c) ＞ a b"
+rands = [
+  { sides = 3, value = 1 },
+  { sides = 2, value = 1 },
+]
+
+[[ test ]]
+game_system = "DiceBot"
 input = "choice3[A(), B(), C()] 全部取る"
 output = "(choice3[A(),B(),C()]) ＞ A(), C(), B()"
 rands = [

--- a/test/data/choice.toml
+++ b/test/data/choice.toml
@@ -122,3 +122,34 @@ game_system = "DiceBot"
 input = "choice[, ,,  ,, ,] 要素数ゼロ"
 output = ""
 rands = []
+
+[[ test ]]
+game_system = "DiceBot"
+input = "choice2[The Call of Cthulhu, The Shadow Over Innsmouth, The Shadow Out of Time] 複数個取得"
+output = "(choice2[The Call of Cthulhu,The Shadow Over Innsmouth,The Shadow Out of Time]) ＞ The Shadow Out of Time, The Call of Cthulhu"
+rands = [
+  { sides = 3, value = 3 },
+  { sides = 2, value = 1 },
+]
+
+[[ test ]]
+game_system = "DiceBot"
+input = "choice3[A(), B(), C()] 全部取る"
+output = "(choice3[A(),B(),C()]) ＞ A(), C(), B()"
+rands = [
+  { sides = 3, value = 1 },
+  { sides = 2, value = 2 },
+  { sides = 1, value = 1 },
+]
+
+[[ test ]]
+game_system = "DiceBot"
+input = "choice0[abc,def] 0個とる"
+output = ""
+rands = []
+
+[[ test ]]
+game_system = "DiceBot"
+input = "choice3[abc,def] とる数が多い"
+output = ""
+rands = []


### PR DESCRIPTION
## 重複なし複数選択

`choise2[A,B,C]` のようにすることで要素の中から指定した数だけ重複なしで複数個選ぶ。

- `choice2[A,B,C]`
  - "A", "B", "C" から重複なしで2個選ぶ
- `choice3[A,B,C]`
  - "A", "B", "C" から全てが選ばれるが、選ばれる順番によって表示順が変わる。実質的に `["A", "B", "C"].shuffle`
- `choice4[A,B,C]`
  - 選択数が要素数を超えているのでエラー
  
## 連続要素の省略表記
指定したい要素が「AからD」のように連続する項目の場合に「A-D」と省略して記述できる。
パースする際に`choice[A-D]`なら`choice[A,B,C,D]`だと解釈され実行される。

### 利用できる省略表記
- アルファベット大文字1字の範囲： `A-G` 等
- アルファベット小文字1字の範囲： `a-z` 等
- 数値の範囲： `10-30` 等

### 省略表記が展開される条件
以下の両方を満たすときに略記が展開される。
- 省略表記1つのみが指定され、他の要素がないとき
  - `choice[A-D, Z]` や `choice[A-D, X-Z]` では展開しない
- `[first]-[last]` が `first <= last` であるとき

## デザインチョイスなど

### `choice2` vs `2choice`

`2choice`だと`choice`を2回っぽいので。あと、`choice2`の方が英語の語順に近い。

### 省略表記は1つしか書けなくて他と共存できない件

choiceは対象の要素をかなり自由に書けてしまうので、思ったように書けないというのを避けるために限定的な状況でのみ発動するようにする。

### アルファベット1文字制限

Rubyで複数文字の`Range`や`String#upto`を`to_a`すると挙動が怪しい……
```
irb(main):001:0> ('a'..'bb').to_a
=> ["a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l", "m", "n", "o", "p", "q", "r", "s", "t", "u", "v", "w", "x", "y", "z", "aa", "ab", "ac", "ad", "ae", "af", "ag", "ah", "ai", "aj", "ak", "al", "am", "an", "ao", "ap", "aq", "ar", "as", "at", "au", "av", "aw", "ax", "ay", "az", "ba", "bb"]
irb(main):002:0> ('b'..'bb').to_a
=> ["b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l", "m", "n", "o", "p", "q", "r", "s", "t", "u", "v", "w", "x", "y", "z", "aa", "ab", "ac", "ad", "ae", "af", "ag", "ah", "ai", "aj", "ak", "al", "am", "an", "ao", "ap", "aq", "ar", "as", "at", "au", "av", "aw", "ax", "ay", "az", "ba", "bb"]
irb(main):003:0> ('c'..'bb').to_a
=> []
```

ちなみに**仕様**とのこと
https://bugs.ruby-lang.org/issues/13663#note-4

## Ref.
- #276 