### PR TITLE
[SwordWorld] [BattleTech] Fix warnings

### DIFF
--- a/lib/bcdice/game_system/BattleTech.rb
+++ b/lib/bcdice/game_system/BattleTech.rb
@@ -46,7 +46,7 @@ module BCDice
 
       # @return [Command::Parser] PPCコマンドの構文解析器
       def self.ppc_parser
-        return @ppc_parser if @ppc_parser
+        return @ppc_parser if defined?(@ppc_parser) && @ppc_parser
 
         @ppc_parser = Command::Parser.new(/PPC(?:[LCR][LU]?)?/, round_type: RoundType::FLOOR)
         @ppc_parser.enable_prefix_number

--- a/lib/bcdice/game_system/sword_world/rating_options.rb
+++ b/lib/bcdice/game_system/sword_world/rating_options.rb
@@ -35,11 +35,11 @@ module BCDice
         attr_accessor :modifier_after_half
 
         def settable_first_roll_adjust_option?
-          return @first_modify.nil? && @first_to.nil?
+          return first_modify.nil? && first_to.nil?
         end
 
         def settable_non_2d_roll_option?
-          return @greatest_fortune.nil? && @semi_fixed_val.nil? && @tmp_fixed_val.nil?
+          return greatest_fortune.nil? && semi_fixed_val.nil? && tmp_fixed_val.nil?
         end
       end
     end


### PR DESCRIPTION
テスト実行時に warning が出力されるのを解消。

出力されていた warning ↓
```
lib/bcdice/game_system/BattleTech.rb:49: warning: instance variable @ppc_parser not initialized

lib/bcdice/game_system/sword_world/rating_options.rb:38: warning: instance variable @first_modify not initialized
lib/bcdice/game_system/sword_world/rating_options.rb:38: warning: instance variable @first_to not initialized

lib/bcdice/game_system/sword_world/rating_options.rb:42: warning: instance variable @greatest_fortune not initialized
lib/bcdice/game_system/sword_world/rating_options.rb:42: warning: instance variable @semi_fixed_val not initialized
lib/bcdice/game_system/sword_world/rating_options.rb:42: warning: instance variable @tmp_fixed_val not initialized
```