### PR TITLE
[VampireTheMasquerade5th] 難易度省略時に判定結果のヒント出力を追加

### DIFF
--- a/lib/bcdice/game_system/VampireTheMasquerade5th.rb
+++ b/lib/bcdice/game_system/VampireTheMasquerade5th.rb
@@ -17,17 +17,18 @@ module BCDice
         ・判定コマンド(nVMFx+x)
           注意：難易度は必要成功数を表す
 
-          難易度指定：判定成功と失敗、Critical判定、
+          難易度指定：成功数のカウント、判定成功と失敗、Critical処理、Critical Winのチェックを行う
                      （Hungerダイスがある場合）Messy CriticalとBestial Failureチェックを行う
           例) (難易度)VMF(ダイスプール)+(Hungerダイス)
               (難易度)VMF(ダイスプール)
 
-          難易度省略：判定失敗、Critical、（Hungerダイスがある場合）Bestial Failureチェックを行う
+          難易度省略：成功数のカウント、判定失敗、Critical処理、（Hungerダイスがある場合）Bestial Failureチェックを行う
                       判定成功、Messy Criticalのチェックを行わない
+                      Critical Win、（Hungerダイスがある場合）Bestial Failure、Messy Criticalのヒントを出力
           例) VMF(ダイスプール)+(Hungerダイス)
               VMF(ダイスプール)
 
-          難易度0指定：全てのチェックを行わない
+          難易度0指定：Critical処理と成功数のカウントを行い、全てのチェックを行わない
           例) 0VMF(ダイスプール)+(Hungerダイス)
               0VMF(ダイスプール)
 
@@ -78,13 +79,12 @@ module BCDice
 
       def get_roll_result(result_text, success_dice, ten_dice, hunger_ten_dice, hunger_botch_dice, difficulty)
         result_text = "#{result_text} 成功数=#{success_dice}"
+        is_critical = ten_dice >= 2
 
         if difficulty > 0
           result_text = "#{result_text} 難易度=#{difficulty}"
 
           if success_dice >= difficulty
-            is_critical = ten_dice >= 2
-
             if hunger_ten_dice > 0 && is_critical
               return Result.critical("#{result_text}：判定成功! [Messy Critical]")
             elsif is_critical
@@ -106,6 +106,16 @@ module BCDice
             end
 
             return Result.failure("#{result_text}：判定失敗!")
+          else
+            if hunger_botch_dice > 0
+              result_text = "#{result_text}\n　判定失敗なら [Bestial Failure]"
+            end
+            if hunger_ten_dice > 0 && is_critical
+              result_text = "#{result_text}\n　判定成功なら [Messy Critical]"
+            elsif is_critical
+              result_text = "#{result_text}\n　判定成功なら [Critical Win]"
+            end
+            return result_text.to_s
           end
         end
 

