### PR TITLE
[Cthulhu] RESx-yを実行できないように

### DIFF
--- a/lib/bcdice/game_system/Cthulhu.rb
+++ b/lib/bcdice/game_system/Cthulhu.rb
@@ -193,12 +193,12 @@ module BCDice
       end
 
       def getRegistResult(command)
-        m = /^RES(B)?([-\d]+)$/i.match(command)
+        m = /^RESB?(-?\d+)$/i.match(command)
         unless m
           return nil
         end
 
-        value = m[2].to_i
+        value = m[1].to_i
         target = value * 5 + 50
 
         if target < 5

--- a/test/data/Cthulhu.toml
+++ b/test/data/Cthulhu.toml
@@ -162,6 +162,12 @@ rands = [
   { sides = 100, value = 47 },
 ]
 
+[[ test ]]
+game_system = "Cthulhu"
+input = "RES18-11"
+output = ""
+rands = []
+
 
 ##### 組み合わせロール CBR #####
 
@@ -819,6 +825,12 @@ rands = [
   { sides = 100, value = 44 },
 ]
 
+
+[[ test ]]
+game_system = "Cthulhu"
+input = "RESB18-11"
+output = ""
+rands = []
 
 ##### 戦闘用組み合わせロール CBRB #####
 


### PR DESCRIPTION
`RESx-y` が実行できるが、 `RESx` で解釈されていた。

ヘルプには `RES(x-y)` が想定書式なので、 `RESx-y` は実行しないようにする。