### PR TITLE
個数カウントダイスを追加する

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ lib/bcdice/arithmetic/parser.rb
 lib/bcdice/command/parser.rb
 lib/bcdice/common_command/add_dice/parser.rb
 lib/bcdice/common_command/barabara_dice/parser.rb
+lib/bcdice/common_command/tally_dice/parser.rb
 lib/bcdice/common_command/calc/parser.rb
 lib/bcdice/common_command/reroll_dice/parser.rb
 lib/bcdice/common_command/upper_dice/parser.rb

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -12,6 +12,7 @@ AllCops:
     - lib/bcdice/command/parser.rb
     - lib/bcdice/common_command/add_dice/parser.rb
     - lib/bcdice/common_command/barabara_dice/parser.rb
+    - lib/bcdice/common_command/tally_dice/parser.rb
     - lib/bcdice/common_command/calc/parser.rb
     - lib/bcdice/common_command/reroll_dice/parser.rb
     - lib/bcdice/common_command/upper_dice/parser.rb

--- a/Rakefile
+++ b/Rakefile
@@ -25,6 +25,7 @@ RACC_TARGETS = [
   "lib/bcdice/command/parser.rb",
   "lib/bcdice/common_command/add_dice/parser.rb",
   "lib/bcdice/common_command/barabara_dice/parser.rb",
+  "lib/bcdice/common_command/tally_dice/parser.rb",
   "lib/bcdice/common_command/calc/parser.rb",
   "lib/bcdice/common_command/reroll_dice/parser.rb",
   "lib/bcdice/common_command/upper_dice/parser.rb",

--- a/lib/bcdice/common_command.rb
+++ b/lib/bcdice/common_command.rb
@@ -2,6 +2,7 @@
 
 require "bcdice/common_command/add_dice"
 require "bcdice/common_command/barabara_dice"
+require "bcdice/common_command/tally_dice"
 require "bcdice/common_command/calc"
 require "bcdice/common_command/choice"
 require "bcdice/common_command/d66_dice"
@@ -15,6 +16,7 @@ module BCDice
     COMMANDS = [
       AddDice,
       BarabaraDice,
+      TallyDice,
       Calc,
       Choice,
       D66Dice,

--- a/lib/bcdice/common_command/tally_dice.rb
+++ b/lib/bcdice/common_command/tally_dice.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require "bcdice/common_command/tally_dice/parser"
+
+module BCDice
+  module CommonCommand
+    # 個数カウントダイスのモジュール
+    module TallyDice
+      PREFIX_PATTERN = /\d+T[YZ]\d+/.freeze
+
+      class << self
+        def eval(command, game_system, randomizer)
+          cmd = Parser.parse(command)
+          cmd&.eval(game_system, randomizer)
+        end
+      end
+    end
+  end
+end

--- a/lib/bcdice/common_command/tally_dice/node.rb
+++ b/lib/bcdice/common_command/tally_dice/node.rb
@@ -1,0 +1,135 @@
+# frozen_string_literal: true
+
+require "bcdice/result"
+
+module BCDice
+  module CommonCommand
+    module TallyDice
+      # 個数カウントダイスを表すノードをまとめるモジュール
+      module Node
+        # 個数カウントダイス：コマンドのノード
+        class Command
+          # 最大面数
+          MAX_SIDES = 20
+
+          # @param secret [Boolean] シークレットダイスか
+          # @param notation [Notation] ダイス表記
+          def initialize(secret:, notation:)
+            @secret = secret
+            @notation = notation
+          end
+
+          # @param game_system [Base] ゲームシステム
+          # @param randomizer [Randomizer] ランダマイザ
+          # @return [Result, nil]
+          def eval(game_system, randomizer)
+            dice = @notation.to_dice(game_system.round_type)
+            unless dice.valid?
+              return nil
+            end
+
+            if dice.sides > MAX_SIDES
+              return Result.new("(#{dice}) ＞ 面数は1以上、#{MAX_SIDES}以下としてください")
+            end
+
+            values = dice.roll(randomizer)
+
+            values_str = (game_system.sort_barabara_dice? ? values.sort : values)
+                         .join(",")
+
+            # TODO: Ruby 2.7以降のみサポートするようになった場合
+            # Enumerable#tally で書く
+            values_count = values
+                           .group_by(&:itself)
+                           .transform_values(&:length)
+
+            values_count_strs = (1..dice.sides).map do |v|
+              count = values_count.fetch(v, 0)
+
+              next nil if count == 0 && !dice.show_zeros?
+
+              "[#{v}]×#{values_count.fetch(v, 0)}"
+            end
+
+            sequence = [
+              "(#{dice})",
+              values_str,
+              values_count_strs.compact.join(", "),
+            ].compact
+
+            Result.new.tap do |r|
+              r.secret = @secret
+              r.text = sequence.join(" ＞ ")
+            end
+          end
+        end
+
+        # 個数カウントダイス：ダイス表記のノード
+        class Notation
+          # @return [Integer] 振る回数
+          attr_reader :times
+          # @return [Integer] 面数
+          attr_reader :sides
+          # @return [Boolean] 個数0を表示するか
+          attr_reader :show_zeros
+
+          # @param times [#eval] 振る回数
+          # @param sides [#eval] 面数
+          # @param show_zeros [Boolean] 個数0を表示するか
+          def initialize(times:, sides:, show_zeros:)
+            @times = times
+            @sides = sides
+            @show_zeros = show_zeros
+          end
+
+          # @param round_type [Symbol] 除算の端数処理方法
+          # @return [Dice]
+          def to_dice(round_type)
+            times = @times.eval(round_type)
+            sides = @sides.eval(round_type)
+
+            Dice.new(times: times, sides: sides, show_zeros: @show_zeros)
+          end
+        end
+
+        # 個数カウントダイス：ダイスのノード
+        class Dice
+          # @return [Integer] 振る回数
+          attr_reader :times
+          # @return [Integer] 面数
+          attr_reader :sides
+          # @return [Boolean] 個数0を表示するか
+          attr_reader :show_zeros
+
+          alias show_zeros? show_zeros
+
+          # @param times [Integer] 振る回数
+          # @param sides [Integer] 面数
+          def initialize(times:, sides:, show_zeros:)
+            @times = times
+            @sides = sides
+            @show_zeros = show_zeros
+          end
+
+          # @return [Boolean] ダイスとして有効（振る回数、面数ともに正の数）か
+          def valid?
+            @times > 0 && @sides > 0
+          end
+
+          # ダイスを振る
+          # @param randomizer [BCDice::Randomizer] ランダマイザ
+          # @return [Array<Integer>] 出目の配列
+          def roll(randomizer)
+            randomizer.roll_barabara(@times, @sides)
+          end
+
+          # @return [String]
+          def to_s
+            show_zeros_symbol = @show_zeros ? "Z" : "Y"
+            "#{@times}T#{show_zeros_symbol}#{@sides}"
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/bcdice/common_command/tally_dice/parser.y
+++ b/lib/bcdice/common_command/tally_dice/parser.y
@@ -1,0 +1,93 @@
+class BCDice::CommonCommand::TallyDice::Parser
+  token NUMBER T Y Z R U C F S PLUS MINUS ASTERISK SLASH PARENL PARENR
+
+  rule
+    expr: secret notation
+        {
+          result = Node::Command.new(
+            secret: val[0],
+            notation: val[1]
+          )
+        }
+
+    secret: /* none */
+          { result = false }
+          | S
+          { result = true }
+
+    notation: term T show_zeros term
+            {
+              result = Node::Notation.new(
+                times: val[0],
+                sides: val[3],
+                show_zeros: val[2]
+              )
+            }
+
+    show_zeros: Y
+              { result = false }
+              | Z
+              { result = true }
+
+    add: add PLUS mul
+       { result = Arithmetic::Node::BinaryOp.new(val[0], :+, val[2]) }
+       | add MINUS mul
+       { result = Arithmetic::Node::BinaryOp.new(val[0], :-, val[2]) }
+       | mul
+
+    mul: mul ASTERISK unary
+       { result = Arithmetic::Node::BinaryOp.new(val[0], :*, val[2]) }
+       | mul SLASH unary round_type
+       {
+         divied_class = val[3]
+         result = divied_class.new(val[0], val[2])
+       }
+       | unary
+
+    round_type: /* none */
+              { result = Arithmetic::Node::DivideWithGameSystemDefault }
+              | U
+              { result = Arithmetic::Node::DivideWithCeil }
+              | C
+              { result = Arithmetic::Node::DivideWithCeil }
+              | R
+              { result = Arithmetic::Node::DivideWithRound }
+              | F
+              { result = Arithmetic::Node::DivideWithFloor }
+
+    unary: PLUS unary
+         { result = val[1] }
+         | MINUS unary
+         { result = Arithmetic::Node::Negative.new(val[1]) }
+         | term
+
+    term: PARENL add PARENR
+        { result = val[1] }
+        | NUMBER
+        { result = Arithmetic::Node::Number.new(val[0]) }
+end
+
+---- header
+
+require "bcdice/common_command/lexer"
+require "bcdice/common_command/tally_dice/node"
+require "bcdice/arithmetic/node"
+
+---- inner
+
+def self.parse(source)
+  new.parse(source)
+end
+
+def parse(source)
+  @lexer = Lexer.new(source)
+  do_parse()
+rescue ParseError
+  nil
+end
+
+private
+
+def next_token
+  @lexer.next_token
+end

--- a/test/data/tally_sort.toml
+++ b/test/data/tally_sort.toml
@@ -1,0 +1,53 @@
+[[ test ]]
+game_system = "StellarKnights"
+input = "20TY6 銀剣のステラナイツ ソートあり（sort_barabara_dice? => true）"
+output = "(20TY6) ＞ 1,1,2,2,3,3,4,4,4,4,4,4,5,5,5,5,6,6,6,6 ＞ [1]×2, [2]×2, [3]×2, [4]×6, [5]×4, [6]×4"
+rands = [
+  { sides = 6, value = 6 },
+  { sides = 6, value = 2 },
+  { sides = 6, value = 6 },
+  { sides = 6, value = 4 },
+  { sides = 6, value = 6 },
+  { sides = 6, value = 5 },
+  { sides = 6, value = 4 },
+  { sides = 6, value = 3 },
+  { sides = 6, value = 2 },
+  { sides = 6, value = 1 },
+  { sides = 6, value = 4 },
+  { sides = 6, value = 4 },
+  { sides = 6, value = 5 },
+  { sides = 6, value = 1 },
+  { sides = 6, value = 6 },
+  { sides = 6, value = 5 },
+  { sides = 6, value = 4 },
+  { sides = 6, value = 3 },
+  { sides = 6, value = 4 },
+  { sides = 6, value = 5 },
+]
+
+[[ test ]]
+game_system = "StellarKnights"
+input = "20TZ6 銀剣のステラナイツ ソートあり（sort_barabara_dice? => true）"
+output = "(20TZ6) ＞ 1,1,2,2,3,3,4,4,4,4,4,4,5,5,5,5,6,6,6,6 ＞ [1]×2, [2]×2, [3]×2, [4]×6, [5]×4, [6]×4"
+rands = [
+  { sides = 6, value = 6 },
+  { sides = 6, value = 2 },
+  { sides = 6, value = 6 },
+  { sides = 6, value = 4 },
+  { sides = 6, value = 6 },
+  { sides = 6, value = 5 },
+  { sides = 6, value = 4 },
+  { sides = 6, value = 3 },
+  { sides = 6, value = 2 },
+  { sides = 6, value = 1 },
+  { sides = 6, value = 4 },
+  { sides = 6, value = 4 },
+  { sides = 6, value = 5 },
+  { sides = 6, value = 1 },
+  { sides = 6, value = 6 },
+  { sides = 6, value = 5 },
+  { sides = 6, value = 4 },
+  { sides = 6, value = 3 },
+  { sides = 6, value = 4 },
+  { sides = 6, value = 5 },
+]

--- a/test/data/tally_ty.toml
+++ b/test/data/tally_ty.toml
@@ -1,0 +1,137 @@
+[[ test ]]
+game_system = "DiceBot"
+input = "20TY6 大文字"
+output = "(20TY6) ＞ 6,2,6,4,6,5,4,3,2,1,4,4,5,1,6,5,4,3,4,5 ＞ [1]×2, [2]×2, [3]×2, [4]×6, [5]×4, [6]×4"
+rands = [
+  { sides = 6, value = 6 },
+  { sides = 6, value = 2 },
+  { sides = 6, value = 6 },
+  { sides = 6, value = 4 },
+  { sides = 6, value = 6 },
+  { sides = 6, value = 5 },
+  { sides = 6, value = 4 },
+  { sides = 6, value = 3 },
+  { sides = 6, value = 2 },
+  { sides = 6, value = 1 },
+  { sides = 6, value = 4 },
+  { sides = 6, value = 4 },
+  { sides = 6, value = 5 },
+  { sides = 6, value = 1 },
+  { sides = 6, value = 6 },
+  { sides = 6, value = 5 },
+  { sides = 6, value = 4 },
+  { sides = 6, value = 3 },
+  { sides = 6, value = 4 },
+  { sides = 6, value = 5 },
+]
+
+[[ test ]]
+game_system = "DiceBot"
+input = "20ty6 小文字"
+output = "(20TY6) ＞ 6,2,6,4,6,5,4,3,2,1,4,4,5,1,6,5,4,3,4,5 ＞ [1]×2, [2]×2, [3]×2, [4]×6, [5]×4, [6]×4"
+rands = [
+  { sides = 6, value = 6 },
+  { sides = 6, value = 2 },
+  { sides = 6, value = 6 },
+  { sides = 6, value = 4 },
+  { sides = 6, value = 6 },
+  { sides = 6, value = 5 },
+  { sides = 6, value = 4 },
+  { sides = 6, value = 3 },
+  { sides = 6, value = 2 },
+  { sides = 6, value = 1 },
+  { sides = 6, value = 4 },
+  { sides = 6, value = 4 },
+  { sides = 6, value = 5 },
+  { sides = 6, value = 1 },
+  { sides = 6, value = 6 },
+  { sides = 6, value = 5 },
+  { sides = 6, value = 4 },
+  { sides = 6, value = 3 },
+  { sides = 6, value = 4 },
+  { sides = 6, value = 5 },
+]
+
+[[ test ]]
+game_system = "DiceBot"
+input = "5TY6 出現しなかった出目がある場合"
+output = "(5TY6) ＞ 6,1,2,5,2 ＞ [1]×1, [2]×2, [5]×1, [6]×1"
+rands = [
+  { sides = 6, value = 6 },
+  { sides = 6, value = 1 },
+  { sides = 6, value = 2 },
+  { sides = 6, value = 5 },
+  { sides = 6, value = 2 },
+]
+
+[[ test ]]
+game_system = "DiceBot"
+input = "(1+2*3)TY4 個数を計算"
+output = "(7TY4) ＞ 1,4,4,3,4,2,3 ＞ [1]×1, [2]×1, [3]×2, [4]×3"
+rands = [
+  { sides = 4, value = 1 },
+  { sides = 4, value = 4 },
+  { sides = 4, value = 4 },
+  { sides = 4, value = 3 },
+  { sides = 4, value = 4 },
+  { sides = 4, value = 2 },
+  { sides = 4, value = 3 },
+]
+
+[[ test ]]
+game_system = "DiceBot"
+input = "7TY(1+5/2C) 面数を計算"
+output = "(7TY4) ＞ 1,4,4,3,4,2,3 ＞ [1]×1, [2]×1, [3]×2, [4]×3"
+rands = [
+  { sides = 4, value = 1 },
+  { sides = 4, value = 4 },
+  { sides = 4, value = 4 },
+  { sides = 4, value = 3 },
+  { sides = 4, value = 4 },
+  { sides = 4, value = 2 },
+  { sides = 4, value = 3 },
+]
+
+[[ test ]]
+game_system = "DiceBot"
+input = "(1+2*3)TY(1+5/2C) 個数と面数を計算"
+output = "(7TY4) ＞ 1,4,4,3,4,2,3 ＞ [1]×1, [2]×1, [3]×2, [4]×3"
+rands = [
+  { sides = 4, value = 1 },
+  { sides = 4, value = 4 },
+  { sides = 4, value = 4 },
+  { sides = 4, value = 3 },
+  { sides = 4, value = 4 },
+  { sides = 4, value = 2 },
+  { sides = 4, value = 3 },
+]
+
+[[ test ]]
+game_system = "DiceBot"
+input = "0TY4 個数0はエラー"
+output = ""
+rands = []
+
+[[ test ]]
+game_system = "DiceBot"
+input = "(2-3)TY4 個数がマイナスはエラー"
+output = ""
+rands = []
+
+[[ test ]]
+game_system = "DiceBot"
+input = "2TY0 面数0はエラー"
+output = ""
+rands = []
+
+[[ test ]]
+game_system = "DiceBot"
+input = "2TY(0-1) 面数がマイナスはエラー"
+output = ""
+rands = []
+
+[[ test ]]
+game_system = "DiceBot"
+input = "2TY21 面数21以上はエラー"
+output = "(2TY21) ＞ 面数は1以上、20以下としてください"
+rands = []

--- a/test/data/tally_tz.toml
+++ b/test/data/tally_tz.toml
@@ -1,0 +1,137 @@
+[[ test ]]
+game_system = "DiceBot"
+input = "20TZ6 大文字"
+output = "(20TZ6) ＞ 6,2,6,4,6,5,4,3,2,1,4,4,5,1,6,5,4,3,4,5 ＞ [1]×2, [2]×2, [3]×2, [4]×6, [5]×4, [6]×4"
+rands = [
+  { sides = 6, value = 6 },
+  { sides = 6, value = 2 },
+  { sides = 6, value = 6 },
+  { sides = 6, value = 4 },
+  { sides = 6, value = 6 },
+  { sides = 6, value = 5 },
+  { sides = 6, value = 4 },
+  { sides = 6, value = 3 },
+  { sides = 6, value = 2 },
+  { sides = 6, value = 1 },
+  { sides = 6, value = 4 },
+  { sides = 6, value = 4 },
+  { sides = 6, value = 5 },
+  { sides = 6, value = 1 },
+  { sides = 6, value = 6 },
+  { sides = 6, value = 5 },
+  { sides = 6, value = 4 },
+  { sides = 6, value = 3 },
+  { sides = 6, value = 4 },
+  { sides = 6, value = 5 },
+]
+
+[[ test ]]
+game_system = "DiceBot"
+input = "20tz6 小文字"
+output = "(20TZ6) ＞ 6,2,6,4,6,5,4,3,2,1,4,4,5,1,6,5,4,3,4,5 ＞ [1]×2, [2]×2, [3]×2, [4]×6, [5]×4, [6]×4"
+rands = [
+  { sides = 6, value = 6 },
+  { sides = 6, value = 2 },
+  { sides = 6, value = 6 },
+  { sides = 6, value = 4 },
+  { sides = 6, value = 6 },
+  { sides = 6, value = 5 },
+  { sides = 6, value = 4 },
+  { sides = 6, value = 3 },
+  { sides = 6, value = 2 },
+  { sides = 6, value = 1 },
+  { sides = 6, value = 4 },
+  { sides = 6, value = 4 },
+  { sides = 6, value = 5 },
+  { sides = 6, value = 1 },
+  { sides = 6, value = 6 },
+  { sides = 6, value = 5 },
+  { sides = 6, value = 4 },
+  { sides = 6, value = 3 },
+  { sides = 6, value = 4 },
+  { sides = 6, value = 5 },
+]
+
+[[ test ]]
+game_system = "DiceBot"
+input = "5TZ6 出現しなかった出目がある場合"
+output = "(5TZ6) ＞ 6,1,2,5,2 ＞ [1]×1, [2]×2, [3]×0, [4]×0, [5]×1, [6]×1"
+rands = [
+  { sides = 6, value = 6 },
+  { sides = 6, value = 1 },
+  { sides = 6, value = 2 },
+  { sides = 6, value = 5 },
+  { sides = 6, value = 2 },
+]
+
+[[ test ]]
+game_system = "DiceBot"
+input = "(1+2*3)TZ4 個数を計算"
+output = "(7TZ4) ＞ 1,4,4,3,4,2,3 ＞ [1]×1, [2]×1, [3]×2, [4]×3"
+rands = [
+  { sides = 4, value = 1 },
+  { sides = 4, value = 4 },
+  { sides = 4, value = 4 },
+  { sides = 4, value = 3 },
+  { sides = 4, value = 4 },
+  { sides = 4, value = 2 },
+  { sides = 4, value = 3 },
+]
+
+[[ test ]]
+game_system = "DiceBot"
+input = "7TZ(1+5/2C) 面数を計算"
+output = "(7TZ4) ＞ 1,4,4,3,4,2,3 ＞ [1]×1, [2]×1, [3]×2, [4]×3"
+rands = [
+  { sides = 4, value = 1 },
+  { sides = 4, value = 4 },
+  { sides = 4, value = 4 },
+  { sides = 4, value = 3 },
+  { sides = 4, value = 4 },
+  { sides = 4, value = 2 },
+  { sides = 4, value = 3 },
+]
+
+[[ test ]]
+game_system = "DiceBot"
+input = "(1+2*3)TZ(1+5/2C) 個数と面数を計算"
+output = "(7TZ4) ＞ 1,4,4,3,4,2,3 ＞ [1]×1, [2]×1, [3]×2, [4]×3"
+rands = [
+  { sides = 4, value = 1 },
+  { sides = 4, value = 4 },
+  { sides = 4, value = 4 },
+  { sides = 4, value = 3 },
+  { sides = 4, value = 4 },
+  { sides = 4, value = 2 },
+  { sides = 4, value = 3 },
+]
+
+[[ test ]]
+game_system = "DiceBot"
+input = "0TZ4 個数0はエラー"
+output = ""
+rands = []
+
+[[ test ]]
+game_system = "DiceBot"
+input = "(2-3)TZ4 個数がマイナスはエラー"
+output = ""
+rands = []
+
+[[ test ]]
+game_system = "DiceBot"
+input = "2TZ0 面数0はエラー"
+output = ""
+rands = []
+
+[[ test ]]
+game_system = "DiceBot"
+input = "2TZ(0-1) 面数がマイナスはエラー"
+output = ""
+rands = []
+
+[[ test ]]
+game_system = "DiceBot"
+input = "2TZ21 面数21以上はエラー"
+output = "(2TZ21) ＞ 面数は1以上、20以下としてください"
+rands = []

--- a/test/test_base.rb
+++ b/test/test_base.rb
@@ -9,7 +9,7 @@ end
 
 class TestBase < Test::Unit::TestCase
   def test_command_pattern
-    assert_equal(/^S?([+\-(]*\d+|\d+B\d+|C[+\-(]*\d+|choice|D66|(repeat|rep|x)\d+|\d+R\d+|\d+U\d+|BCDiceVersion|ABC|XYZ|IP\d+)/i, DummySystem.command_pattern)
+    assert_equal(/^S?([+\-(]*\d+|\d+B\d+|\d+T[YZ]\d+|C[+\-(]*\d+|choice|D66|(repeat|rep|x)\d+|\d+R\d+|\d+U\d+|BCDiceVersion|ABC|XYZ|IP\d+)/i, DummySystem.command_pattern)
 
     assert_match(DummySystem.command_pattern, "ABC+123")
     assert_match(DummySystem.command_pattern, "XYZ[hoge]")
@@ -20,6 +20,8 @@ class TestBase < Test::Unit::TestCase
     assert_match(DummySystem.command_pattern, "1D100<=70")
     assert_match(DummySystem.command_pattern, "4D6+2D8")
     assert_match(DummySystem.command_pattern, "4B6+2B8")
+    assert_match(DummySystem.command_pattern, "5TY6")
+    assert_match(DummySystem.command_pattern, "5TZ6")
     assert_match(DummySystem.command_pattern, "C2+4*3/2")
     assert_match(DummySystem.command_pattern, "choice[うさぎ,かめ]")
     assert_match(DummySystem.command_pattern, "D66s")

--- a/test/test_sai_fic_skill_table.rb
+++ b/test/test_sai_fic_skill_table.rb
@@ -12,6 +12,6 @@ class TestSaiFicSkillTable < Test::Unit::TestCase
   end
 
   def test_command_pattern
-    assert_equal(/^S?([+\-(]*\d+|\d+B\d+|C[+\-(]*\d+|choice|D66|(repeat|rep|x)\d+|\d+R\d+|\d+U\d+|BCDiceVersion|RTT[1-6]?|RCT)/i, DummySystem.command_pattern)
+    assert_equal(/^S?([+\-(]*\d+|\d+B\d+|\d+T[YZ]\d+|C[+\-(]*\d+|choice|D66|(repeat|rep|x)\d+|\d+R\d+|\d+U\d+|BCDiceVersion|RTT[1-6]?|RCT)/i, DummySystem.command_pattern)
   end
 end


### PR DESCRIPTION
Discordのbcdice-helpサーバで出た質問を基にして、バラバラダイスの出目の個数を数える汎用コマンドを追加してみました。ご意見をいただきながら、使いやすい形にしていきたいと思います。

# 背景

* きっかけとなったDiscordのbcdice-helpサーバで出た質問では、CoCのシナリオ内の処理で需要があるとのことでした。
* Discordや私の[ツイート](https://twitter.com/ochaochaocha3/status/1447043959205683200)の返信で教えていただいたところ、出目の個数のカウントは複数のシステムにある汎用的なルールと考えられました。具体的には、銀剣のステラナイツ、光砕のリヴァルチャー、魔法学園RPGハーベストにあるとのことです。
* 現在のBCDiceでは、アルケミア・ストラグルが固有コマンド `xUL` で対応しています。ただし、面数が6に固定されており、他の面数で振りたい場合は、手作業で数えるか各システムに固有コマンドを追加する必要がありました。

# 目的

多くのシステムでバラバラダイスの出目の個数を数えられるようにするため、そのように動作する汎用コマンドを追加します。他の汎用コマンドと同様に、振るダイスの個数と面数を指定できるようにします。

# 仕様

https://github.com/bcdice/BCDice/pull/509#issuecomment-965549815 に合わせた仕様です。

## 名称

* コマンド名：個数カウントダイス
* クラス名：`BCDice::CommonCommand::TallyDice`

（「tally」は[英語で「集計する」という意味](https://eow.alc.co.jp/search?q=tally)。Rubyではこのコマンドと同様の集計操作が [`Enumerable#tally`](https://docs.ruby-lang.org/ja/latest/method/Enumerable/i/tally.html) というメソッドになっています。）

## 書式

このコマンドには2種類の書式があります。選んだ書式によって、出現しなかった目について「×0」を表示するかどうかが変わります。

### 「×0」を表示しない場合

```
xTYy
```

（由来：英単語「**t**all**y**」の略）

### 「×0」を表示する場合

```
xTZy
```

（由来：「**T**ally with **Z**ero」の略）

## 動作の概要

`y` 面ダイスを `x` 個ダイスロールし、各出目の個数を表示します。選んだ書式によって、出現しなかった目について「×0」を表示するかどうかが変わります。

* `xTYy`：出現しなかった目の表示が省略されます。
* `xTZy`：出現しなかった目が「×0」と表示されます。

表示が極端に長くなることを防ぐため、現在はダイスの面数を20以下に制限しています。今後の利用状況や要望に応じて、拡張される可能性があります。

## 実行例

```
[DiceBot]> 10TY6
(10TY6) ＞ 4,6,1,1,5,3,1,4,5,6 ＞ [1]×3, [3]×1, [4]×2, [5]×2, [6]×2

[DiceBot]> 10TZ6
(10TZ6) ＞ 4,6,1,1,5,3,1,4,5,6 ＞ [1]×3, [2]×0, [3]×1, [4]×2, [5]×2, [6]×2
```

## 動作の詳細

* ダイスの個数が0以下、または面数が0以下の場合は、無効なダイスとして無視します。
* ダイスの面数が21以上の場合は以下のようにエラーメッセージを表示します。
    ```
    [DiceBot]> 10TY21
    (10TY21) ＞ 面数は1以上、20以下としてください
    ```
* 結果表示において、出目がソートされるかはゲームシステムに依存します。バラバラダイスがソートされるゲームシステムでは、出目がソートされます。

# （参考）旧仕様

## 名称

* コマンド名：個数カウントダイス
* クラス名：`BCDice::CommonCommand::BarabaraCountDice`

クラス名の由来は、バラバラダイス＋カウントです。

## 書式

```
xBCy
```

`BC` はクラス名 `BarabaraCount` の略です。

## 動作の概要

`y` 面ダイスを `x` 個ダイスロールし、各出目の個数を表示します。

## 実行例

```
[DiceBot]> 10BC6
(10BC6) ＞ 4,6,1,1,5,3,1,4,5,6 ＞ [1]×3, [3]×1, [4]×2, [5]×2, [6]×2
```

# 論点

* 名称（コマンド名、クラス名）や書式は適切か。
* 振った結果の表示について：
    * ソートを行うか（現在はソートなし）。
        * 参考：以前追加されたフィルタ付き加算ダイスは、システムと関係なくソートされます。
    * 表示形式が適切か。
        * bcdice-helpでのコメント：現在の出力はやや分かりにくい。`①2 ②3…、1(2個) 2(3個)…、⚀⚁…` など様々な表記が考えられる。
        * ツイートへの返信：[1つも出なかった目は0個と表示されるのか、表示がないのか、または選べるオプションがあるのか気になる。](https://twitter.com/riko1043/status/1447049650918150150)
        * ツイートへの返信：["個"の表示が言語依存している。](https://twitter.com/mihoshiinfo/status/1447048439859007488)