### PR TITLE
『砂塵戦機アーガス2ed.』のダイスにファンブル処理を追加しました。

### DIFF
--- a/lib/bcdice/game_system/SajinsenkiAGuS.rb
+++ b/lib/bcdice/game_system/SajinsenkiAGuS.rb
@@ -54,6 +54,7 @@ module BCDice
 
         return Result.new.tap do |result|
           result.condition = total <= target
+          result.rands = dice_list
 
           sequence = [
             "(2D10<=#{target})",
@@ -91,6 +92,7 @@ module BCDice
 
         return Result.new.tap do |r|
           r.condition = total <= target
+          r.rands = dice_list
           r.critical = criticals >= 1
           r.text = [
             "(2D10<=#{target})",
@@ -114,6 +116,7 @@ module BCDice
 
         return Result.new.tap do |r|
           r.condition = total <= target
+          r.rands = dice_list
           r.critical = criticals >= 1
           r.text = [
             "(3D10<=#{target})",

--- a/lib/bcdice/game_system/SajinsenkiAGuS2E.rb
+++ b/lib/bcdice/game_system/SajinsenkiAGuS2E.rb
@@ -52,19 +52,17 @@ module BCDice
       end
 
       def eval_game_system_specific_command(command)
-        roll_ippan2(command) ||
-          roll_hit_check2(command) ||
-          roll_tables(command, TABLES) ||
+        super(command) ||
           roll_tables(command, SECOND_ED_TABLES)
       end
 
-      def roll_ippan2(command)
-        result = roll_ippan(command)
+      def roll_ippan(command)
+        result = super
         return change_fumble(result)
       end
 
-      def roll_hit_check2(command)
-        result = roll_hit_check(command)
+      def roll_hit_check(command)
+        result = super
         return change_fumble(result)
       end
 

--- a/lib/bcdice/game_system/SajinsenkiAGuS2E.rb
+++ b/lib/bcdice/game_system/SajinsenkiAGuS2E.rb
@@ -69,20 +69,14 @@ module BCDice
       def change_fumble(result)
         return nil if result.nil?
 
-        if check_fumble(result.rands)
+        fumble_counts = result.rands.count { |val| val >= 8 }
+        if fumble_counts >= 2
           result.text.sub!(/(成功|失敗).*$/, 'ファンブル')
           result.failure = true
           result.success = false
           result.fumble = true
         end
         return result
-      end
-
-      def check_fumble(dice)
-        return false if dice.nil?
-
-        fumble_counts = dice.count { |val| val >= 8 }
-        return fumble_counts >= 2
       end
 
       SECOND_ED_TABLES = {

--- a/lib/bcdice/game_system/SajinsenkiAGuS2E.rb
+++ b/lib/bcdice/game_system/SajinsenkiAGuS2E.rb
@@ -72,7 +72,7 @@ module BCDice
         return nil if result.nil?
 
         if check_fumble(result.rands)
-          result.text.sub!(/(成功|失敗).*$/, '自動失敗')
+          result.text.sub!(/(成功|失敗).*$/, 'ファンブル')
           result.failure = true
           result.success = false
           result.fumble = true

--- a/test/data/SajinsenkiAGuS2E.toml
+++ b/test/data/SajinsenkiAGuS2E.toml
@@ -100,6 +100,17 @@ rands = [
 
 [[ test ]]
 game_system = "SajinsenkiAGuS2E"
+input = "10AG #自動失敗"
+output = "(2D10<=20) ＞ 16[8,8] ＞ 自動失敗"
+failure = true
+fumble = true
+rands = [
+  { sides = 10, value = 8 },
+  { sides = 10, value = 8 },
+]
+
+[[ test ]]
+game_system = "SajinsenkiAGuS2E"
 input = "OM+8"
 output = "(2D10<=8) ＞ 4[3,1] ＞ 成功（HR=4、クリティカル0）"
 success = true
@@ -175,6 +186,17 @@ rands = [
 
 [[ test ]]
 game_system = "SajinsenkiAGuS2E"
+input = "OM+20 #自動失敗"
+output = "(2D10<=20) ＞ 17[9,8] ＞ 自動失敗"
+failure = true
+fumble = true
+rands = [
+  { sides = 10, value = 8 },
+  { sides = 10, value = 9 },
+]
+
+[[ test ]]
+game_system = "SajinsenkiAGuS2E"
 input = "NM+8"
 output = "(3D10<=8) ＞ 5[3,2&1] ＞ 成功（HR=3、クリティカル0）"
 success = true
@@ -229,6 +251,19 @@ rands = [
   { sides = 10, value = 3 },
   { sides = 10, value = 10 },
   { sides = 10, value = 10 },
+]
+
+
+[[ test ]]
+game_system = "SajinsenkiAGuS2E"
+input = "NM+20"
+output = "(3D10<=20) ＞ 18[9,9&1] ＞ 自動失敗"
+failure = true
+fumble = true
+rands = [
+  { sides = 10, value = 9 },
+  { sides = 10, value = 9 },
+  { sides = 10, value = 1 },
 ]
 
 [[ test ]]

--- a/test/data/SajinsenkiAGuS2E.toml
+++ b/test/data/SajinsenkiAGuS2E.toml
@@ -101,7 +101,7 @@ rands = [
 [[ test ]]
 game_system = "SajinsenkiAGuS2E"
 input = "10AG #自動失敗"
-output = "(2D10<=20) ＞ 16[8,8] ＞ 自動失敗"
+output = "(2D10<=20) ＞ 16[8,8] ＞ ファンブル"
 failure = true
 fumble = true
 rands = [
@@ -187,7 +187,7 @@ rands = [
 [[ test ]]
 game_system = "SajinsenkiAGuS2E"
 input = "OM+20 #自動失敗"
-output = "(2D10<=20) ＞ 17[9,8] ＞ 自動失敗"
+output = "(2D10<=20) ＞ 17[9,8] ＞ ファンブル"
 failure = true
 fumble = true
 rands = [
@@ -256,8 +256,8 @@ rands = [
 
 [[ test ]]
 game_system = "SajinsenkiAGuS2E"
-input = "NM+20"
-output = "(3D10<=20) ＞ 18[9,9&1] ＞ 自動失敗"
+input = "NM+16 #自動失敗"
+output = "(3D10<=16) ＞ 18[9,9&1] ＞ ファンブル"
 failure = true
 fumble = true
 rands = [


### PR DESCRIPTION
アーガス作者の潮屋様からの提案を元に、アーガス2ed.にサプリメントで追加されたファンブル処理を追加しました。
・各判定で振ったダイスがすべて8以上の場合はファンブル(自動失敗)となる

オーバーライドする都合上、アーガス1ed.のダイスに処理を若干追加しています。