### PR TITLE
frozen_string_literal対応

### DIFF
--- a/lib/bcdice/game_system/CastleInGray.rb
+++ b/lib/bcdice/game_system/CastleInGray.rb
@@ -1,16 +1,18 @@
+# frozen_string_literal: true
+
 module BCDice
   module GameSystem
     class CastleInGray < Base
       # ゲームシステムの識別子
-      ID = "CastleInGray".freeze
+      ID = "CastleInGray"
 
       # ゲームシステム名
-      NAME = "灰色城綺譚".freeze
+      NAME = "灰色城綺譚"
 
       # ゲームシステム名の読みがな
-      SORT_KEY = "はいいろしようきたん".freeze
+      SORT_KEY = "はいいろしようきたん"
 
-      HELP_MESSAGE = <<~TEXT.freeze
+      HELP_MESSAGE = <<~TEXT
         ■ 色占い (BnWm)
         n: 黒
         m: 白

--- a/lib/bcdice/game_system/cthulhu7th/rollable.rb
+++ b/lib/bcdice/game_system/cthulhu7th/rollable.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module BCDice
   module GameSystem
     class Cthulhu7th < Base

--- a/lib/bcdice/game_system/sword_world/transcendent_test.rb
+++ b/lib/bcdice/game_system/sword_world/transcendent_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "bcdice/result"
 require "bcdice/translate"
 


### PR DESCRIPTION
`# frozen_string_literal: true` が無かったファイルを修正しました。

# 経緯
frozen_string_literalが無いファイルで文字列リテラルをfreezeすると、Opalへの変換時に専用のクラスにラップされる:
```
[String: '灰色城綺譚']
[String: '■ 色占い (BnWm)\n' +
  'n: 黒\n' +
  'm: 白\n' +
  'n, m は1～12の異なる整数\n' +
  '\n' +
  '例) B12W7\n' +
  '例) B5W12\n' +
  '\n' +
  '■ 悪意の渦による占い (MALn)\n' +
  'n: 悪意の渦\n' +
  'n は1～12の整数\n' +
  '\n' +
  '■ その他\n' +
  '・感情表 ET\n' +
  '・暗示表(黒) BIT\n' +
  '・暗示表(白) WIT\n']
```
これが原因と思われる不具合がユーザーから報告された。