### PR TITLE
『砂塵戦機アーガス』のダイスを変更しました

### DIFF
--- a/lib/bcdice/game_system/SajinsenkiAGuS.rb
+++ b/lib/bcdice/game_system/SajinsenkiAGuS.rb
@@ -51,6 +51,7 @@ module BCDice
 
         dice_list = @randomizer.roll_barabara(2, 10).map { |d| d == 10 ? 0 : d }
         total = dice_list.sum
+        success_level = 1 + dice_list.count { |val| val <= level }
 
         return Result.new.tap do |result|
           result.condition = total <= target
@@ -59,7 +60,7 @@ module BCDice
             "(2D10<=#{target})",
             "#{total}[#{dice_list.join(',')}]",
             ("チャンス" if dice_list.include?(0)),
-            result.success? ? "成功" : "失敗"
+            result.success? ? "成功(+#{success_level})" : "失敗"
           ].compact
 
           result.text = sequence.join(" ＞ ")

--- a/test/data/SajinsenkiAGuS.toml
+++ b/test/data/SajinsenkiAGuS.toml
@@ -1,7 +1,7 @@
 [[ test ]]
 game_system = "SajinsenkiAGuS"
 input = "AG"
-output = "(2D10<=7) ＞ 5[2,3] ＞ 成功"
+output = "(2D10<=7) ＞ 5[2,3] ＞ 成功(+1)"
 success = true
 rands = [
   { sides = 10, value = 2 },
@@ -21,7 +21,7 @@ rands = [
 [[ test ]]
 game_system = "SajinsenkiAGuS"
 input = "AG"
-output = "(2D10<=7) ＞ 7[0,7] ＞ チャンス ＞ 成功"
+output = "(2D10<=7) ＞ 7[0,7] ＞ チャンス ＞ 成功(+2)"
 success = true
 rands = [
   { sides = 10, value = 10 },
@@ -41,7 +41,7 @@ rands = [
 [[ test ]]
 game_system = "SajinsenkiAGuS"
 input = "1AG"
-output = "(2D10<=11) ＞ 9[0,9] ＞ チャンス ＞ 成功"
+output = "(2D10<=11) ＞ 9[0,9] ＞ チャンス ＞ 成功(+2)"
 success = true
 rands = [
   { sides = 10, value = 10 },
@@ -51,7 +51,7 @@ rands = [
 [[ test ]]
 game_system = "SajinsenkiAGuS"
 input = "2AG-1"
-output = "(2D10<=11) ＞ 9[0,9] ＞ チャンス ＞ 成功"
+output = "(2D10<=11) ＞ 9[0,9] ＞ チャンス ＞ 成功(+2)"
 success = true
 rands = [
   { sides = 10, value = 10 },
@@ -81,7 +81,7 @@ rands = [
 [[ test ]]
 game_system = "SajinsenkiAGuS"
 input = "(2-1)AG+3-2"
-output = "(2D10<=12) ＞ 9[0,9] ＞ チャンス ＞ 成功"
+output = "(2D10<=12) ＞ 9[0,9] ＞ チャンス ＞ 成功(+2)"
 success = true
 rands = [
   { sides = 10, value = 10 },

--- a/test/data/SajinsenkiAGuS2E.toml
+++ b/test/data/SajinsenkiAGuS2E.toml
@@ -1,7 +1,7 @@
 [[ test ]]
 game_system = "SajinsenkiAGuS2E"
 input = "AG"
-output = "(2D10<=7) ＞ 5[2,3] ＞ 成功"
+output = "(2D10<=7) ＞ 5[2,3] ＞ 成功(+1)"
 success = true
 rands = [
   { sides = 10, value = 2 },
@@ -21,7 +21,7 @@ rands = [
 [[ test ]]
 game_system = "SajinsenkiAGuS2E"
 input = "AG"
-output = "(2D10<=7) ＞ 7[0,7] ＞ チャンス ＞ 成功"
+output = "(2D10<=7) ＞ 7[0,7] ＞ チャンス ＞ 成功(+2)"
 success = true
 rands = [
   { sides = 10, value = 10 },
@@ -41,7 +41,7 @@ rands = [
 [[ test ]]
 game_system = "SajinsenkiAGuS2E"
 input = "1AG"
-output = "(2D10<=11) ＞ 9[0,9] ＞ チャンス ＞ 成功"
+output = "(2D10<=11) ＞ 9[0,9] ＞ チャンス ＞ 成功(+2)"
 success = true
 rands = [
   { sides = 10, value = 10 },
@@ -51,7 +51,7 @@ rands = [
 [[ test ]]
 game_system = "SajinsenkiAGuS2E"
 input = "2AG-1"
-output = "(2D10<=11) ＞ 9[0,9] ＞ チャンス ＞ 成功"
+output = "(2D10<=11) ＞ 9[0,9] ＞ チャンス ＞ 成功(+2)"
 success = true
 rands = [
   { sides = 10, value = 10 },
@@ -81,7 +81,7 @@ rands = [
 [[ test ]]
 game_system = "SajinsenkiAGuS2E"
 input = "(2-1)AG+3-2"
-output = "(2D10<=12) ＞ 9[0,9] ＞ チャンス ＞ 成功"
+output = "(2D10<=12) ＞ 9[0,9] ＞ チャンス ＞ 成功(+2)"
 success = true
 rands = [
   { sides = 10, value = 10 },


### PR DESCRIPTION
アーガスのダイスで一般判定に「成功レベル」を表示してほしい旨要望があったので、実装してみました。
使用方法等は変わらず、一般判定の成功時に「成功(+2)」などと成功レベルを併記するようにしました。
rubocop通過済みです。

お手隙の際に、ご確認くださいませ。