### PR TITLE
 [SwordWorld2.0] [SwordWorld2.5] レーティング表まわりのリファクタリング

### DIFF
--- a/lib/bcdice/game_system/SwordWorld2_0.rb
+++ b/lib/bcdice/game_system/SwordWorld2_0.rb
@@ -116,20 +116,19 @@ module BCDice
 
       def rollDice(command, round)
         if command.semi_fixed_val > 0
+          # 常に片方の出目を固定
           dice = @randomizer.roll_once(6)
           return dice + command.semi_fixed_val, "#{dice},#{command.semi_fixed_val}"
-        end
-        if round == 0 && command.tmp_fixed_val > 0
+        elsif round == 0 && command.tmp_fixed_val > 0
+          # 回転前だけ片方の出目を固定
           dice = @randomizer.roll_once(6)
           return dice + command.tmp_fixed_val, "#{dice},#{command.tmp_fixed_val}"
-        end
-        unless command.greatest_fortune
-          return super(command, round)
-        end
-
-        if command.greatest_fortune
+        elsif command.greatest_fortune
+          # グレイテスト・フォーチュン
           dice = @randomizer.roll_once(6)
           return dice * 2, "#{dice},#{dice}"
+        else
+          return super(command, round)
         end
       end
 

--- a/lib/bcdice/game_system/sword_world/rating_options.rb
+++ b/lib/bcdice/game_system/sword_world/rating_options.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+module BCDice
+  module GameSystem
+    class SwordWorld < Base
+      class RatingOptions
+        # @return [Integer, nil]
+        attr_accessor :critical
+
+        # @return [Integer, nil]
+        attr_accessor :kept_modify
+
+        # @return [Integer, nil]
+        attr_accessor :first_to
+
+        # @return [Integer, nil]
+        attr_accessor :first_modify
+
+        # @return [Integer, nil]
+        attr_accessor :rateup
+
+        # @return [Boolean, nil]
+        attr_accessor :greatest_fortune
+
+        # @return [Integer, nil]
+        attr_accessor :semi_fixed_val
+
+        # @return [Integer, nil]
+        attr_accessor :tmp_fixed_val
+
+        # @return [Integer, nil]
+        attr_accessor :modifier
+
+        # @return [Integer, nil]
+        attr_accessor :modifier_after_half
+
+        def settable_first_roll_adjust_option?
+          return @first_modify.nil? && @first_to.nil?
+        end
+
+        def settable_non_2d_roll_option?
+          return @greatest_fortune.nil? && @semi_fixed_val.nil? && @tmp_fixed_val.nil?
+        end
+      end
+    end
+  end
+end

--- a/lib/bcdice/game_system/sword_world/rating_parsed.rb
+++ b/lib/bcdice/game_system/sword_world/rating_parsed.rb
@@ -61,7 +61,7 @@ module BCDice
           if @semi_fixed_val <= 1
             return 3
           else
-            return (@semi_fixed_val + @kept_modify + 2).clamp(3..13)
+            return (@semi_fixed_val + @kept_modify + 2).clamp(3, 13)
           end
         end
 

--- a/lib/bcdice/game_system/sword_world/rating_parsed.rb
+++ b/lib/bcdice/game_system/sword_world/rating_parsed.rb
@@ -7,7 +7,7 @@ module BCDice
         # @return [Integer]
         attr_accessor :rate
 
-        # @return [Integer, nil]
+        # @return [Integer]
         attr_accessor :critical
 
         # @return [Integer]
@@ -40,7 +40,7 @@ module BCDice
         def initialize(rate, modifier)
           @rate = rate
           @modifier = modifier
-          @critical = nil
+          @critical = 13
           @kept_modify = 0
           @first_to = 0
           @first_modify = 0

--- a/lib/bcdice/game_system/sword_world/rating_parsed.rb
+++ b/lib/bcdice/game_system/sword_world/rating_parsed.rb
@@ -8,45 +8,47 @@ module BCDice
         attr_accessor :rate
 
         # @return [Integer, nil]
-        attr_writer :critical
+        attr_accessor :critical
 
-        # @return [Integer, nil]
-        attr_writer :kept_modify
+        # @return [Integer]
+        attr_accessor :kept_modify
 
-        # @return [Integer, nil]
-        attr_writer :first_to
+        # @return [Integer]
+        attr_accessor :first_to
 
-        # @return [Integer, nil]
-        attr_writer :first_modify
+        # @return [Integer]
+        attr_accessor :first_modify
 
