### PR TITLE
成功数より1の数が多いときに大失敗になるバグ修正

### DIFF
--- a/lib/bcdice/game_system/WorldOfDarkness.rb
+++ b/lib/bcdice/game_system/WorldOfDarkness.rb
@@ -25,17 +25,9 @@ module BCDice
 
       register_prefix('\d+ST')
 
-      def initialize(command)
-        super(command)
-        @successDice = 0
-        @botchDice = 0
-        @rerollDice = 0
-      end
-
       def eval_game_system_specific_command(command)
-        diff = 6
+        difficulty = 6
         auto_success = 0
-
         enabled_reroll = false
         enabled_20th = false
 
@@ -48,40 +40,55 @@ module BCDice
         when 'STA'
           enabled_20th = true
         end
-        diff = md[3].to_i if md[3]
+        difficulty = md[3].to_i if md[3]
         auto_success = md[4].to_i if md[4]
 
-        diff = 6 if diff < 2
+        difficulty = 6 if difficulty < 2
 
         sequence = []
-        sequence.push "DicePool=#{dice_pool}, Difficulty=#{diff}, AutomaticSuccess=#{auto_success}"
+        sequence.push "DicePool=#{dice_pool}, Difficulty=#{difficulty}, AutomaticSuccess=#{auto_success}"
 
         # 出力では Difficulty=11..12 もあり得る
-        diff = 10 if diff > 10
+        difficulty = 10 if difficulty > 10
 
-        total_success = auto_success
+        total_success = 0
         total_botch = 0
+        once_success = false
 
-        dice, success, botch, auto_success = roll_wod(dice_pool, diff, true, enabled_20th ? 2 : 1)
+        dice, ten_success, success, botch = roll_wod(dice_pool, difficulty)
         sequence.push dice.join(',')
         total_success += success
         total_botch += botch
 
-        if enabled_reroll
-          # 振り足し
-          while auto_success > 0
-            dice_pool = auto_success
-            # 振り足しの出目1は大失敗ではない
-            dice, success, botch, auto_success = roll_wod(dice_pool, diff, false)
-            sequence.push dice.join(',')
-            total_success += success
-            total_botch += botch
+        # 成功がひとつでもあったか覚えておく
+        once_success = true if success > 0 || ten_success > 0
+
+        if enabled_20th
+          # 20周年記念版なら10の目は2成功扱い
+          total_success += ten_success * 2
+        else
+          # Revised Editionでは10は1成功と数える
+          total_success += ten_success
+
+          # 振り足し判定ありなら10が出ただけ振り足しを行う
+          if enabled_reroll
+            while ten_success > 0
+              # 振り足しの出目1は大失敗ではない
+              dice, ten_success, success = roll_wod(ten_success, difficulty)
+              sequence.push dice.join(',')
+              total_success += (success + ten_success)
+            end
           end
         end
 
+        total_success -= [total_success, total_botch].min
+
+        total_success += auto_success # 意志力による自動成功は打ち消されない
+
         if total_success > 0
           sequence.push "成功数#{total_success}"
-        elsif total_botch > 0
+        elsif total_botch > 0 && once_success == false
+          # ボッチが存在し、かつ成功がひとつもない場合のみ大失敗
           sequence.push "大失敗"
         else
           sequence.push "失敗"
@@ -91,10 +98,9 @@ module BCDice
         return output
       end
 
-      # Revised Edition
-      # 出目10は1自動成功 振り足し
-      # 出目1は大失敗: 成功を1つ相殺
-      def roll_wod(dice_pool, diff, enabled_botch = true, auto_success_value = 1)
+      # 出目10と1、難易度以上が出た成功の目をカウントする。
+      # それぞれの解釈はバージョンによって異なるため、呼び出し元で行う。
+      def roll_wod(dice_pool, difficulty)
         # FIXME: まとめて振る
         dice = Array.new(dice_pool) do
           dice_now = @randomizer.roll_once(10)
@@ -105,30 +111,20 @@ module BCDice
 
         success = 0
         botch = 0
