### PR TITLE
最大値抽出・最小値抽出の汎用コマンドを追加

### DIFF
--- a/lib/bcdice/common_command/add_dice/node.rb
+++ b/lib/bcdice/common_command/add_dice/node.rb
@@ -493,7 +493,7 @@ module BCDice
 
           # ノードを初期化する
           # @param [Object] times ダイスを振る回数のノード
-          # @param [Object] sides ダイスの面数のノード
+          # @param [Object, nil] sides ダイスの面数のノード（暗黙の面数を参照したい場合は nil ）
           # @param [Object] n_filtering ダイスを残す/減らす個数のノード
           # @param [Filter] filter フィルタ
           def initialize(times, sides, n_filtering, filter)
@@ -515,7 +515,7 @@ module BCDice
           # @return [Integer] 評価結果（出目の合計値）
           def eval(game_system, randomizer)
             times = @times.eval(game_system, nil)
-            sides = @sides.eval(game_system, nil)
+            sides = @sides.nil? ? game_system.sides_implicit_d : @sides.eval(game_system, nil)
             n_filtering = @n_filtering.eval(game_system, nil)
 
             sorted_values = randomizer.roll(times, sides).sort
@@ -537,7 +537,7 @@ module BCDice
           # @return [String]
           def expr(game_system)
             times = @times.eval(game_system, nil)
-            sides = @sides.eval(game_system, nil)
+            sides = @sides.nil? ? game_system.sides_implicit_d : @sides.eval(game_system, nil)
             n_filtering = @n_filtering.eval(game_system, nil)
 
             "#{times}D#{sides}#{@filter.abbr}#{n_filtering}"
@@ -552,63 +552,7 @@ module BCDice
           # ノードのS式を返す
           # @return [String]
           def s_exp
-            "(DiceRollWithFilter #{@times.s_exp} #{@sides.s_exp} #{@filter.abbr.inspect} #{@n_filtering.s_exp})"
-          end
-        end
-
-        # フィルタ処理付きダイスロール（面数省略）のノード
-        class DiceRollWithFilterImplicitSides
-          # @param [Object] times ダイスを振る回数のノード
-          # @param [Object] n_filtering ダイスを残す/減らす個数のノード
-          # @param [Filter] filter フィルタ
-          def initialize(times, n_filtering, filter)
-            @times = times
-            @n_filtering = n_filtering
-            @filter = filter
-
-            @text = nil
-          end
-
-          # @param [Randomizer] randomizer ランダマイザ
-          # @return [Integer] 評価結果（出目の合計値）
-          def eval(game_system, randomizer)
-            times = @times.eval(game_system, nil)
-            sides = game_system.sides_implicit_d
-            n_filtering = @n_filtering.eval(game_system, nil)
-
-            sorted_values = randomizer.roll(times, sides).sort
-            total = @filter
-                    .apply[sorted_values, n_filtering]
-                    .sum()
-
-            @text = "#{total}[#{sorted_values.join(',')}]"
-
-            return total
-          end
-
-          # @return [Boolean]
-          def include_dice?
-            true
-          end
-
-          # @return [String]
-          def expr(game_system)
-            times = @times.eval(game_system, nil)
-            n_filtering = @n_filtering.eval(game_system, nil)
-
-            "#{times}D#{game_system.sides_implicit_d}#{@filter.abbr}#{n_filtering}"
-          end
-
-          # メッセージへの出力を返す
-          # @return [String]
-          def output
-            @text
-          end
-
-          # ノードのS式を返す
-          # @return [String]
-          def s_exp
-            "(ImplicitSidesDiceRollWithFilter #{@times.s_exp} #{@filter.abbr.inspect} #{@n_filtering.s_exp})"
+            "(DiceRollWithFilter #{@times.s_exp} #{@sides.nil? ? 'nil' : @sides.s_exp} #{@filter.abbr.inspect} #{@n_filtering.s_exp})"
           end
         end
 

--- a/lib/bcdice/common_command/add_dice/node.rb
+++ b/lib/bcdice/common_command/add_dice/node.rb
@@ -556,6 +556,62 @@ module BCDice
           end
         end
 
