### PR TITLE
[VampireTheMasquerade5th] Hungerダイスの取り扱いをヘルプに追加

### DIFF
--- a/lib/bcdice/game_system/VampireTheMasquerade5th.rb
+++ b/lib/bcdice/game_system/VampireTheMasquerade5th.rb
@@ -15,22 +15,24 @@ module BCDice
       # ダイスボットの使い方
       HELP_MESSAGE = <<~MESSAGETEXT
         ・判定コマンド(nVMFx+x)
-          注意：難易度は必要成功数を表す
+          注意：Hungerダイスは内数として処理する。
+                例：9ダイスプールでHungerダイス3個ならば、通常ダイス6個、Hungerダイス3個となる。
+                また、難易度は必要成功数を表す。
 
           難易度指定：成功数のカウント、判定成功と失敗、Critical処理、Critical Winのチェックを行う
                      （Hungerダイスがある場合）Messy CriticalとBestial Failureチェックを行う
-          例) (難易度)VMF(ダイスプール)+(Hungerダイス)
-              (難易度)VMF(ダイスプール)
+          例) (難易度)VMF(通常ダイス)+(Hungerダイス)
+              (難易度)VMF(通常ダイス)
 
           難易度省略：成功数のカウント、判定失敗、Critical処理、（Hungerダイスがある場合）Bestial Failureチェックを行う
                       判定成功、Messy Criticalのチェックを行わない
                       Critical Win、（Hungerダイスがある場合）Bestial Failure、Messy Criticalのヒントを出力
-          例) VMF(ダイスプール)+(Hungerダイス)
-              VMF(ダイスプール)
+          例) VMF(通常ダイス)+(Hungerダイス)
+              VMF(通常ダイス)
 
           難易度0指定：Critical処理と成功数のカウントを行い、全てのチェックを行わない
-          例) 0VMF(ダイスプール)+(Hungerダイス)
-              0VMF(ダイスプール)
+          例) 0VMF(通常ダイス)+(Hungerダイス)
+              0VMF(通常ダイス)
 
       MESSAGETEXT
 


### PR DESCRIPTION
**【修正の背景】**
このシステムではHungerダイスは追加ダイスとしてではなく、通常のダイスプールの内数として処理される。つまり、ダイスプール９個の技能等を使う時、Hungerダイス３個だった場合、通常ダイス６個Hungerダイス3個で合計９個のダイスプールになるように調整する。
しかし、今までのヘルプでは追加ダイスとして処理するように読み取れてしまう懸念があった。

**【変更の内容】**
ヘルプに以下の内容を追記/修正を行うことでユーザがコマンド仕様を把握しやすくした。

- Hungerダイスが内数であることを明記。
- Hungerダイスがあった場合、ダイスプールの内数として処理することを例示。
- ダイスプールという記述を通常ダイスとし、Hunterダイスとの対比を明確化。