### PR TITLE
ダイス面数の上限を 10,000 に増加

### DIFF
--- a/lib/bcdice/randomizer.rb
+++ b/lib/bcdice/randomizer.rb
@@ -4,7 +4,7 @@ module BCDice
   # 乱数生成器
   class Randomizer
     UPPER_LIMIT_DICE_TIMES = 200
-    UPPER_LIMIT_DICE_SIDES = 1000
+    UPPER_LIMIT_DICE_SIDES = 10000
 
     UPPER_LIMIT_RANDS = 10000
 

--- a/test/data/randomizer.toml
+++ b/test/data/randomizer.toml
@@ -1,0 +1,13 @@
+[[ test ]]
+game_system = "DiceBot"
+input = "1D10000"
+output = "(1D10000) ＞ 9876"
+rands = [
+  { sides = 10000, value = 9876 },
+]
+
+[[ test ]]
+game_system = "DiceBot"
+input = "1D10001"
+output = "(1D10001) ＞ 0"
+rands = []

--- a/test/test_randomizer.rb
+++ b/test/test_randomizer.rb
@@ -10,12 +10,12 @@ class TestRandomizer < Test::Unit::TestCase
 
   # ダイス面数が上限ぎりぎり
   def test_upper_limit_sides
-    assert_not_equal(0, @randomizer.roll_once(1000))
+    assert_not_equal(0, @randomizer.roll_once(10000))
   end
 
   # ダイス面数が上限超え
   def test_over_upper_limit_sides
-    assert_equal(0, @randomizer.roll_once(1001))
+    assert_equal(0, @randomizer.roll_once(10001))
   end
 
   # ダイス個数が上限ぎりぎり


### PR DESCRIPTION
# 内容

ダイス面数の上限 `BCDice::Randomizer::UPPER_LIMIT_DICE_SIDES` を増加。

* 変更前： 1,000
* 変更後： 10,000

# 理由

1,000 より大きな面数のダイスロールをあつかうゲームに対応するため。

具体的な一例として、[『オバケ空間探索配信ＲＰＧ「実況ゴーストライヴ」』](https://booth.pm/ja/items/3810620)を想定しています。同ゲームでは 10,000 面のダイスロールが発生します。

# 備考

Discord 上で @ysakasin さんに実装方針を相談済みです。
