### PR TITLE
[VampireTheMasquerade5th] コマンドの正規表現が完全一致ではないバグを修正

### DIFF
--- a/lib/bcdice/game_system/VampireTheMasquerade5th.rb
+++ b/lib/bcdice/game_system/VampireTheMasquerade5th.rb
@@ -47,7 +47,7 @@ module BCDice
       register_prefix('\d*VMF')
 
       def eval_game_system_specific_command(command)
-        m = /\A(\d+)?(VMF)(\d+)(\+(\d+))?/.match(command)
+        m = /\A(\d+)?(VMF)(\d+)(\+(\d+))?$/.match(command)
         unless m
           return ''
         end


### PR DESCRIPTION
【修正の背景】
　Hunter:the Reckoning5thダイスボットにて[コマンドの正規表現が完全一致ではない旨指摘](https://github.com/bcdice/BCDice/pull/589#discussion_r1038666221)され、同じ正規表現を使用しているVampire:the Masquerade5thダイスボットに対しても修正を行うこととした。

【修正の内容】
以前の正規表現を、
> m = /\A(\d+)?(HRF)(\d+)(\+(\d+))?/.match(command)

以下のように修正した。

> m = /\A(\d+)?(HRF)(\d+)(\+(\d+))?$/.match(command)