### PR TITLE
[MonotoneMuseum]>=?判定を修正

### DIFF
--- a/lib/bcdice/game_system/MonotoneMuseum.rb
+++ b/lib/bcdice/game_system/MonotoneMuseum.rb
@@ -59,7 +59,7 @@ module BCDice
       private
 
       def check_roll(command)
-        m = /^(\d+)D6([+\-\d]*)>=(\d+)(\[(\d+)?(,(\d+))?\])?$/i.match(command)
+        m = /^(\d+)D6([+\-\d]*)>=(\?|\d+)(\[(\d+)?(,(\d+))?\])?$/i.match(command)
         unless m
           return nil
         end
@@ -80,6 +80,8 @@ module BCDice
             Result.fumble(translate("MonotoneMuseum.automatic_failure"))
           elsif dice_value >= critical
             Result.critical(translate("MonotoneMuseum.automatic_success"))
+          elsif target == 0
+            Result.success('')
           elsif total >= target
             Result.success(translate("success"))
           else
@@ -93,7 +95,7 @@ module BCDice
           result.text,
         ]
 
-        result.text = sequence.join(" ＞ ")
+        result.text = sequence.join(" ＞ ").chomp(" ＞ ")
 
         result
       end

--- a/test/data/MonotoneMuseum.toml
+++ b/test/data/MonotoneMuseum.toml
@@ -140,6 +140,146 @@ rands = [
 
 [[ test ]]
 game_system = "MonotoneMuseum"
+input = "2D6>=?"
+output = "(2D6>=?) ＞ 7[2,5] ＞ 7"
+success = true
+rands = [
+  { sides = 6, value = 5 },
+  { sides = 6, value = 2 },
+]
+
+[[ test ]]
+game_system = "MonotoneMuseum"
+input = "2D6+1>=0"
+output = "(2D6+1>=0) ＞ 5[1,4]+1 ＞ 6"
+success = true
+rands = [
+  { sides = 6, value = 4 },
+  { sides = 6, value = 1 },
+]
+
+[[ test ]]
+game_system = "MonotoneMuseum"
+input = "2D6>=?"
+output = "(2D6>=?) ＞ 12[6,6] ＞ 12 ＞ 自動成功"
+success = true
+critical = true
+rands = [
+  { sides = 6, value = 6 },
+  { sides = 6, value = 6 },
+]
+
+[[ test ]]
+game_system = "MonotoneMuseum"
+input = "2D6>=?"
+output = "(2D6>=?) ＞ 2[1,1] ＞ 2 ＞ 自動失敗"
+failure = true
+fumble = true
+rands = [
+  { sides = 6, value = 1 },
+  { sides = 6, value = 1 },
+]
+
+[[ test ]]
+game_system = "MonotoneMuseum"
+input = "2D6+1>=?[11,3]"
+output = "(2D6+1>=?[11,3]) ＞ 6[2,4]+1 ＞ 7"
+success = true
+rands = [
+  { sides = 6, value = 2 },
+  { sides = 6, value = 4 },
+]
+
+[[ test ]]
+game_system = "MonotoneMuseum"
+input = "2D6+1>=?[11,3]"
+output = "(2D6+1>=?[11,3]) ＞ 11[5,6]+1 ＞ 12 ＞ 自動成功"
+success = true
+critical = true
+rands = [
+  { sides = 6, value = 5 },
+  { sides = 6, value = 6 },
+]
+
+[[ test ]]
+game_system = "MonotoneMuseum"
+input = "2D6+1>=?[11,3]"
+output = "(2D6+1>=?[11,3]) ＞ 3[1,2]+1 ＞ 4 ＞ 自動失敗"
+failure = true
+fumble = true
+rands = [
+  { sides = 6, value = 1 },
+  { sides = 6, value = 2 },
+]
+
+[[ test ]]
+game_system = "MonotoneMuseum"
+input = "2D6+1>=?[11]"
+output = "(2D6+1>=?[11]) ＞ 11[5,6]+1 ＞ 12 ＞ 自動成功"
+success = true
+critical = true
+rands = [
+  { sides = 6, value = 5 },
+  { sides = 6, value = 6 },
+]
+
+[[ test ]]
+game_system = "MonotoneMuseum"
+input = "2D6+1>=?[,3]"
+output = "(2D6+1>=?[,3]) ＞ 3[1,2]+1 ＞ 4 ＞ 自動失敗"
+failure = true
+fumble = true
+rands = [
+  { sides = 6, value = 1 },
+  { sides = 6, value = 2 },
+]
+
+[[ test ]]
+game_system = "MonotoneMuseum"
+input = "2D6+1>=?[,3]"
+output = "(2D6+1>=?[,3]) ＞ 12[6,6]+1 ＞ 13 ＞ 自動成功"
+success = true
+critical = true
+rands = [
+  { sides = 6, value = 6 },
+  { sides = 6, value = 6 },
+]
+
+[[ test ]]
+game_system = "MonotoneMuseum"
+input = "2D6+1>=?[7,7] ファンブル値優先"
+output = "(2D6+1>=?[7,7]) ＞ 7[2,5]+1 ＞ 8 ＞ 自動失敗"
+failure = true
+fumble = true
+rands = [
+  { sides = 6, value = 5 },
+  { sides = 6, value = 2 },
+]
+
+[[ test ]]
+game_system = "MonotoneMuseum"
+input = "3D6+1>=?"
+output = "(3D6+1>=?) ＞ 12[2,4,6]+1 ＞ 13 ＞ 自動成功"
+success = true
+critical = true
+rands = [
+  { sides = 6, value = 2 },
+  { sides = 6, value = 6 },
+  { sides = 6, value = 4 },
+]
+
+[[ test ]]
+game_system = "MonotoneMuseum"
+input = "1D6>=?"
+output = "(1D6>=?) ＞ 2[2] ＞ 2 ＞ 自動失敗"
+failure = true
+fumble = true
+rands = [
+  { sides = 6, value = 2 },
+]
+
+[[ test ]]
+game_system = "MonotoneMuseum"
 input = "OT"
 output = "兆候表(6) ＞ 【重圧】\nあなたはバッドステータスの[重圧]を受ける。"
 rands = [


### PR DESCRIPTION
### 問題点
目標値が不明の場合にクリティカル・ファンブルの判定ができず、2d6>=?[12,2]のように手動でクリティカル・ファンブル値を設定する場合は動作しませんでした。

### 変更点
- 目標値が不明(0または?)の場合でもクリティカル・ファンブルの判定を行います。
- 目標値が不明の場合は、成功・失敗の判定を行いません。
- 目標値不明の場合でも、クリティカル・ファンブル値を設定して動作するように修正しました。