### PR TITLE
カバレッジ計測に codecov/codecov-action@v3 を使う

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,11 @@ jobs:
       with:
         ruby-version: ${{ matrix.ruby }}
         bundler-cache: true
-    - name: "Set CHECK_COVERAGE=true on Ruby 2.7"
-      run: echo "CHECK_COVERAGE=true" >> $GITHUB_ENV
-      if: matrix.ruby == '2.7'
     - run: bundle exec rake test
+      env:
+        ENABLE_COBERTURA: true
+    - name: Upload to Codecov
+      uses: codecov/codecov-action@v3
+      with:
+        file: coverage/coverage.xml
+      if: matrix.ruby == '3.1'

--- a/Gemfile
+++ b/Gemfile
@@ -3,11 +3,11 @@ source "https://rubygems.org"
 gemspec
 
 group :development, :test do
-  gem "codecov", "~> 0.4.2"
   gem "racc", "~> 1.5.1"
   gem "rake", "~> 13.0.3"
   gem "rubocop", "~> 1.7.0", require: false
   gem "simplecov", "~>0.21.2", require: false
+  gem "simplecov-cobertura", "~> 2.1.0", require: false
   gem "test-unit", "~>3.3.7", require: false
   gem "tomlrb", "~>2.0.3"
   gem "yard"

--- a/test/setup.rb
+++ b/test/setup.rb
@@ -2,9 +2,9 @@
 
 require "simplecov"
 
-if ENV["CI"] == "true" && ENV["CHECK_COVERAGE"] == "true"
-  require "codecov"
-  SimpleCov.formatter = SimpleCov::Formatter::Codecov
+if ENV["CI"] == "true" && ENV["ENABLE_COBERTURA"] == "true"
+  require "simplecov-cobertura"
+  SimpleCov.formatter = SimpleCov::Formatter::CoberturaFormatter
 end
 
 SimpleCov.at_exit do


### PR DESCRIPTION
RubyGemsの codecov が非推奨になったため、新しいアップローダーに入れ替える。

Ref. #575 