### PR TITLE
[SwordWorld2.0/2.5] 超越判定の際に自動的成功した場合でも、達成値算出のために振り足しを行う

### DIFF
--- a/lib/bcdice/game_system/sword_world/transcendent_test.rb
+++ b/lib/bcdice/game_system/sword_world/transcendent_test.rb
@@ -39,7 +39,7 @@ module BCDice
           fumble = first_value_group == [1, 1]
           critical = first_value_group == [6, 6]
 
-          if !fumble && !critical
+          unless fumble
             while sum_of_dice(value_groups.last) >= @critical_value
               value_groups.push(randomizer.roll_barabara(2, 6))
             end

--- a/test/data/SwordWorld2_0.toml
+++ b/test/data/SwordWorld2_0.toml
@@ -526,11 +526,13 @@ rands = [
 [[ test ]]
 game_system = "SwordWorld2.0"
 input = "2D6@10+31>=30"
-output = "(2D6@10+31>=30) ＞ 12[6,6]+31 ＞ 43 ＞ 自動的成功"
+output = "(2D6@10+31>=30) ＞ 20[6,6][2,6]+31 ＞ 51 ＞ 自動的成功"
 success = true
 critical = true
 rands = [
   { sides = 6, value = 6 },
+  { sides = 6, value = 6 },
+  { sides = 6, value = 2 },
   { sides = 6, value = 6 },
 ]
 
@@ -587,11 +589,13 @@ rands = []
 [[ test ]]
 game_system = "SwordWorld2.0"
 input = "2d6@10+11>30"
-output = "(2D6@10+11>30) ＞ 12[6,6]+11 ＞ 23 ＞ 自動的成功"
+output = "(2D6@10+11>30) ＞ 20[6,6][2,6]+11 ＞ 31 ＞ 自動的成功"
 success = true
 critical = true
 rands = [
   { sides = 6, value = 6 },
+  { sides = 6, value = 6 },
+  { sides = 6, value = 2 },
   { sides = 6, value = 6 },
 ]
 

--- a/test/data/SwordWorld2_0_SimplifiedChinese.toml
+++ b/test/data/SwordWorld2_0_SimplifiedChinese.toml
@@ -526,11 +526,13 @@ rands = [
 [[ test ]]
 game_system = "SwordWorld2.0:SimplifiedChinese"
 input = "2D6@10+31>=30"
-output = "(2D6@10+31>=30) ＞ 12[6,6]+31 ＞ 43 ＞ 自动成功"
+output = "(2D6@10+31>=30) ＞ 20[6,6][2,6]+31 ＞ 51 ＞ 自动成功"
 success = true
 critical = true
 rands = [
   { sides = 6, value = 6 },
+  { sides = 6, value = 6 },
+  { sides = 6, value = 2 },
   { sides = 6, value = 6 },
 ]
 
@@ -587,11 +589,13 @@ rands = []
 [[ test ]]
 game_system = "SwordWorld2.0:SimplifiedChinese"
 input = "2d6@10+11>30"
-output = "(2D6@10+11>30) ＞ 12[6,6]+11 ＞ 23 ＞ 自动成功"
+output = "(2D6@10+11>30) ＞ 20[6,6][2,6]+11 ＞ 31 ＞ 自动成功"
 success = true
 critical = true
 rands = [
   { sides = 6, value = 6 },
+  { sides = 6, value = 6 },
+  { sides = 6, value = 2 },
   { sides = 6, value = 6 },
 ]
 

--- a/test/data/SwordWorld2_5.toml
+++ b/test/data/SwordWorld2_5.toml
@@ -622,11 +622,13 @@ rands = [
 [[ test ]]
 game_system = "SwordWorld2.5"
 input = "2D6@10+31>=30"
-output = "(2D6@10+31>=30) ＞ 12[6,6]+31 ＞ 43 ＞ 自動的成功"
+output = "(2D6@10+31>=30) ＞ 20[6,6][2,6]+31 ＞ 51 ＞ 自動的成功"
 success = true
 critical = true
 rands = [
   { sides = 6, value = 6 },
+  { sides = 6, value = 6 },
+  { sides = 6, value = 2 },
   { sides = 6, value = 6 },
 ]
 
@@ -683,11 +685,13 @@ rands = []
 [[ test ]]
 game_system = "SwordWorld2.5"
 input = "2d6@10+11>30"
-output = "(2D6@10+11>30) ＞ 12[6,6]+11 ＞ 23 ＞ 自動的成功"
+output = "(2D6@10+11>30) ＞ 20[6,6][2,6]+11 ＞ 31 ＞ 自動的成功"
 success = true
 critical = true
 rands = [
   { sides = 6, value = 6 },
+  { sides = 6, value = 6 },
+  { sides = 6, value = 2 },
   { sides = 6, value = 6 },
 ]
 

--- a/test/data/SwordWorld2_5_SimplifiedChinese.toml
+++ b/test/data/SwordWorld2_5_SimplifiedChinese.toml
@@ -622,11 +622,13 @@ rands = [
 [[ test ]]
 game_system = "SwordWorld2.5:SimplifiedChinese"
 input = "2D6@10+31>=30"
-output = "(2D6@10+31>=30) ＞ 12[6,6]+31 ＞ 43 ＞ 自动成功"
+output = "(2D6@10+31>=30) ＞ 20[6,6][2,6]+31 ＞ 51 ＞ 自动成功"
 success = true
 critical = true
 rands = [
   { sides = 6, value = 6 },
+  { sides = 6, value = 6 },
+  { sides = 6, value = 2 },
   { sides = 6, value = 6 },
 ]
 
@@ -683,11 +685,13 @@ rands = []
 [[ test ]]
 game_system = "SwordWorld2.5:SimplifiedChinese"
 input = "2d6@10+11>30"
-output = "(2D6@10+11>30) ＞ 12[6,6]+11 ＞ 23 ＞ 自动成功"
+output = "(2D6@10+11>30) ＞ 20[6,6][2,6]+11 ＞ 31 ＞ 自动成功"
 success = true
 critical = true
 rands = [
   { sides = 6, value = 6 },
+  { sides = 6, value = 6 },
+  { sides = 6, value = 2 },
   { sides = 6, value = 6 },
 ]
 


### PR DESCRIPTION
〈アステリアの連刃剣〉の効果などで自動成功しても達成値が必要になる場合があり、そのために達成値自体は算出するように動作を変更する。

自動的成功の条件自体に変更はない。