### PR TITLE
[WorldOfDarkness] 振り足しの1で成功数の打ち消しが発生するコマンドを追加

### DIFF
--- a/test/data/WorldOfDarkness.toml
+++ b/test/data/WorldOfDarkness.toml
@@ -728,3 +728,76 @@ rands = [
   { sides = 10, value = 6 },
   { sides = 10, value = 6 },
 ]
+
+# リロール分でボッチが発生するコマンドのテスト
+[[ test ]]
+game_system = "WorldOfDarkness"
+input = "1STB テキスト"
+output = "DicePool=1, Difficulty=6, AutomaticSuccess=0 ＞ 1 ＞ 大失敗"
+rands = [
+  { sides = 10, value = 1 },
+]
+
+[[ test ]]
+game_system = "WorldOfDarkness"
+input = "1STB"
+output = "DicePool=1, Difficulty=6, AutomaticSuccess=0 ＞ 6 ＞ 成功数1"
+rands = [
+  { sides = 10, value = 6 },
+]
+
+[[ test ]]
+game_system = "WorldOfDarkness"
+input = "5STB"
+output = "DicePool=5, Difficulty=6, AutomaticSuccess=0 ＞ 1,5,6,10,10 ＞ 1,7 ＞ 成功数2"
+rands = [
+  { sides = 10, value = 10 },
+  { sides = 10, value = 1 },
+  { sides = 10, value = 6 },
+  { sides = 10, value = 5 },
+  { sides = 10, value = 10 },
+  { sides = 10, value = 1 },
+  { sides = 10, value = 7 },
+]
+
+[[ test ]]
+game_system = "WorldOfDarkness"
+input = "5STB7"
+output = "DicePool=5, Difficulty=7, AutomaticSuccess=0 ＞ 1,1,1,6,10 ＞ 1 ＞ 失敗"
+rands = [
+  { sides = 10, value = 1 },
+  { sides = 10, value = 1 },
+  { sides = 10, value = 1 },
+  { sides = 10, value = 6 },
+  { sides = 10, value = 10 },
+  { sides = 10, value = 1 },
+]
+
+[[ test ]]
+game_system = "WorldOfDarkness"
+input = "5STB7+1"
+output = "DicePool=5, Difficulty=7, AutomaticSuccess=1 ＞ 1,1,1,6,10 ＞ 1 ＞ 成功数1"
+rands = [
+  { sides = 10, value = 1 },
+  { sides = 10, value = 1 },
+  { sides = 10, value = 1 },
+  { sides = 10, value = 6 },
+  { sides = 10, value = 10 },
+  { sides = 10, value = 1 },
+]
+
+
+# リロール分の1で大失敗が起きないか確認
+[[ test ]]
+game_system = "WorldOfDarkness"
+input = "5STB"
+output = "DicePool=5, Difficulty=6, AutomaticSuccess=0 ＞ 1,1,1,6,10 ＞ 1 ＞ 失敗"
+rands = [
+  { sides = 10, value = 1 },
+  { sides = 10, value = 1 },
+  { sides = 10, value = 1 },
+  { sides = 10, value = 6 },
+  { sides = 10, value = 10 },
+  { sides = 10, value = 1 },
+]
+


### PR DESCRIPTION
**【追加機能の背景】**
World of Darknessのシステムでは、下記に例示するように10の目が出た時の振り足しにおいてシステム毎に1の扱いが違う。

- 日本語版ヴァンパイア：ザ マスカレード → 振り足しの1に明示的な記載なし
- 日本語版ワーウフル：ジ アポカリプス → 振り足しで1が出ても打ち消さない
- 日本語版メイジ：ジ アセンション → 振り足しで1が出た時に打ち消しが発生

にもかかわらず、振り足しが発生するコマンドSTSでは1が出ても打ち消されないパターンしか対応できていなかった。

**【追加機能】**
上記の背景を踏まえ、振り足しで1が出た時に成功数との打ち消しが発生するSTBというコマンドを実装した。
また、既存のコマンドであるSTSのヘルプを変更。振り足しにおいて1での打ち消しが発生しないことを明示した。