### PR TITLE
加算ダイスで `D20` 記法に対応

### DIFF
--- a/lib/bcdice/common_command/add_dice.rb
+++ b/lib/bcdice/common_command/add_dice.rb
@@ -7,7 +7,7 @@ require "bcdice/common_command/add_dice/randomizer"
 module BCDice
   module CommonCommand
     module AddDice
-      PREFIX_PATTERN = /[+\-(]*\d+/.freeze
+      PREFIX_PATTERN = /[+\-(]*(\d+|D\d+)/.freeze
 
       class << self
         def eval(command, game_system, randomizer)

--- a/lib/bcdice/common_command/add_dice/parser.y
+++ b/lib/bcdice/common_command/add_dice/parser.y
@@ -114,6 +114,40 @@ rule
 
         result = Node::DiceRollWithFilter.new(times, sides, n_filtering, filter)
       }
+      | D term
+      {
+        times = Node::Number.new(1)
+        sides = val[1]
+        raise ParseError if sides.include_dice?
+        raise ParseError if sides.instance_of?(Node::Number) && sides.literal == 66
+
+        result = Node::DiceRoll.new(times, sides)
+      }
+      | D term filter_type_with_shorthand
+      {
+        times = Node::Number.new(1)
+        sides = val[1]
+        filter = val[2]
+
+        raise ParseError if sides != :implicit && sides.include_dice?
+        raise ParseError if sides.instance_of?(Node::Number) && sides.literal == 66
+
+        n_filtering = Node::Number.new(1)
+        result = Node::DiceRollWithFilter.new(times, sides, n_filtering, filter)
+      }
+      | D term filter_type term
+      {
+        times = Node::Number.new(1)
+        sides = val[1]
+        filter = val[2]
+        n_filtering = val[3]
+
+        raise ParseError if sides != :implicit && sides.include_dice?
+        raise ParseError if n_filtering.include_dice?
+        raise ParseError if sides.instance_of?(Node::Number) && sides.literal == 66
+
+        result = Node::DiceRollWithFilter.new(times, sides, n_filtering, filter)
+      }
       | term
 
   explicit_or_implicit_sides: /* 指定なし => 暗黙の面数 */

--- a/lib/bcdice/common_command/add_dice/parser.y
+++ b/lib/bcdice/common_command/add_dice/parser.y
@@ -90,24 +90,12 @@ rule
 
         result = Node::ImplicitSidesDiceRoll.new(times)
       }
-      | term D explicit_or_implicit_sides filter_type_with_shorthand
+      | term D explicit_or_implicit_sides filter
       {
         times = val[0]
         sides = val[2]
-        filter = val[3]
-
-        raise ParseError if sides != :implicit && sides.include_dice?
-        raise ParseError if times.include_dice?
-
-        n_filtering = Node::Number.new(1)
-        result = Node::DiceRollWithFilter.new(times, sides, n_filtering, filter)
-      }
-      | term D explicit_or_implicit_sides filter_type term
-      {
-        times = val[0]
-        sides = val[2]
-        filter = val[3]
-        n_filtering = val[4]
+        filter = val[3][:filter]
+        n_filtering = val[3][:n_filtering]
 
         raise ParseError if sides != :implicit && sides.include_dice?
         raise ParseError if times.include_dice? || n_filtering.include_dice?
@@ -123,24 +111,12 @@ rule
 
         result = Node::DiceRoll.new(times, sides)
       }
