### PR TITLE
Base:prefixesの破壊的concatを回避

### DIFF
--- a/lib/bcdice/base.rb
+++ b/lib/bcdice/base.rb
@@ -20,8 +20,7 @@ module BCDice
       # 応答するコマンドのprefixを登録する
       # @param prefixes [Array<String>]
       def register_prefix(*prefixes)
-        @prefixes ||= []
-        @prefixes.concat(prefixes.flatten)
+        @prefixes = (@prefixes || []) + prefixes.flatten
       end
 
       def register_prefix_from_super_class


### PR DESCRIPTION
`freeze` された `prefixes` で `concat` が呼び出されることで例外が発生するケースがありました。他のGameSystemを継承したGameSystemなどで発生するようです。

該当部分を非破壊的に結合するように変更しました。