### PR TITLE
[Avandner] Fix: クリティカル閾値の上限を修正（ 3 → 2 ）

### DIFF
--- a/lib/bcdice/game_system/Avandner.rb
+++ b/lib/bcdice/game_system/Avandner.rb
@@ -48,8 +48,7 @@ module BCDice
           target = Regexp.last_match(2).to_i
           damage = (Regexp.last_match(5) || 0).to_i
           criticalTrigger = (Regexp.last_match(7) || 0).to_i
-          criticalNumber = (Regexp.last_match(9) || 1).to_i
-          criticalNumber = 2 if criticalNumber > 2
+          criticalNumber = (Regexp.last_match(9) || 1).to_i.clamp(0, 2)
           return checkRoll(diceCount, target, damage, criticalTrigger, criticalNumber)
         end
 

--- a/lib/bcdice/game_system/Avandner.rb
+++ b/lib/bcdice/game_system/Avandner.rb
@@ -49,7 +49,7 @@ module BCDice
           damage = (Regexp.last_match(5) || 0).to_i
           criticalTrigger = (Regexp.last_match(7) || 0).to_i
           criticalNumber = (Regexp.last_match(9) || 1).to_i
-          criticalNumber = 2 if criticalNumber > 3
+          criticalNumber = 2 if criticalNumber > 2
           return checkRoll(diceCount, target, damage, criticalTrigger, criticalNumber)
         end
 

--- a/test/data/Avandner.toml
+++ b/test/data/Avandner.toml
@@ -99,6 +99,21 @@ rands = [
 
 [[ test ]]
 game_system = "Avandner"
+input = "6AV4c3" # クリティカル閾値の上限が 2 である（ 2 以下に丸められる）ことのテスト
+output = "(6D10<=4) ＞ 4[1,2,3,4,5,6]+1[3,6] ＞ 成功数：5 / 2クリティカル"
+rands = [
+  { sides = 10, value = 1 },
+  { sides = 10, value = 2 },
+  { sides = 10, value = 3 },
+  { sides = 10, value = 4 },
+  { sides = 10, value = 5 },
+  { sides = 10, value = 6 },
+  { sides = 10, value = 3 },
+  { sides = 10, value = 6 },
+]
+
+[[ test ]]
+game_system = "Avandner"
 input = "4AV3*5"
 output = "(4D10<=3) ＞ 0[6,6,6,6] ＞ Hits：0*5 ＞ 0ダメージ"
 rands = [


### PR DESCRIPTION
根拠：

 - ヘルプメッセージでは、もともと 2 が上限となっている
 - ゲームルール上も、閾値が 3 となるケースはない
   - 『黒絢のアヴァンドナー』電子版（2020/09/25初版・現行最新）とサプリメント『叡智と栄光』電子版（2020/05/31修正版・現行最新）に対して「クリティカル」で全文検索して、ひととおり記述を確認したつもりです。