-      | D term filter_type_with_shorthand
+      | D term filter
       {
         times = Node::Number.new(1)
         sides = val[1]
-        filter = val[2]
-
-        raise ParseError if sides != :implicit && sides.include_dice?
-        raise ParseError if sides.instance_of?(Node::Number) && sides.literal == 66
-
-        n_filtering = Node::Number.new(1)
-        result = Node::DiceRollWithFilter.new(times, sides, n_filtering, filter)
-      }
-      | D term filter_type term
-      {
-        times = Node::Number.new(1)
-        sides = val[1]
-        filter = val[2]
-        n_filtering = val[3]
+        filter = val[2][:filter]
+        n_filtering = val[2][:n_filtering]
 
         raise ParseError if sides != :implicit && sides.include_dice?
         raise ParseError if n_filtering.include_dice?
@@ -154,6 +130,12 @@ rule
                             { result = :implicit }
                             | term
                             { result = val[0] }
+
+
+  filter: filter_type term
+        { result = {filter: val[0], n_filtering: val[1]} }
+        | filter_type_with_shorthand
+        { result = {filter: val[0], n_filtering: Node::Number.new(1)} }
 
   filter_shorthand: M A X
                   { result = Node::DiceRollWithFilter::KEEP_HIGHEST }

--- a/test/data/AddDice.toml
+++ b/test/data/AddDice.toml
@@ -82,6 +82,16 @@ rands = [
   { sides = 6, value = 1 },
 ]
 
+[[ test ]]
+game_system = "DiceBot"
+input = "D20+3D4"
+output = "(1D20+3D4) ＞ 20[20]+6[1,2,3] ＞ 26"
+rands = [
+  { sides = 20, value = 20 },
+  { sides = 4, value = 1 },
+  { sides = 4, value = 2 },
+  { sides = 4, value = 3 },
+]
 
 [[ test ]]
 game_system = "DiceBot"

--- a/test/test_add_dice_parser.rb
+++ b/test/test_add_dice_parser.rb
@@ -34,9 +34,20 @@ class AddDiceParserTest < Test::Unit::TestCase
     test_parse("2D+3", "(Command (+ (ImplicitSidesDiceRoll 2) 3))")
   end
 
+  # ダイス数の省略
   def test_parse_implicit_times
     test_parse("D20", "(Command (DiceRoll 1 20))")
     test_parse("D20+3", "(Command (+ (DiceRoll 1 20) 3))")
+  end
+
+  def test_parse_d66
+    assert_not_parse("D66", "D66は処理しない")
+    assert_not_parse("1+D66", "D66は処理しない")
+  end
+
+  # 1D66は66面ダイス扱い
+  def test_parse_1d66
+    test_parse("1D66", "(Command (DiceRoll 1 66))")
   end
 
   # 最初の空白までがパース対象となる

--- a/test/test_add_dice_parser.rb
+++ b/test/test_add_dice_parser.rb
@@ -34,6 +34,11 @@ class AddDiceParserTest < Test::Unit::TestCase
     test_parse("2D+3", "(Command (+ (ImplicitSidesDiceRoll 2) 3))")
   end
 
+  def test_parse_implicit_times
+    test_parse("D20", "(Command (DiceRoll 1 20))")
+    test_parse("D20+3", "(Command (+ (DiceRoll 1 20) 3))")
+  end
+
   # 最初の空白までがパース対象となる
   def test_parse_only_first_word
     test_parse("2D6 +1", "(Command (DiceRoll 2 6))")

--- a/test/test_base.rb
+++ b/test/test_base.rb
@@ -9,7 +9,7 @@ end
 
 class TestBase < Test::Unit::TestCase
   def test_command_pattern
-    assert_equal(/^S?([+\-(]*\d+|\d+B\d+|\d+T[YZ]\d+|C[+\-(]*\d+|choice|D66|(repeat|rep|x)\d+|\d+R\d+|\d+U\d+|BCDiceVersion|ABC|XYZ|IP\d+)/i, DummySystem.command_pattern)
+    assert_equal(/^S?([+\-(]*(\d+|D\d+)|\d+B\d+|\d+T[YZ]\d+|C[+\-(]*\d+|choice|D66|(repeat|rep|x)\d+|\d+R\d+|\d+U\d+|BCDiceVersion|ABC|XYZ|IP\d+)/i, DummySystem.command_pattern)
 
     assert_match(DummySystem.command_pattern, "ABC+123")
     assert_match(DummySystem.command_pattern, "XYZ[hoge]")
@@ -18,6 +18,8 @@ class TestBase < Test::Unit::TestCase
     assert_not_match(DummySystem.command_pattern, "EFG")
 
     assert_match(DummySystem.command_pattern, "1D100<=70")
+    assert_match(DummySystem.command_pattern, "D6")
+    assert_match(DummySystem.command_pattern, "3D")
     assert_match(DummySystem.command_pattern, "4D6+2D8")
     assert_match(DummySystem.command_pattern, "4B6+2B8")
     assert_match(DummySystem.command_pattern, "5TY6")
@@ -33,7 +35,8 @@ class TestBase < Test::Unit::TestCase
     assert_not_match(DummySystem.command_pattern, "[1...3]D100<=70")
     assert_match(DummySystem.command_pattern, "-3+2D100<=70")
     assert_match(DummySystem.command_pattern, "+3+2D100<=70")
-    assert_not_match(DummySystem.command_pattern, "D6")
+    assert_not_match(DummySystem.command_pattern, "D")
+    assert_not_match(DummySystem.command_pattern, "D-6")
     assert_not_match(DummySystem.command_pattern, "+-")
     assert_match(DummySystem.command_pattern, "+(---(-3+1))D")
   end

--- a/test/test_sai_fic_skill_table.rb
+++ b/test/test_sai_fic_skill_table.rb
@@ -12,6 +12,6 @@ class TestSaiFicSkillTable < Test::Unit::TestCase
   end
 
   def test_command_pattern
-    assert_equal(/^S?([+\-(]*\d+|\d+B\d+|\d+T[YZ]\d+|C[+\-(]*\d+|choice|D66|(repeat|rep|x)\d+|\d+R\d+|\d+U\d+|BCDiceVersion|RTT[1-6]?|RCT)/i, DummySystem.command_pattern)
+    assert_equal(/^S?([+\-(]*(\d+|D\d+)|\d+B\d+|\d+T[YZ]\d+|C[+\-(]*\d+|choice|D66|(repeat|rep|x)\d+|\d+R\d+|\d+U\d+|BCDiceVersion|RTT[1-6]?|RCT)/i, DummySystem.command_pattern)
   end
 end


### PR DESCRIPTION
加算ダイスをダイス数を省略した `D20` のような記法に対応する。`D66`は既存のD66コマンドと競合するため、パースエラーにする。