### PR TITLE
[GoblinSlayer] 判定に大成功と大失敗の閾値変更オプションを追加

### DIFF
--- a/test/data/GoblinSlayer.toml
+++ b/test/data/GoblinSlayer.toml
@@ -132,6 +132,105 @@ rands = [
 
 [[ test ]]
 game_system = "GoblinSlayer"
+input = "GS@10"
+output = "(GS@10) ＞ 10[5,5] ＞ 10 ＞ 大成功"
+rands = [
+  { sides = 6, value = 5 },
+  { sides = 6, value = 5 },
+]
+
+[[ test ]]
+game_system = "GoblinSlayer"
+input = "GS@10>=9"
+output = "(GS@10>=9) ＞ 10[5,5] ＞ 10 ＞ 大成功"
+rands = [
+  { sides = 6, value = 5 },
+  { sides = 6, value = 5 },
+]
+
+[[ test ]]
+game_system = "GoblinSlayer"
+input = "GS@10"
+output = "(GS@10) ＞ 9[4,5] ＞ 9"
+rands = [
+  { sides = 6, value = 4 },
+  { sides = 6, value = 5 },
+]
+
+[[ test ]]
+game_system = "GoblinSlayer"
+input = "GS@10>=9"
+output = "(GS@10>=9) ＞ 9[4,5] ＞ 9 ＞ 成功"
+rands = [
+  { sides = 6, value = 4 },
+  { sides = 6, value = 5 },
+]
+
+[[ test ]]
+game_system = "GoblinSlayer"
+input = "GS+1@10"
+output = "(GS+1@10) ＞ 1 + 9[4,5] ＞ 10"
+rands = [
+  { sides = 6, value = 4 },
+  { sides = 6, value = 5 },
+]
+
+[[ test ]]
+game_system = "GoblinSlayer"
+input = "GS#3"
+output = "(GS#3) ＞ 3[1,2] ＞ 3 ＞ 大失敗"
+rands = [
+  { sides = 6, value = 1 },
+  { sides = 6, value = 2 },
+]
+
+[[ test ]]
+game_system = "GoblinSlayer"
+input = "GS#3"
+output = "(GS#3) ＞ 4[2,2] ＞ 4"
+rands = [
+  { sides = 6, value = 2 },
+  { sides = 6, value = 2 },
+]
+
+[[ test ]]
+game_system = "GoblinSlayer"
+input = "GS1#3"
+output = "(GS1#3) ＞ 1 + 3[1,2] ＞ 4 ＞ 大失敗"
+rands = [
+  { sides = 6, value = 1 },
+  { sides = 6, value = 2 },
+]
+
+[[ test ]]
+game_system = "GoblinSlayer"
+input = "GS@9#4"
+output = "(GS@9#4) ＞ 9[4,5] ＞ 9 ＞ 大成功"
+rands = [
+  { sides = 6, value = 4 },
+  { sides = 6, value = 5 },
+]
+
+[[ test ]]
+game_system = "GoblinSlayer"
+input = "GS@9#4"
+output = "(GS@9#4) ＞ 4[2,2] ＞ 4 ＞ 大失敗"
+rands = [
+  { sides = 6, value = 2 },
+  { sides = 6, value = 2 },
+]
+
+[[ test ]]
+game_system = "GoblinSlayer"
+input = "GS#4@9"
+output = "(GS#4@9) ＞ 4[2,2] ＞ 4 ＞ 大失敗"
+rands = [
+  { sides = 6, value = 2 },
+  { sides = 6, value = 2 },
+]
+
+[[ test ]]
+game_system = "GoblinSlayer"
 input = "GS>5"
 output = "(GS>5) ＞ 5[2,3] ＞ 5 ＞ 失敗"
 rands = [


### PR DESCRIPTION
判定コマンド `GS` に大成功と大失敗の閾値を変更するオプションを追加する。

```
GSx@c#f>=y
```

`@c` で大成功を、 `#f` で大失敗を指定する。未指定の場合にはこれまでと同じでc=12、f=2として扱われる。cとfは順不同で指定可能とした。

`c<=f`となった場合の動作は未定義とするが、現時点では大失敗となる。


Ref. #557