-        # @return [Integer, nil]
-        attr_writer :rateup
+        # @return [Integer]
+        attr_accessor :rateup
 
         # @return [Boolean]
         attr_accessor :greatest_fortune
 
-        # @return [Integer, nil]
-        attr_writer :semi_fixed_val
+        # @return [Integer]
+        attr_accessor :semi_fixed_val
 
-        # @return [Integer, nil]
-        attr_writer :tmp_fixed_val
+        # @return [Integer]
+        attr_accessor :tmp_fixed_val
 
         # @return [Integer]
         attr_accessor :modifier
 
         # @return [Integer, nil]
-        attr_writer :modifier_after_half
+        attr_accessor :modifier_after_half
 
-        def initialize
+        def initialize(rate, modifier)
+          @rate = rate
+          @modifier = modifier
           @critical = nil
-          @min_critical = nil
-          @kept_modify = nil
-          @first_to = nil
-          @first_modify = nil
+          @kept_modify = 0
+          @first_to = 0
+          @first_modify = 0
           @greatest_fortune = false
-          @rateup = nil
-          @semi_fixed_val = nil
-          @tmp_fixed_val = nil
+          @rateup = 0
+          @semi_fixed_val = 0
+          @tmp_fixed_val = 0
+          @modifier_after_half = nil
         end
 
         # @return [Boolean]
@@ -55,62 +57,17 @@ module BCDice
         end
 
         # @return [Integer]
-        def critical
-          return @critical || (half ? 13 : 10)
-        end
-
-        # @return [Integer]
         def min_critical
-          min_critical = 3
-          unless @semi_fixed_val.nil?
-            if @kept_modify.nil?
-              min_critical = @semi_fixed_val + 2 if min_critical < @semi_fixed_val + 2
-            else
-              min_critical = @semi_fixed_val + @kept_modify + 2 if min_critical < @semi_fixed_val + @kept_modify + 2
-            end
-            min_critical = 3 if @semi_fixed_val == 1
+          if @semi_fixed_val <= 1
+            return 3
+          else
+            return (@semi_fixed_val + @kept_modify + 2).clamp(3..13)
           end
-          min_critical = 13 if min_critical > 13
-          return min_critical
         end
 
-        # @return [Integer]
-        def first_modify
-          return @first_modify || 0
-        end
-
-        # @return [Integer]
-        def first_to
-          return @first_to || 0
-        end
-
-        # @return [Integer]
-        def rateup
-          return @rateup || 0
-        end
-
-        # @return [Integer]
-        def semi_fixed_val
-          sf = @semi_fixed_val || 0
-          sf = 6 if sf > 6
-          return sf
-        end
-
-        # @return [Integer]
-        def tmp_fixed_val
-          tf = @tmp_fixed_val || 0
-          tf = 6 if tf > 6
-          return tf
-        end
-
-        # @return [Integer]
-        def kept_modify
-          return @kept_modify || 0
-        end
-
-        # @return [Integer]
-        def modifier_after_half
-          return @modifier_after_half || 0
+        # @return [Boolean]
+        def infinite_roll?
+          return critical < min_critical
         end
 
         # @return [String]
@@ -130,11 +87,6 @@ module BCDice
             output += Format.modifier(@modifier)
           end
           return output
-        end
-
-        # @return [Boolean]
-        def infinite_roll?
-          return critical < min_critical
         end
       end
     end

--- a/lib/bcdice/game_system/sword_world/rating_parser.y
+++ b/lib/bcdice/game_system/sword_world/rating_parser.y
@@ -214,7 +214,7 @@ def parsed(rate, modifier, option)
     p.semi_fixed_val = option.semi_fixed_val&.clamp(1..6) || 0
     p.tmp_fixed_val = option.tmp_fixed_val&.clamp(1..6) || 0
     p.modifier_after_half = option.modifier_after_half&.eval(@round_type)
-    p.critical = option.critical&.eval(@round_type)&.clamp(..13) || (p.half ? 13 : 10)
+    p.critical = option.critical&.eval(@round_type)&.clamp(0..13) || (p.half ? 13 : 10)
   end
 end
 

--- a/lib/bcdice/game_system/sword_world/rating_parser.y
+++ b/lib/bcdice/game_system/sword_world/rating_parser.y
@@ -8,14 +8,14 @@ class RatingParser
         {
           rate, option = val
           modifier = option[:modifier] || Arithmetic::Node::Number.new(0)
-          result = parsed(rate, modifier, option)
+          result = parsed(rate, modifier.eval(@round_type), option)
         }
         | H rate option
         {
           _, rate, option = val
           option[:modifier_after_half] ||= Arithmetic::Node::Number.new(0)
           modifier = option[:modifier] || Arithmetic::Node::Number.new(0)
-          result = parsed(rate, modifier, option)
+          result = parsed(rate, modifier.eval(@round_type), option)
         }
 
 