+        # フィルタ処理付きダイスロール（面数省略）のノード
+        class DiceRollWithFilterImplicitSides
+          # @param [Object] times ダイスを振る回数のノード
+          # @param [Object] n_filtering ダイスを残す/減らす個数のノード
+          # @param [Filter] filter フィルタ
+          def initialize(times, n_filtering, filter)
+            @times = times
+            @n_filtering = n_filtering
+            @filter = filter
+
+            @text = nil
+          end
+
+          # @param [Randomizer] randomizer ランダマイザ
+          # @return [Integer] 評価結果（出目の合計値）
+          def eval(game_system, randomizer)
+            times = @times.eval(game_system, nil)
+            sides = game_system.sides_implicit_d
+            n_filtering = @n_filtering.eval(game_system, nil)
+
+            sorted_values = randomizer.roll(times, sides).sort
+            total = @filter
+                    .apply[sorted_values, n_filtering]
+                    .sum()
+
+            @text = "#{total}[#{sorted_values.join(',')}]"
+
+            return total
+          end
+
+          # @return [Boolean]
+          def include_dice?
+            true
+          end
+
+          # @return [String]
+          def expr(game_system)
+            times = @times.eval(game_system, nil)
+            n_filtering = @n_filtering.eval(game_system, nil)
+
+            "#{times}D#{game_system.sides_implicit_d}#{@filter.abbr}#{n_filtering}"
+          end
+
+          # メッセージへの出力を返す
+          # @return [String]
+          def output
+            @text
+          end
+
+          # ノードのS式を返す
+          # @return [String]
+          def s_exp
+            "(ImplicitSidesDiceRollWithFilter #{@times.s_exp} #{@filter.abbr.inspect} #{@n_filtering.s_exp})"
+          end
+        end
+
         # カッコで式をまとめるノード
         class Parenthesis
           # @param expr [Object] カッコ内のノード

--- a/lib/bcdice/common_command/add_dice/node.rb
+++ b/lib/bcdice/common_command/add_dice/node.rb
@@ -562,7 +562,7 @@ module BCDice
           # ノードのS式を返す
           # @return [String]
           def s_exp
-            sides_s_exp = implicit_sides? ? 'nil' : @sides.s_exp
+            sides_s_exp = implicit_sides? ? @sides.inspect : @sides.s_exp
 
             "(DiceRollWithFilter #{@times.s_exp} #{sides_s_exp} #{@filter.abbr.inspect} #{@n_filtering.s_exp})"
           end

--- a/lib/bcdice/common_command/add_dice/parser.y
+++ b/lib/bcdice/common_command/add_dice/parser.y
@@ -1,5 +1,5 @@
 class BCDice::CommonCommand::AddDice::Parser
-token NUMBER CMP_OP S D K H L U R F C PLUS MINUS ASTERISK SLASH PARENL PARENR QUESTION
+token NUMBER CMP_OP S D K H L M A X I N U R F C PLUS MINUS ASTERISK SLASH PARENL PARENR QUESTION
 
 rule
   command: secret add
@@ -90,6 +90,16 @@ rule
 
         result = Node::ImplicitSidesDiceRoll.new(times)
       }
+      | term D term filter_shorthand
+      {
+        times = val[0]
+        sides = val[2]
+        filter = val[3]
+        raise ParseError if times.include_dice? || sides.include_dice?
+
+        n_filtering = Node::Number.new(1)
+        result = Node::DiceRollWithFilter.new(times, sides, n_filtering, filter)
+      }
       | term D term filter_type term
       {
         times = val[0]
@@ -101,6 +111,11 @@ rule
         result = Node::DiceRollWithFilter.new(times, sides, n_filtering, filter)
       }
       | term
+
+  filter_shorthand: M A X
+                  { result = Node::DiceRollWithFilter::KEEP_HIGHEST }
+                  | M I N
+                  { result = Node::DiceRollWithFilter::KEEP_LOWEST }
 
   filter_type: K H
              { result = Node::DiceRollWithFilter::KEEP_HIGHEST }

--- a/lib/bcdice/common_command/add_dice/parser.y
+++ b/lib/bcdice/common_command/add_dice/parser.y
@@ -110,6 +110,16 @@ rule
         n_filtering = Node::Number.new(1)
         result = Node::DiceRollWithFilter.new(times, sides, n_filtering, filter)
       }
+      | term D term filter_type
+      {
+        times = val[0]
+        sides = val[2]
+        filter = val[3]
+        raise ParseError if times.include_dice? || sides.include_dice?
+
+        n_filtering = Node::Number.new(1)
+        result = Node::DiceRollWithFilter.new(times, sides, n_filtering, filter)
+      }
       | term D term filter_type term
       {
         times = val[0]
@@ -118,6 +128,26 @@ rule
         n_filtering = val[4]
         raise ParseError if times.include_dice? || sides.include_dice? || n_filtering.include_dice?
 
+        result = Node::DiceRollWithFilter.new(times, sides, n_filtering, filter)
+      }
+      | term D filter_type term
+      {
+        times = val[0]
+        filter = val[2]
+        n_filtering = val[3]
+        raise ParseError if times.include_dice? || n_filtering.include_dice?
+
+        sides = nil
+        result = Node::DiceRollWithFilter.new(times, sides, n_filtering, filter)
+      }
+      | term D filter_type
+      {
+        times = val[0]
+        filter = val[2]
+        raise ParseError if times.include_dice?
+
+        sides = nil
+        n_filtering = Node::Number.new(1)
         result = Node::DiceRollWithFilter.new(times, sides, n_filtering, filter)
       }
       | term

