### PR TITLE
[SwordWorld2.0][SwordWorld2.5] i18nのロケールが正しく渡っていない箇所を修正

### DIFF
--- a/lib/bcdice/game_system/SwordWorld2_0.rb
+++ b/lib/bcdice/game_system/SwordWorld2_0.rb
@@ -99,7 +99,7 @@ module BCDice
             return nil
           end
 
-          node = TranscendentTest.new(cmd.critical, cmd.modify_number, cmd.cmp_op, cmd.target_number)
+          node = TranscendentTest.new(cmd.critical, cmd.modify_number, cmd.cmp_op, cmd.target_number, @locale)
           node.execute(@randomizer)
         when 'FT'
           get_fumble_table

--- a/lib/bcdice/game_system/SwordWorld2_5.rb
+++ b/lib/bcdice/game_system/SwordWorld2_5.rb
@@ -84,12 +84,6 @@ module BCDice
 
       register_prefix('H?K', 'Gr', '2D6?@\d+', 'FT', 'TT', 'Dru', 'ABT')
 
-      ABYSS_CURSE_TABLE = DiceTable::D66GridTable.from_i18n('SwordWorld2_5.AbyssCurseTable', @locale)
-
-      ABYSS_CURSE_CATEGORY_TABLE = DiceTable::D66ParityTable.from_i18n('SwordWorld2_5.AbyssCurseCategoryTable', @locale)
-
-      ABYSS_CURSE_ATTR_TABLE = DiceTable::D66ParityTable.from_i18n('SwordWorld2_5.AbyssCurseAttrTable', @locale)
-
       def eval_game_system_specific_command(command)
         case command
         when /^dru\[(\d+),(\d+),(\d+)\]/i
@@ -138,13 +132,13 @@ module BCDice
       end
 
       def get_abyss_curse_table
-        table_result = ABYSS_CURSE_TABLE.roll(@randomizer)
+        table_result = DiceTable::D66GridTable.from_i18n('SwordWorld2_5.AbyssCurseTable', @locale).roll(@randomizer)
         additional =
           case table_result.value
           when 14  # 「差別の」における分類決定表
-            ABYSS_CURSE_CATEGORY_TABLE.roll(@randomizer).to_s
+            DiceTable::D66ParityTable.from_i18n('SwordWorld2_5.AbyssCurseCategoryTable', @locale).roll(@randomizer).to_s
           when 25  # 「過敏な」における属性決定表
-            ABYSS_CURSE_ATTR_TABLE.roll(@randomizer).to_s
+            DiceTable::D66ParityTable.from_i18n('SwordWorld2_5.AbyssCurseAttrTable', @locale).roll(@randomizer).to_s
           end
         final_result = [
           table_result.to_s,

--- a/lib/bcdice/game_system/sword_world/transcendent_test.rb
+++ b/lib/bcdice/game_system/sword_world/transcendent_test.rb
@@ -12,11 +12,12 @@ module BCDice
         # @param [Integer] modifier 修正値
         # @param [String, nil] cmp_op 比較演算子（> または >=）
         # @param [Integer, nil] target 目標値
-        def initialize(critical_value, modifier, cmp_op, target)
+        def initialize(critical_value, modifier, cmp_op, target, locale)
           @critical_value = critical_value
           @modifier = modifier
           @cmp_op = cmp_op
           @target = target
+          @locale = locale
 
           @modifier_str = Format.modifier(@modifier)
           @expression = node_expression()


### PR DESCRIPTION
超越判定のダイスコマンドおよびアビスカース表について、localeの情報が正しく渡っておらず、Ruby 2.7での単体テスト時にwarnが出る問題を見落しておりましたため、修正しました。