@@ -213,18 +213,16 @@ end
 private
 
 def parsed(rate, modifier, option)
-  RatingParsed.new.tap do |p|
-    p.rate = rate
-    p.critical = option[:critical]&.eval(@round_type)
-    p.kept_modify = option[:kept_modify]&.eval(@round_type)
-    p.first_to = option[:first_to]
-    p.first_modify = option[:first_modify]
-    p.rateup = option[:rateup]&.eval(@round_type)
+  RatingParsed.new(rate, modifier).tap do |p|
+    p.kept_modify = option[:kept_modify]&.eval(@round_type) || 0
+    p.first_to = option[:first_to] || 0
+    p.first_modify = option[:first_modify] || 0
+    p.rateup = option[:rateup]&.eval(@round_type) || 0
     p.greatest_fortune = option.fetch(:greatest_fortune, false)
-    p.semi_fixed_val = option[:semi_fixed_val]
-    p.tmp_fixed_val = option[:tmp_fixed_val]
-    p.modifier = modifier.eval(@round_type)
+    p.semi_fixed_val = option[:semi_fixed_val]&.clamp(1..6) || 0
+    p.tmp_fixed_val = option[:tmp_fixed_val]&.clamp(1..6) || 0
     p.modifier_after_half = option[:modifier_after_half]&.eval(@round_type)
+    p.critical = option[:critical]&.eval(@round_type)&.clamp(..13) || (p.half ? 13 : 10)
   end
 end
 

--- a/lib/bcdice/game_system/sword_world/rating_parser.y
+++ b/lib/bcdice/game_system/sword_world/rating_parser.y
@@ -211,10 +211,10 @@ def parsed(rate, modifier, option)
     p.first_modify = option.first_modify || 0
     p.rateup = option.rateup&.eval(@round_type) || 0
     p.greatest_fortune = option.greatest_fortune if !option.greatest_fortune.nil?
-    p.semi_fixed_val = option.semi_fixed_val&.clamp(1..6) || 0
-    p.tmp_fixed_val = option.tmp_fixed_val&.clamp(1..6) || 0
+    p.semi_fixed_val = option.semi_fixed_val&.clamp(1, 6) || 0
+    p.tmp_fixed_val = option.tmp_fixed_val&.clamp(1, 6) || 0
     p.modifier_after_half = option.modifier_after_half&.eval(@round_type)
-    p.critical = option.critical&.eval(@round_type)&.clamp(0..13) || (p.half ? 13 : 10)
+    p.critical = option.critical&.eval(@round_type)&.clamp(0, 13) || (p.half ? 13 : 10)
   end
 end
 

--- a/test/test_sword_world_rating_command_parser.rb
+++ b/test/test_sword_world_rating_command_parser.rb
@@ -70,7 +70,7 @@ class TestSwordWorldRatingCommandParser < Test::Unit::TestCase
     assert_false(parsed.greatest_fortune)
     assert_equal(0, parsed.rateup)
     assert_false(parsed.half)
-    assert_equal(0, parsed.modifier_after_half)
+    assert_nil(parsed.modifier_after_half)
   end
 
   def test_parse_v1_brace_critical_only
@@ -87,7 +87,7 @@ class TestSwordWorldRatingCommandParser < Test::Unit::TestCase
     assert_false(parsed.greatest_fortune)
     assert_equal(0, parsed.rateup)
     assert_false(parsed.half)
-    assert_equal(0, parsed.modifier_after_half)
+    assert_nil(parsed.modifier_after_half)
   end
 
   def test_parse_v1_brace_critical_duplicate
@@ -139,7 +139,7 @@ class TestSwordWorldRatingCommandParser < Test::Unit::TestCase
     assert_false(parsed.greatest_fortune)
     assert_equal(0, parsed.rateup)
     assert_false(parsed.half)
-    assert_equal(0, parsed.modifier_after_half)
+    assert_nil(parsed.modifier_after_half)
   end
 
   def test_parse_v20_full_gf


### PR DESCRIPTION
#516 の対応PRです。

## 対応方針
- パースしたオプションの結果をhashではなく専用のクラスに格納し、一部パースエラーに関わる判定をメソッド化
- パース後の正規化処理を、Parsedのインスタンスを作成した直後に一度だけ行うようにする
- その他細かい処理を整理