### PR TITLE
[RuneQuest:Roleplaying in Glorantha]「失敗」判定の優先順位バグ修正

### DIFF
--- a/lib/bcdice/game_system/RuneQuestRoleplayingInGlorantha.rb
+++ b/lib/bcdice/game_system/RuneQuestRoleplayingInGlorantha.rb
@@ -128,10 +128,10 @@ module BCDice
         note_str = "クリティカル/スペシャル、ファンブルは未処理。必要なら確認すること。"
 
         if roll_value >= 96
-          # 96-99は無条件で失敗
+          # 96以上は無条件で失敗
           Result.failure("#{result_prefix_str} 失敗\n#{note_str}")
         elsif roll_value <= 5 || roll_value <= modifiy_value
-          # 02-05あるいは修正値以下は無条件で成功
+          # 05以下あるいは修正値以下は無条件で成功
           Result.success("#{result_prefix_str} 成功\n#{note_str}")
         else
           # 上記全てが当てはまらない時に突破可能な能力値を算出
@@ -151,15 +151,18 @@ module BCDice
         elsif (roll_value == 100) || (roll_value >= (100 - funmble_value + 1))
           # ファンブル(00は必ずファンブル)
           Result.fumble("#{result_str} ファンブル")
+        elsif roll_value >= 96 || ((roll_value > success_value) && (roll_value > 5))
+          # 失敗(96以上は必ず失敗、出目が01-05ではなく技能値より上なら失敗)
+          Result.failure("#{result_str} 失敗")
         elsif roll_value <= special_value
           # スペシャル
           Result.success("#{result_str} スペシャル")
-        elsif (roll_value <= 95) && ((roll_value <= 5) || (roll_value <= success_value))
-          # 成功(02-05は必ず成功で、96-99は必ず失敗)
+        elsif (roll_value <= 5) || (roll_value <= success_value)
+          # 成功(05以下は必ず成功)
           Result.success("#{result_str} 成功")
         else
-          # 失敗
-          Result.failure("#{result_str} 失敗")
+          # ここには到達しないはずだが、念のため捕捉
+          Result.failure("#{result_str} エラー")
         end
       end
     end

--- a/test/data/RuneQuestRoleplayingInGlorantha.toml
+++ b/test/data/RuneQuestRoleplayingInGlorantha.toml
@@ -1493,3 +1493,27 @@ failure = true
 rands = [
   { sides = 100, value = 100 },
 ]
+
+#===== バグ対応 ======#
+
+#【出目96以上でスペシャルになる問題対応】
+# 96は計算上スペシャルだが、96以上の出目は失敗
+[[ test ]]
+game_system = "RuneQuestRoleplayingInGlorantha"
+input = "RQG<=540"
+output = "(1D100<=540) ＞ 96 ＞ 失敗"
+failure = true
+rands = [
+  { sides = 100, value = 96 },
+]
+
+#【出目96以上でスペシャルになる問題対応】
+# 95は計算上スペシャル
+[[ test ]]
+game_system = "RuneQuestRoleplayingInGlorantha"
+input = "RQG<=540"
+output = "(1D100<=540) ＞ 95 ＞ スペシャル"
+success = true
+rands = [
+  { sides = 100, value = 95 },
+]

--- a/test/data/RuneQuestRoleplayingInGlorantha.toml
+++ b/test/data/RuneQuestRoleplayingInGlorantha.toml
@@ -1496,7 +1496,7 @@ rands = [
 
 #===== バグ対応 ======#
 
-#【出目96以上でスペシャルになる問題対応】
+#【技能540%の時、出目96以上でスペシャルになる問題対応】
 # 96は計算上スペシャルだが、96以上の出目は失敗
 [[ test ]]
 game_system = "RuneQuestRoleplayingInGlorantha"
@@ -1507,7 +1507,7 @@ rands = [
   { sides = 100, value = 96 },
 ]
 
-#【出目96以上でスペシャルになる問題対応】
+#【技能540%の時、出目96以上でスペシャルになる問題対応】
 # 95は計算上スペシャル
 [[ test ]]
 game_system = "RuneQuestRoleplayingInGlorantha"


### PR DESCRIPTION
**【背景】**
RuneQuest:Roleplaying in Glorantha(以下、RQG)の判定では01は常にクリティカル、00は常にファンブル、05以下は常に成功、96以上は常に失敗となる。しかし、500%以上の技能値を持つとき、ダイス目が96-99の時でも失敗ではなくスペシャルになるバグが存在していた。

**【修正】**
96以上は失敗する判定の前にスペシャルの判定があり、これにより上記の現象が発生していた。
このため以下のように判定の優先順位を修正した。
１．クリティカル(01、あるいはクリティカル成功値以下)
２．ファンブル(00、あるいはファンブル値以上)
３．失敗(96以上、5以下の出目を除く技能値を超える値)
４．スペシャル(技能値の1/5以下)
５．成功(05以下、あるいは技能値以下)

この修正に伴い、失敗値周りのコメントを上記の処理に合うよう変更。また、テストケースも２例追加した。