-        auto_success = 0
+        ten_success = 0
 
         dice.each do |d|
           case d
           when 10
-            auto_success += auto_success_value
-          when diff..10
+            ten_success += 1
+          when difficulty...10
             success += 1
           when 1
-            botch += 1 if enabled_botch
+            botch += 1
           end
         end
 
-        # 自動成功を成功に加算する
-        success += auto_success
-
-        if enabled_botch
-          # 成功と大失敗を相殺する
-          c = [success, botch].min
-          success -= c
-          botch -= c
-        end
-
-        return dice, success, botch, auto_success
+        return dice, ten_success, success, botch
       end
     end
   end

--- a/test/data/WorldOfDarkness.toml
+++ b/test/data/WorldOfDarkness.toml
@@ -565,3 +565,166 @@ rands = [
   { sides = 10, value = 10 },
   { sides = 10, value = 1 },
 ]
+
+# ひとつでも成功の目が出たら1の目が成功より多くても大失敗ではなく失敗になるか確認
+[[ test ]]
+game_system = "WorldOfDarkness"
+input = "5ST"
+output = "DicePool=5, Difficulty=6, AutomaticSuccess=0 ＞ 1,1,1,6,6 ＞ 失敗"
+rands = [
+  { sides = 10, value = 1 },
+  { sides = 10, value = 1 },
+  { sides = 10, value = 1 },
+  { sides = 10, value = 6 },
+  { sides = 10, value = 6 },
+]
+
+[[ test ]]
+game_system = "WorldOfDarkness"
+input = "5STS"
+output = "DicePool=5, Difficulty=6, AutomaticSuccess=0 ＞ 1,1,1,10,10 ＞ 1,5 ＞ 失敗"
+rands = [
+  { sides = 10, value = 1 },
+  { sides = 10, value = 1 },
+  { sides = 10, value = 1 },
+  { sides = 10, value = 10 },
+  { sides = 10, value = 10 },
+  { sides = 10, value = 1 },
+  { sides = 10, value = 5 },
+]
+
+[[ test ]]
+game_system = "WorldOfDarkness"
+input = "5STA"
+output = "DicePool=5, Difficulty=6, AutomaticSuccess=0 ＞ 1,1,1,5,10 ＞ 失敗"
+rands = [
+   { sides = 10, value = 1  },
+   { sides = 10, value = 1  },
+   { sides = 10, value = 1  },
+   { sides = 10, value = 5  },
+   { sides = 10, value = 10 },
+]
+
+# リロール分の1が成功を打ち消してないか確認
+[[ test ]]
+game_system = "WorldOfDarkness"
+input = "5STS"
+output = "DicePool=5, Difficulty=6, AutomaticSuccess=0 ＞ 1,1,2,10,10 ＞ 1,6 ＞ 成功数1"
+rands = [
+  { sides = 10, value = 1 },
+  { sides = 10, value = 1 },
+  { sides = 10, value = 2 },
+  { sides = 10, value = 10 },
+  { sides = 10, value = 10 },
+  { sides = 10, value = 1 },
+  { sides = 10, value = 6 },
+]
+
+# 自動成功が打ち消されずに成功になるか確認
+[[ test ]]
+game_system = "WorldOfDarkness"
+input = "5ST+1"
+output = "DicePool=5, Difficulty=6, AutomaticSuccess=1 ＞ 1,1,1,5,5 ＞ 成功数1"
+rands = [
+  { sides = 10, value = 1 },
+  { sides = 10, value = 1 },
+  { sides = 10, value = 1 },
+  { sides = 10, value = 5 },
+  { sides = 10, value = 5 },
+]
+
+[[ test ]]
+game_system = "WorldOfDarkness"
+input = "5ST+1"
+output = "DicePool=5, Difficulty=6, AutomaticSuccess=1 ＞ 1,1,1,6,6 ＞ 成功数1"
+rands = [
+  { sides = 10, value = 1 },
+  { sides = 10, value = 1 },
+  { sides = 10, value = 1 },
+  { sides = 10, value = 6 },
+  { sides = 10, value = 6 },
+]
+
+[[ test ]]
+game_system = "WorldOfDarkness"
+input = "5ST+1"
+output = "DicePool=5, Difficulty=6, AutomaticSuccess=1 ＞ 1,1,6,6,6 ＞ 成功数2"
+rands = [
+  { sides = 10, value = 1 },
+  { sides = 10, value = 1 },
+  { sides = 10, value = 6 },
+  { sides = 10, value = 6 },
+  { sides = 10, value = 6 },
+]
+
+[[ test ]]
+game_system = "WorldOfDarkness"
+input = "5STS+1"
+output = "DicePool=5, Difficulty=6, AutomaticSuccess=1 ＞ 1,1,1,5,5 ＞ 成功数1"
+rands = [
+  { sides = 10, value = 1 },
+  { sides = 10, value = 1 },
+  { sides = 10, value = 1 },
+  { sides = 10, value = 5 },
+  { sides = 10, value = 5 },
+]
+
+[[ test ]]
+game_system = "WorldOfDarkness"
+input = "5STS+1"
+output = "DicePool=5, Difficulty=6, AutomaticSuccess=1 ＞ 1,1,1,6,6 ＞ 成功数1"
+rands = [
+  { sides = 10, value = 1 },
+  { sides = 10, value = 1 },
+  { sides = 10, value = 1 },
+  { sides = 10, value = 6 },
+  { sides = 10, value = 6 },
+]
+
+[[ test ]]
+game_system = "WorldOfDarkness"
+input = "5STS+1"
+output = "DicePool=5, Difficulty=6, AutomaticSuccess=1 ＞ 1,1,6,6,6 ＞ 成功数2"
+rands = [
+  { sides = 10, value = 1 },
+  { sides = 10, value = 1 },
+  { sides = 10, value = 6 },
+  { sides = 10, value = 6 },
+  { sides = 10, value = 6 },
+]
+
+[[ test ]]
+game_system = "WorldOfDarkness"
+input = "5STA+1"
+output = "DicePool=5, Difficulty=6, AutomaticSuccess=1 ＞ 1,1,1,6,6 ＞ 成功数1"
+rands = [
+  { sides = 10, value = 1 },
+  { sides = 10, value = 1 },
+  { sides = 10, value = 1 },
+  { sides = 10, value = 6 },
+  { sides = 10, value = 6 },
+]
+
+[[ test ]]
+game_system = "WorldOfDarkness"
+input = "5STA+1"
+output = "DicePool=5, Difficulty=6, AutomaticSuccess=1 ＞ 1,1,1,5,5 ＞ 成功数1"
+rands = [
+  { sides = 10, value = 1 },
+  { sides = 10, value = 1 },
+  { sides = 10, value = 1 },
+  { sides = 10, value = 5 },
+  { sides = 10, value = 5 },
+]
+
+[[ test ]]
+game_system = "WorldOfDarkness"
+input = "5STS+1"
+output = "DicePool=5, Difficulty=6, AutomaticSuccess=1 ＞ 1,1,6,6,6 ＞ 成功数2"
+rands = [
+  { sides = 10, value = 1 },
+  { sides = 10, value = 1 },
+  { sides = 10, value = 6 },
+  { sides = 10, value = 6 },
+  { sides = 10, value = 6 },
+]


### PR DESCRIPTION
**【バグ内容】**
本システム群はd10を使用するダイスプール判定であるが、

- 難易度以上の出目が出た数だけ成功
- 1の目の数だけ成功数を打ち消し
- 成功数が0か、1で打ち消されて0になった時は失敗
- ただし、成功数が0かつ1の目がひとつ以上出た時、大失敗

本来は上記ルールで判定されるはずが、「1の目の数＞成功数」であるとき常に大失敗となっていた。

**【修正内容】**
- ひとつでも成功しているのなら1で成功が全て打ち消されても大失敗にはならず通常の失敗になるように修正
- 上記修正のテストケース追加