--- a/test/data/VampireTheMasquerade5th.toml
+++ b/test/data/VampireTheMasquerade5th.toml
@@ -177,11 +177,23 @@ rands = [
 [[ test ]]
 game_system = "VampireTheMasquerade5th"
 input = "VMF3"
-output = "(3D10) ＞ [10,10,4]  成功数=4"
+output = "(3D10) ＞ [10,10,4]  成功数=4\n　判定成功なら [Critical Win]"
 rands = [
   { sides = 10, value = 10 },
   { sides = 10, value = 10 },
   { sides = 10, value = 4 },
+]
+
+[[ test ]]
+game_system = "VampireTheMasquerade5th"
+input = "VMF3+2"
+output = "(3D10+2D10) ＞ [2,5,1]+[6,3]  成功数=1"
+rands = [
+  { sides = 10, value = 2 },
+  { sides = 10, value = 5 },
+  { sides = 10, value = 1 },
+  { sides = 10, value = 6 },
+  { sides = 10, value = 3 },
 ]
 
 [[ test ]]
@@ -214,7 +226,7 @@ rands = [
 [[ test ]]
 game_system = "VampireTheMasquerade5th"
 input = "VMF3+2"
-output = "(3D10+2D10) ＞ [2,5,8]+[1,6]  成功数=2"
+output = "(3D10+2D10) ＞ [2,5,8]+[1,6]  成功数=2\n　判定失敗なら [Bestial Failure]"
 rands = [
   { sides = 10, value = 2 },
   { sides = 10, value = 5 },
@@ -226,7 +238,19 @@ rands = [
 [[ test ]]
 game_system = "VampireTheMasquerade5th"
 input = "VMF3+2"
-output = "(3D10+2D10) ＞ [2,10,10]+[1,6]  成功数=5"
+output = "(3D10+2D10) ＞ [2,5,8]+[10,10]  成功数=5\n　判定成功なら [Messy Critical]"
+rands = [
+  { sides = 10, value = 2 },
+  { sides = 10, value = 5 },
+  { sides = 10, value = 8 },
+  { sides = 10, value = 10 },
+  { sides = 10, value = 10 },
+]
+
+[[ test ]]
+game_system = "VampireTheMasquerade5th"
+input = "VMF3+2"
+output = "(3D10+2D10) ＞ [2,10,10]+[1,6]  成功数=5\n　判定失敗なら [Bestial Failure]\n　判定成功なら [Critical Win]"
 rands = [
   { sides = 10, value = 2 },
   { sides = 10, value = 10 },
@@ -238,7 +262,7 @@ rands = [
 [[ test ]]
 game_system = "VampireTheMasquerade5th"
 input = "VMF3+2"
-output = "(3D10+2D10) ＞ [2,10,10]+[10,1]  成功数=5"
+output = "(3D10+2D10) ＞ [2,10,10]+[10,1]  成功数=5\n　判定失敗なら [Bestial Failure]\n　判定成功なら [Messy Critical]"
 rands = [
   { sides = 10, value = 2 },
   { sides = 10, value = 10 },
@@ -512,7 +536,7 @@ rands = [
 [[ test ]]
 game_system = "VampireTheMasquerade5th"
 input = "SVMF3"
-output = "(3D10) ＞ [10,10,4]  成功数=4"
+output = "(3D10) ＞ [10,10,4]  成功数=4\n　判定成功なら [Critical Win]"
 secret = true
 rands = [
   { sides = 10, value = 10 },
@@ -537,6 +561,19 @@ rands = [
 [[ test ]]
 game_system = "VampireTheMasquerade5th"
 input = "SVMF3+2"
+output = "(3D10+2D10) ＞ [2,5,1]+[6,3]  成功数=1"
+secret = true
+rands = [
+  { sides = 10, value = 2 },
+  { sides = 10, value = 5 },
+  { sides = 10, value = 1 },
+  { sides = 10, value = 6 },
+  { sides = 10, value = 3 },
+]
+
+[[ test ]]
+game_system = "VampireTheMasquerade5th"
+input = "SVMF3+2"
 output = "(3D10+2D10) ＞ [2,5,1]+[4,1]  成功数=0：判定失敗! [Bestial Failure]"
 failure = true
 fumble = true
@@ -552,7 +589,7 @@ rands = [
 [[ test ]]
 game_system = "VampireTheMasquerade5th"
 input = "SVMF3+2"
-output = "(3D10+2D10) ＞ [2,5,8]+[1,6]  成功数=2"
+output = "(3D10+2D10) ＞ [2,5,8]+[1,6]  成功数=2\n　判定失敗なら [Bestial Failure]"
 secret = true
 rands = [
   { sides = 10, value = 2 },
@@ -565,7 +602,20 @@ rands = [
 [[ test ]]
 game_system = "VampireTheMasquerade5th"
 input = "SVMF3+2"
-output = "(3D10+2D10) ＞ [2,10,10]+[1,6]  成功数=5"
+output = "(3D10+2D10) ＞ [2,5,8]+[10,10]  成功数=5\n　判定成功なら [Messy Critical]"
+secret = true
+rands = [
+  { sides = 10, value = 2 },
+  { sides = 10, value = 5 },
+  { sides = 10, value = 8 },
+  { sides = 10, value = 10 },
+  { sides = 10, value = 10 },
+]
+
+[[ test ]]
+game_system = "VampireTheMasquerade5th"
+input = "SVMF3+2"
+output = "(3D10+2D10) ＞ [2,10,10]+[1,6]  成功数=5\n　判定失敗なら [Bestial Failure]\n　判定成功なら [Critical Win]"
 secret = true
 rands = [
   { sides = 10, value = 2 },
@@ -578,7 +628,7 @@ rands = [
 [[ test ]]
 game_system = "VampireTheMasquerade5th"
 input = "SVMF3+2"
-output = "(3D10+2D10) ＞ [2,10,10]+[10,1]  成功数=5"
+output = "(3D10+2D10) ＞ [2,10,10]+[10,1]  成功数=5\n　判定失敗なら [Bestial Failure]\n　判定成功なら [Messy Critical]"
 secret = true
 rands = [
   { sides = 10, value = 2 },


### PR DESCRIPTION
**【機能追加の背景】**
　コマンドで難易度が省略された際はCritical Win、Messy Criticalは決定できず、Bestial Failureは１つも成功がない場合にのみ判定できるため、「1つも成功が無い場合のBestial Failure」以外は判定結果として表示していなかった。
　この処理自体は間違いではないが、実運用では何のメッセージも出力されないためCritical WinとMessy Critical、Bestial Failureの発生が判定し辛く、見逃されやすい状態であった。特にMessy Critical、Bestial Failureは判定結果として重要であるため、見落とされやすい表示は不適切である。

**【機能追加の内容】**
上記背景を踏まえ、以下の修正を行った。
- 難易度省略時、Critical Win、Messy CriticalとBestial Failureの可能性があるときにそれを示唆するメッセージを表示
- 今回機能追加に合わせてテストケースの修正と追加
- 今回の修正の対応としてヘルプを修正
- それに伴い、Critical（10,10のペアで成功数増加）とCritical Win(Criticalを含む判定が成功した)の区別がわかりにくかったので、分かり易くヘルプ修正