--- a/lib/bcdice/common_command/add_dice/parser.y
+++ b/lib/bcdice/common_command/add_dice/parser.y
@@ -96,8 +96,9 @@ rule
         filter = val[2]
         raise ParseError if times.include_dice?
 
+        sides = nil
         n_filtering = Node::Number.new(1)
-        result = Node::DiceRollWithFilterImplicitSides.new(times, n_filtering, filter)
+        result = Node::DiceRollWithFilter.new(times, sides, n_filtering, filter)
       }
       | term D term filter_shorthand
       {

--- a/lib/bcdice/common_command/add_dice/parser.y
+++ b/lib/bcdice/common_command/add_dice/parser.y
@@ -90,6 +90,15 @@ rule
 
         result = Node::ImplicitSidesDiceRoll.new(times)
       }
+      | term D filter_shorthand
+      {
+        times = val[0]
+        filter = val[2]
+        raise ParseError if times.include_dice?
+
+        n_filtering = Node::Number.new(1)
+        result = Node::DiceRollWithFilterImplicitSides.new(times, n_filtering, filter)
+      }
       | term D term filter_shorthand
       {
         times = val[0]

--- a/test/data/None.toml
+++ b/test/data/None.toml
@@ -1411,6 +1411,16 @@ rands = [
 
 [[ test ]]
 game_system = "DiceBot"
+input = "3DMAX 最大値抽出、面数省略"
+output = "(3D6KH1) ＞ 5[1,3,5] ＞ 5"
+rands = [
+  { sides = 6, value = 3 },
+  { sides = 6, value = 5 },
+  { sides = 6, value = 1 },
+]
+
+[[ test ]]
+game_system = "DiceBot"
 input = "3D6MAX+2 最大値抽出、修正値つき"
 output = "(3D6KH1+2) ＞ 5[1,3,5]+2 ＞ 7"
 rands = [
@@ -1462,6 +1472,18 @@ rands = [
   { sides = 10, value = 9 },
   { sides = 10, value = 2 },
   { sides = 10, value = 5 },
+]
+
+[[ test ]]
+game_system = "DiceBot"
+input = "5DMIN 最小値抽出、面数省略"
+output = "(5D6KL1) ＞ 2[2,3,5,5,6] ＞ 2"
+rands = [
+  { sides = 6, value = 5 },
+  { sides = 6, value = 3 },
+  { sides = 6, value = 6 },
+  { sides = 6, value = 2 },
+  { sides = 6, value = 5 },
 ]
 
 [[ test ]]

--- a/test/data/None.toml
+++ b/test/data/None.toml
@@ -1311,6 +1311,42 @@ rands = [
 
 [[ test ]]
 game_system = "DiceBot"
+input = "5D10KH 最大値を取る（ KH の個数省略）"
+output = "(5D10KH1) ＞ 8[2,3,5,8,8] ＞ 8"
+rands = [
+  { sides = 10, value = 8 },
+  { sides = 10, value = 3 },
+  { sides = 10, value = 2 },
+  { sides = 10, value = 5 },
+  { sides = 10, value = 8 },
+]
+
+[[ test ]]
+game_system = "DiceBot"
+input = "5DKH3 大きな出目から3個取った後の和（面数省略）"
+output = "(5D6KH3) ＞ 17[2,3,5,6,6] ＞ 17"
+rands = [
+  { sides = 6, value = 6 },
+  { sides = 6, value = 3 },
+  { sides = 6, value = 2 },
+  { sides = 6, value = 5 },
+  { sides = 6, value = 6 },
+]
+
+[[ test ]]
+game_system = "DiceBot"
+input = "5DKH 最大値を取る（面数省略）"
+output = "(5D6KH1) ＞ 6[2,3,5,6,6] ＞ 6"
+rands = [
+  { sides = 6, value = 6 },
+  { sides = 6, value = 3 },
+  { sides = 6, value = 2 },
+  { sides = 6, value = 5 },
+  { sides = 6, value = 6 },
+]
+
+[[ test ]]
+game_system = "DiceBot"
 input = "(2+3)D(5+5)KH(5-2) 大きな出目から3個取った後の和"
 output = "(5D10KH3) ＞ 21[2,3,5,8,8] ＞ 21"
 rands = [
@@ -1335,6 +1371,42 @@ rands = [
 
 [[ test ]]
 game_system = "DiceBot"
+input = "5D10KL 最小値を取る（ KL の個数省略）"
+output = "(5D10KL1) ＞ 2[2,3,5,8,8] ＞ 2"
+rands = [
+  { sides = 10, value = 8 },
+  { sides = 10, value = 3 },
+  { sides = 10, value = 2 },
+  { sides = 10, value = 5 },
+  { sides = 10, value = 8 },
+]
+
+[[ test ]]
+game_system = "DiceBot"
+input = "5DKL3 小さな出目から3個取った後の和（面数省略）"
+output = "(5D6KL3) ＞ 10[2,3,5,6,6] ＞ 10"
+rands = [
+  { sides = 6, value = 6 },
+  { sides = 6, value = 3 },
+  { sides = 6, value = 2 },
+  { sides = 6, value = 5 },
+  { sides = 6, value = 6 },
+]
+
+[[ test ]]
+game_system = "DiceBot"
+input = "5DKL 最小値を取る（（面数省略）"
+output = "(5D6KL1) ＞ 2[2,3,5,6,6] ＞ 2"
+rands = [
+  { sides = 6, value = 6 },
+  { sides = 6, value = 3 },
+  { sides = 6, value = 2 },
+  { sides = 6, value = 5 },
+  { sides = 6, value = 6 },
+]
+
+[[ test ]]
+game_system = "DiceBot"
 input = "5D10DH3 大きな出目から3個除いた後の和"
 output = "(5D10DH3) ＞ 5[2,3,5,8,8] ＞ 5"
 rands = [
@@ -1343,6 +1415,90 @@ rands = [
   { sides = 10, value = 2 },
   { sides = 10, value = 5 },
   { sides = 10, value = 8 },
+]
+
+[[ test ]]
+game_system = "DiceBot"
+input = "5D10DH 最も大きな出目1個を除いた後の和"
+output = "(5D10DH1) ＞ 18[2,3,5,8,8] ＞ 18"
+rands = [
+  { sides = 10, value = 8 },
+  { sides = 10, value = 3 },
+  { sides = 10, value = 2 },
+  { sides = 10, value = 5 },
+  { sides = 10, value = 8 },
+]
+
+[[ test ]]
+game_system = "DiceBot"
+input = "5DDH3 大きな出目から3個除いた後の和（面数省略）"
+output = "(5D6DH3) ＞ 5[2,3,5,6,6] ＞ 5"
+rands = [
+  { sides = 6, value = 6 },
+  { sides = 6, value = 3 },
+  { sides = 6, value = 2 },
+  { sides = 6, value = 5 },
+  { sides = 6, value = 6 },
+]
+
+[[ test ]]
+game_system = "DiceBot"
+input = "5DDH 最も大きな出目1個を除いた後の和（面数省略）"
+output = "(5D6DH1) ＞ 16[2,3,5,6,6] ＞ 16"
+rands = [
+  { sides = 6, value = 6 },
+  { sides = 6, value = 3 },
+  { sides = 6, value = 2 },
+  { sides = 6, value = 5 },
+  { sides = 6, value = 6 },
+]
+
+[[ test ]]
+game_system = "DiceBot"
+input = "5D10DL3 小さな出目から3個除いた後の和"
+output = "(5D10DL3) ＞ 16[2,3,5,8,8] ＞ 16"
+rands = [
+  { sides = 10, value = 8 },
+  { sides = 10, value = 3 },
+  { sides = 10, value = 2 },
+  { sides = 10, value = 5 },
+  { sides = 10, value = 8 },
+]
+
+[[ test ]]
+game_system = "DiceBot"
+input = "5D10DL 最も小さな出目1個を除いた後の和"
+output = "(5D10DL1) ＞ 24[2,3,5,8,8] ＞ 24"
+rands = [
+  { sides = 10, value = 8 },
+  { sides = 10, value = 3 },
+  { sides = 10, value = 2 },
+  { sides = 10, value = 5 },
+  { sides = 10, value = 8 },
+]
+
+[[ test ]]
+game_system = "DiceBot"
+input = "5DDL3 小さな出目から3個除いた後の和（面数省略）"
+output = "(5D6DL3) ＞ 12[2,3,5,6,6] ＞ 12"
+rands = [
+  { sides = 6, value = 6 },
+  { sides = 6, value = 3 },
+  { sides = 6, value = 2 },
+  { sides = 6, value = 5 },
+  { sides = 6, value = 6 },
+]
+
+[[ test ]]
+game_system = "DiceBot"
+input = "5DDL 最も小さな出目1個を除いた後の和（面数省略）"
+output = "(5D6DL1) ＞ 20[2,3,5,6,6] ＞ 20"
+rands = [
+  { sides = 6, value = 6 },
+  { sides = 6, value = 3 },
+  { sides = 6, value = 2 },
+  { sides = 6, value = 5 },
+  { sides = 6, value = 6 },
 ]
 
 [[ test ]]

--- a/test/data/None.toml
+++ b/test/data/None.toml
@@ -1401,6 +1401,83 @@ rands = [
 
 [[ test ]]
 game_system = "DiceBot"
+input = "3D6MAX 最大値抽出"
+output = "(3D6KH1) ＞ 5[1,3,5] ＞ 5"
+rands = [
+  { sides = 6, value = 3 },
+  { sides = 6, value = 5 },
+  { sides = 6, value = 1 },
+]
+
+[[ test ]]
+game_system = "DiceBot"
+input = "3D6MAX+2 最大値抽出、修正値つき"
+output = "(3D6KH1+2) ＞ 5[1,3,5]+2 ＞ 7"
+rands = [
+  { sides = 6, value = 3 },
+  { sides = 6, value = 5 },
+  { sides = 6, value = 1 },
+]
+
+[[ test ]]
+game_system = "DiceBot"
+input = "3D6MAX>=4 最大値抽出、目標値つき（成功）"
+output = "(3D6KH1>=4) ＞ 5[1,3,5] ＞ 5 ＞ 成功"
+rands = [
+  { sides = 6, value = 3 },
+  { sides = 6, value = 5 },
+  { sides = 6, value = 1 },
+]
+success = true
+
+[[ test ]]
+game_system = "DiceBot"
+input = "3D6MAX>=5 最大値抽出、目標値つき（成功・同値）"
+output = "(3D6KH1>=5) ＞ 5[1,3,5] ＞ 5 ＞ 成功"
+rands = [
+  { sides = 6, value = 3 },
+  { sides = 6, value = 5 },
+  { sides = 6, value = 1 },
+]
+success = true
+
+[[ test ]]
+game_system = "DiceBot"
+input = "3D6MAX>=6 最大値抽出、目標値つき（失敗）"
+output = "(3D6KH1>=6) ＞ 5[1,3,5] ＞ 5 ＞ 失敗"
+rands = [
+  { sides = 6, value = 3 },
+  { sides = 6, value = 5 },
+  { sides = 6, value = 1 },
+]
+failure = true
+
+[[ test ]]
+game_system = "DiceBot"
+input = "5D10MIN 最小値抽出"
+output = "(5D10KL1) ＞ 2[2,3,5,7,9] ＞ 2"
+rands = [
+  { sides = 10, value = 7 },
+  { sides = 10, value = 3 },
+  { sides = 10, value = 9 },
+  { sides = 10, value = 2 },
+  { sides = 10, value = 5 },
+]
+
+[[ test ]]
+game_system = "DiceBot"
+input = "5D10MIN-3 最小値抽出、修正値つき"
+output = "(5D10KL1-3) ＞ 2[2,3,5,7,9]-3 ＞ -1"
+rands = [
+  { sides = 10, value = 7 },
+  { sides = 10, value = 3 },
+  { sides = 10, value = 9 },
+  { sides = 10, value = 2 },
+  { sides = 10, value = 5 },
+]
+
+[[ test ]]
+game_system = "DiceBot"
 input = "D66 入れ替えはゲーム依存"
 output = "(D66) ＞ 16"
 rands = [

--- a/test/test_add_dice.rb
+++ b/test/test_add_dice.rb
@@ -75,6 +75,20 @@ class AddDiceTest < Test::Unit::TestCase
     assert_equal("(2D4KH1) ＞ 3[1,3] ＞ 3", game_system.eval.text)
   end
 
+  def test_max_implicit_d
+    game_system = BCDice::Base.new("2DMAX")
+    game_system.randomizer = RandomizerMock.new([[5, 6], [1, 6]])
+
+    assert_equal("(2D6KH1) ＞ 5[1,5] ＞ 5", game_system.eval.text)
+  end
+
+  def test_max_implicit_d10
+    game_system = ImplicitD10.new("2DMAX")
+    game_system.randomizer = RandomizerMock.new([[7, 10], [1, 10]])
+
+    assert_equal("(2D10KH1) ＞ 7[1,7] ＞ 7", game_system.eval.text)
+  end
+
   def test_min
     game_system = BCDice::Base.new("2D4MIN")
     game_system.randomizer = RandomizerMock.new([[3, 4], [1, 4]])

--- a/test/test_add_dice.rb
+++ b/test/test_add_dice.rb
@@ -67,4 +67,18 @@ class AddDiceTest < Test::Unit::TestCase
 
     assert_equal("(1D6+4) ＞ 6[6]+4 ＞ 10", game_system.eval.text)
   end
+
+  def test_max
+    game_system = BCDice::Base.new("2D4MAX")
+    game_system.randomizer = RandomizerMock.new([[3, 4], [1, 4]])
+
+    assert_equal("(2D4KH1) ＞ 3[1,3] ＞ 3", game_system.eval.text)
+  end
+
+  def test_min
+    game_system = BCDice::Base.new("2D4MIN")
+    game_system.randomizer = RandomizerMock.new([[3, 4], [1, 4]])
+
+    assert_equal("(2D4KL1) ＞ 1[1,3] ＞ 1", game_system.eval.text)
+  end
 end

--- a/test/test_add_dice.rb
+++ b/test/test_add_dice.rb
@@ -68,6 +68,41 @@ class AddDiceTest < Test::Unit::TestCase
     assert_equal("(1D6+4) ＞ 6[6]+4 ＞ 10", game_system.eval.text)
   end
 
+  def test_parse_keep_highest
+    game_system = BCDice::Base.new("2D4KH")
+    game_system.randomizer = RandomizerMock.new([[3, 4], [1, 4]])
+
+    assert_equal("(2D4KH1) ＞ 3[1,3] ＞ 3", game_system.eval.text)
+  end
+
+  def test_parse_keep_high_implicit_d
+    game_system = BCDice::Base.new("3DKH2")
+    game_system.randomizer = RandomizerMock.new([[3, 6], [1, 6], [2, 6]])
+
+    assert_equal("(3D6KH2) ＞ 5[1,2,3] ＞ 5", game_system.eval.text)
+  end
+
+  def test_parse_keep_high_implicit_d10
+    game_system = ImplicitD10.new("3DKH2")
+    game_system.randomizer = RandomizerMock.new([[8, 10], [1, 10], [3, 10]])
+
+    assert_equal("(3D10KH2) ＞ 11[1,3,8] ＞ 11", game_system.eval.text)
+  end
+
+  def test_parse_keep_highest_implicit_d
+    game_system = BCDice::Base.new("3DKH")
+    game_system.randomizer = RandomizerMock.new([[3, 6], [1, 6], [2, 6]])
+
+    assert_equal("(3D6KH1) ＞ 3[1,2,3] ＞ 3", game_system.eval.text)
+  end
+
+  def test_parse_keep_highest_implicit_d10
+    game_system = ImplicitD10.new("3DKH")
+    game_system.randomizer = RandomizerMock.new([[9, 10], [1, 10], [3, 10]])
+
+    assert_equal("(3D10KH1) ＞ 9[1,3,9] ＞ 9", game_system.eval.text)
+  end
+
   def test_max
     game_system = BCDice::Base.new("2D4MAX")
     game_system.randomizer = RandomizerMock.new([[3, 4], [1, 4]])

--- a/test/test_add_dice_parser.rb
+++ b/test/test_add_dice_parser.rb
@@ -366,6 +366,13 @@ class AddDiceParserTest < Test::Unit::TestCase
     )
   end
 
+  # 最大値抽出、パース不可
+  def test_not_parse_max
+    # 個数を指定できない
+    assert_not_parse("3D6MAX1")
+    assert_not_parse("3DMAX1")
+  end
+
   # 最小値抽出（ KL1 の簡易記法）
   def test_parse_min
     test_parse(
@@ -388,6 +395,13 @@ class AddDiceParserTest < Test::Unit::TestCase
       "5D10MIN-3",
       "(Command (- (DiceRollWithFilter 5 10 :KL 1) 3))"
     )
+  end
+
+  # 最小値抽出、パース不可
+  def test_not_parse_min
+    # 個数を指定できない
+    assert_not_parse("3D6MIN1")
+    assert_not_parse("3DMIN1")
   end
 
   def test_parse_filter_nested_dice

--- a/test/test_add_dice_parser.rb
+++ b/test/test_add_dice_parser.rb
@@ -254,6 +254,14 @@ class AddDiceParserTest < Test::Unit::TestCase
     )
   end
 
+  # 最大値抽出、面数省略
+  def test_parse_max_implicit_sides
+    test_parse(
+      "3DMAX",
+      "(Command (ImplicitSidesDiceRollWithFilter 3 :KH 1))"
+    )
+  end
+
   # 最大値抽出、修正値つき
   def test_parse_max_with_modifier
     test_parse(
@@ -267,6 +275,14 @@ class AddDiceParserTest < Test::Unit::TestCase
     test_parse(
       "5D10MIN",
       "(Command (DiceRollWithFilter 5 10 :KL 1))"
+    )
+  end
+
+  # 最小値抽出、面数省略
+  def test_parse_min_implicit_sides
+    test_parse(
+      "5DMIN",
+      "(Command (ImplicitSidesDiceRollWithFilter 5 :KL 1))"
     )
   end
 

--- a/test/test_add_dice_parser.rb
+++ b/test/test_add_dice_parser.rb
@@ -258,7 +258,7 @@ class AddDiceParserTest < Test::Unit::TestCase
   def test_parse_max_implicit_sides
     test_parse(
       "3DMAX",
-      "(Command (ImplicitSidesDiceRollWithFilter 3 :KH 1))"
+      "(Command (DiceRollWithFilter 3 nil :KH 1))"
     )
   end
 
@@ -282,7 +282,7 @@ class AddDiceParserTest < Test::Unit::TestCase
   def test_parse_min_implicit_sides
     test_parse(
       "5DMIN",
-      "(Command (ImplicitSidesDiceRollWithFilter 5 :KL 1))"
+      "(Command (DiceRollWithFilter 5 nil :KL 1))"
     )
   end
 

--- a/test/test_add_dice_parser.rb
+++ b/test/test_add_dice_parser.rb
@@ -202,7 +202,7 @@ class AddDiceParserTest < Test::Unit::TestCase
   def test_parse_keep_high_implicit_sides
     test_parse(
       "5DKH3",
-      "(Command (DiceRollWithFilter 5 nil :KH 3))"
+      "(Command (DiceRollWithFilter 5 :implicit :KH 3))"
     )
   end
 
@@ -210,7 +210,7 @@ class AddDiceParserTest < Test::Unit::TestCase
   def test_parse_keep_highest_implicit_sides
     test_parse(
       "5DKH",
-      "(Command (DiceRollWithFilter 5 nil :KH 1))"
+      "(Command (DiceRollWithFilter 5 :implicit :KH 1))"
     )
   end
 
@@ -234,7 +234,7 @@ class AddDiceParserTest < Test::Unit::TestCase
   def test_parse_keep_low_implicit_sides
     test_parse(
       "5DKL3",
-      "(Command (DiceRollWithFilter 5 nil :KL 3))"
+      "(Command (DiceRollWithFilter 5 :implicit :KL 3))"
     )
   end
 
@@ -242,7 +242,7 @@ class AddDiceParserTest < Test::Unit::TestCase
   def test_parse_keep_lowest_implicit_sides
     test_parse(
       "5DKL",
-      "(Command (DiceRollWithFilter 5 nil :KL 1))"
+      "(Command (DiceRollWithFilter 5 :implicit :KL 1))"
     )
   end
 
@@ -266,7 +266,7 @@ class AddDiceParserTest < Test::Unit::TestCase
   def test_parse_drop_high_implicit_sides
     test_parse(
       "5DDH3",
-      "(Command (DiceRollWithFilter 5 nil :DH 3))"
+      "(Command (DiceRollWithFilter 5 :implicit :DH 3))"
     )
   end
 
@@ -274,7 +274,7 @@ class AddDiceParserTest < Test::Unit::TestCase
   def test_parse_drop_highest_implicit_sides
     test_parse(
       "5DDH",
-      "(Command (DiceRollWithFilter 5 nil :DH 1))"
+      "(Command (DiceRollWithFilter 5 :implicit :DH 1))"
     )
   end
 
@@ -298,7 +298,7 @@ class AddDiceParserTest < Test::Unit::TestCase
   def test_parse_drop_low_implicit_sides
     test_parse(
       "5DDL3",
-      "(Command (DiceRollWithFilter 5 nil :DL 3))"
+      "(Command (DiceRollWithFilter 5 :implicit :DL 3))"
     )
   end
 
@@ -306,7 +306,7 @@ class AddDiceParserTest < Test::Unit::TestCase
   def test_parse_drop_lowest_implicit_sides
     test_parse(
       "5DDL",
-      "(Command (DiceRollWithFilter 5 nil :DL 1))"
+      "(Command (DiceRollWithFilter 5 :implicit :DL 1))"
     )
   end
 
@@ -354,7 +354,7 @@ class AddDiceParserTest < Test::Unit::TestCase
   def test_parse_max_implicit_sides
     test_parse(
       "3DMAX",
-      "(Command (DiceRollWithFilter 3 nil :KH 1))"
+      "(Command (DiceRollWithFilter 3 :implicit :KH 1))"
     )
   end
 
@@ -385,7 +385,7 @@ class AddDiceParserTest < Test::Unit::TestCase
   def test_parse_min_implicit_sides
     test_parse(
       "5DMIN",
-      "(Command (DiceRollWithFilter 5 nil :KL 1))"
+      "(Command (DiceRollWithFilter 5 :implicit :KL 1))"
     )
   end
 

--- a/test/test_add_dice_parser.rb
+++ b/test/test_add_dice_parser.rb
@@ -190,11 +190,59 @@ class AddDiceParserTest < Test::Unit::TestCase
     )
   end
 
+  # 大きな出目から1個取る
+  def test_parse_keep_highest
+    test_parse(
+      "5D10KH",
+      "(Command (DiceRollWithFilter 5 10 :KH 1))"
+    )
+  end
+
+  # 大きな出目から複数個取る（面数省略）
+  def test_parse_keep_high_implicit_sides
+    test_parse(
+      "5DKH3",
+      "(Command (DiceRollWithFilter 5 nil :KH 3))"
+    )
+  end
+
+  # 大きな出目から1個取る（面数省略）
+  def test_parse_keep_highest_implicit_sides
+    test_parse(
+      "5DKH",
+      "(Command (DiceRollWithFilter 5 nil :KH 1))"
+    )
+  end
+
   # 小さな出目から複数個取る
   def test_parse_keep_low
     test_parse(
       "5D10KL3",
       "(Command (DiceRollWithFilter 5 10 :KL 3))"
+    )
+  end
+
+  # 小さな出目から1個取る
+  def test_parse_keep_lowest
+    test_parse(
+      "5D10KL",
+      "(Command (DiceRollWithFilter 5 10 :KL 1))"
+    )
+  end
+
+  # 小さな出目から複数個取る（面数省略）
+  def test_parse_keep_low_implicit_sides
+    test_parse(
+      "5DKL3",
+      "(Command (DiceRollWithFilter 5 nil :KL 3))"
+    )
+  end
+
+  # 小さな出目から1個取る（面数省略）
+  def test_parse_keep_lowest_implicit_sides
+    test_parse(
+      "5DKL",
+      "(Command (DiceRollWithFilter 5 nil :KL 1))"
     )
   end
 
@@ -206,11 +254,59 @@ class AddDiceParserTest < Test::Unit::TestCase
     )
   end
 
+  # 大きな出目から1個除く
+  def test_parse_drop_highest
+    test_parse(
+      "5D10DH",
+      "(Command (DiceRollWithFilter 5 10 :DH 1))"
+    )
+  end
+
+  # 大きな出目から複数個除く（面数省略）
+  def test_parse_drop_high_implicit_sides
+    test_parse(
+      "5DDH3",
+      "(Command (DiceRollWithFilter 5 nil :DH 3))"
+    )
+  end
+
+  # 大きな出目から1個除く（面数省略）
+  def test_parse_drop_highest_implicit_sides
+    test_parse(
+      "5DDH",
+      "(Command (DiceRollWithFilter 5 nil :DH 1))"
+    )
+  end
+
   # 小さな出目から複数個除く
   def test_parse_drop_low
     test_parse(
       "5D10DL3",
       "(Command (DiceRollWithFilter 5 10 :DL 3))"
+    )
+  end
+
+  # 小さな出目から1個除く
+  def test_parse_drop_lowest
+    test_parse(
+      "5D10DL",
+      "(Command (DiceRollWithFilter 5 10 :DL 1))"
+    )
+  end
+
+  # 小さな出目から複数個除く（面数省略）
+  def test_parse_drop_low_implicit_sides
+    test_parse(
+      "5DDL3",
+      "(Command (DiceRollWithFilter 5 nil :DL 3))"
+    )
+  end
+
+  # 小さな出目から1個除く（面数省略）
+  def test_parse_drop_lowest_implicit_sides
+    test_parse(
+      "5DDL",
+      "(Command (DiceRollWithFilter 5 nil :DL 1))"
     )
   end
 

--- a/test/test_add_dice_parser.rb
+++ b/test/test_add_dice_parser.rb
@@ -246,6 +246,38 @@ class AddDiceParserTest < Test::Unit::TestCase
     )
   end
 
+  # 最大値抽出（ KH1 の簡易記法）
+  def test_parse_max
+    test_parse(
+      "3D6MAX",
+      "(Command (DiceRollWithFilter 3 6 :KH 1))"
+    )
+  end
+
+  # 最大値抽出、修正値つき
+  def test_parse_max_with_modifier
+    test_parse(
+      "3D6MAX+2",
+      "(Command (+ (DiceRollWithFilter 3 6 :KH 1) 2))"
+    )
+  end
+
+  # 最小値抽出（ KL1 の簡易記法）
+  def test_parse_min
+    test_parse(
+      "5D10MIN",
+      "(Command (DiceRollWithFilter 5 10 :KL 1))"
+    )
+  end
+
+  # 最小値抽出、修正値つき
+  def test_parse_min_with_modifier
+    test_parse(
+      "5D10MIN-3",
+      "(Command (- (DiceRollWithFilter 5 10 :KL 1) 3))"
+    )
+  end
+
   def test_parse_filter_nested_dice
     assert_not_parse("(1D6)D6HK3", "ダイス数にダイスロールをネストできない")
     assert_not_parse("1D(1D6)HK3", "面数数にダイスロールをネストできない")


### PR DESCRIPTION
# 背景

https://github.com/bcdice/BCDice/pull/527#issuecomment-1017562913 より

> 別途 `nMAX` 相当の共通コマンドの提案

> 共通コマンドを作る場合、`xDyKH1` の別書式として `xDyMAX` とするのが良いと思います。

# 書式

`x` = ダイス数
`y` = ダイス面数

## 最大値

`xDyMAX` （ `xDyKH1` 互換）
`xDMAX` （面数省略）（ `xDKH` 互換）

## 最小値

`xDyMIN` （ `xDyKL1` 互換）
`xDMIN` （面数省略）（ `xDKL` 互換）

# 実装方針

add_dice を拡張して実現。

# 最小値抽出について

この提案をするにいたった背景においては最大値の抽出だけあれば済むのですが、「 max があるのに min がない」のは、汎用コマンドとして利用者の期待・直感に反すると考え、最小値の抽出も提供しています。

# 面数の省略について

より簡便に利用できるコマンドとしての追加であり、省略し得るものは省略できたほうがその目的に適うので、面数の省略をサポートしています。
（「特定の一種類の面数しか使わない」ゲームシステムは現在のところそれなりに多いはずであり、現実のユースケースにおいて省略の恩恵はあると思っています）

---

追記

# KH, KL, DH, DL 機能の強化

`xDy[KD][HL]n` 機能において、面数 y と個数 n を省略できるようにしました。

* 面数 y の省略時は `game_system.sides_implicit_d` 相当
* 個数 n の省略時は `1` 相当

で動作します。
