### PR TITLE
[AssaultEngine]Discordで報告されていたバグの修正

### DIFF
--- a/lib/bcdice/game_system/AssaultEngine.rb
+++ b/lib/bcdice/game_system/AssaultEngine.rb
@@ -44,7 +44,7 @@ module BCDice
           r1 = judge(target, total)
           r2 = judge(target, swap)
           text = "(AES#{format00(target)}) ＞ #{r1.text} / スワップ#{r2.text}"
-          check_result(r1, r2, text)
+          return_result(r1, r2, text)
         elsif cmd.prefix_number.nil? # 初回ロール
           total = @randomizer.roll_once(100) % 100 # 0-99
           judge(target, total).tap do |r|
@@ -57,7 +57,7 @@ module BCDice
           new2 = judge(target, now % 10 + die * 10)      # 10の位を振り直す
 
           text = "(#{format00(now)}AE#{format00(target)}) ＞ #{die} ＞ #{new1.text} / #{new2.text}"
-          check_result(new1, new2, text)
+          return_result(new1, new2, text)
         end
       end
 
@@ -65,7 +65,7 @@ module BCDice
         format("%02d", dice)
       end
 
-      def check_result(result1, result2, text)
+      def return_result(result1, result2, text)
         if result1.critical? || result2.critical?
           Result.critical(text)
         elsif result1.success? || result2.success?

--- a/test/data/AssaultEngine.toml
+++ b/test/data/AssaultEngine.toml
@@ -118,3 +118,17 @@ output = "(90AE44) ＞ 0 ＞ (90)失敗 / (00)クリティカル"
 success = true
 critical = true
 rands = [ { sides = 10, value = 10 } ]
+
+[[ test ]]
+game_system = "AssaultEngine"
+input = "1D100<=39"
+output = "(1D100<=39) ＞ 20 ＞ 成功"
+success = true
+rands = [ { sides = 100, value = 20 } ]
+
+[[ test ]]
+game_system = "AssaultEngine"
+input = "1D100<=39"
+output = "(1D100<=39) ＞ 52 ＞ 失敗"
+failure = true
+rands = [ { sides = 100, value = 52 } ]


### PR DESCRIPTION
### 事象
Discordサーバー、bcdice-helpにて、アサルトエンジンのダイスボットで成否判定を伴う加算ダイスが振られないというバグが報告された。
### 原因
継承元の`check_result`がオーバーライドされていたことが原因とみられる。
### 対応
`check_result`として使われていたメソッドの名称を`return_result`に変更した。
### 結果
テストとreplで動作を確認。