### PR TITLE
失敗時のSL0表示を+0から-0に修正

### DIFF
--- a/lib/bcdice/game_system/Warhammer4.rb
+++ b/lib/bcdice/game_system/Warhammer4.rb
@@ -72,6 +72,10 @@ module BCDice
           end
 
         sl_text = format("(SL%+d)", sl)
+        if (sl == 0) && (total > target)
+          sl_text = "(SL-0)"
+        end
+
         result.text += "#{sl_text} ＞ #{result_detail(sl, total, target)}"
 
         return result

--- a/test/data/Warhammer4.toml
+++ b/test/data/Warhammer4.toml
@@ -64,7 +64,7 @@ rands = [
 [[ test ]]
 game_system = "Warhammer4"
 input = "1D100<=10"
-output = "(1D100<=10) ＞ 19 ＞ 失敗(SL+0) ＞ 小失敗"
+output = "(1D100<=10) ＞ 19 ＞ 失敗(SL-0) ＞ 小失敗"
 failure = true
 rands = [
   { sides = 100, value = 19 }


### PR DESCRIPTION
WHコマンドの成功度判定について、失敗時にSLが0だったときルール上は「-0」表記しなくてはいけないが「+0」表記になっていた不具合の修正。

bundle exec rake test:dicebots target=Warhammer4　実行済み。