### PR TITLE
[StellarLife] 「アバターアルファベット表②」のコマンド（ `AAST` ）が実行できなかったのを修正

### DIFF
--- a/lib/bcdice/game_system/StellarLife.rb
+++ b/lib/bcdice/game_system/StellarLife.rb
@@ -37,7 +37,7 @@ module BCDice
         　・超未来の宇宙船内　INT
       MESSAGETEXT
 
-      register_prefix('\d*DA', 'VPFT', 'VNFT', 'VNRT', 'AAFT', 'AST', 'RNST', 'RET', 'TRST', 'TRAT', 'TRMT', 'TROT', 'TET', 'ENT', 'CUT', 'NAT', 'INT')
+      register_prefix('\d*DA', 'VPFT', 'VNFT', 'VNRT', 'AAFT', 'AAST', 'RNST', 'RET', 'TRST', 'TRAT', 'TRMT', 'TROT', 'TET', 'ENT', 'CUT', 'NAT', 'INT')
       def eval_game_system_specific_command(command) # ダイスロールコマンド
         # 通常判定部分をgetJudgeResultコマンドに切り分け
         output = getJudgeResult(command)

--- a/test/data/StellarLife.toml
+++ b/test/data/StellarLife.toml
@@ -49,6 +49,14 @@ rands = [
 
 [[ test ]]
 game_system = "StellarLife"
+input = "aast"
+output = "アバターアルファベット表②(8) ＞ X"
+rands = [
+  { sides = 10, value = 9 },
+]
+
+[[ test ]]
+game_system = "StellarLife"
 input = "RNST"
 output = "ランダムNPC艦表(21) ＞ 〈リサイクルフォージ〉"
 rands = [


### PR DESCRIPTION
# 原因

　prefix が誤っていた。

# 補足

　テストを見ればわかるように、出目と項番がズレているのですが、これは、

- この PR の主旨（特定のコマンドがそもそも実行できない問題の解消）とは異なる
- このコマンドにかぎらず StellarLife のあらゆる表を引くコマンドにわたって発生している問題である

　という観点から、この PR では修正しません。
　（追って別の PR で修正する想定です）