### PR TITLE
Vtm5th hunger limit

### DIFF
--- a/lib/bcdice/game_system/VampireTheMasquerade5th.rb
+++ b/lib/bcdice/game_system/VampireTheMasquerade5th.rb
@@ -67,6 +67,9 @@ module BCDice
         if dice_pool < 0
           return "ダイスプールより多いHungerダイスは指定できません。"
         end
+        if hunger_dice_pool && hunger_dice_pool > 5
+          return "Hungerダイス指定は5ダイスが最大です。"
+        end
 
         dice_text, success_dice, ten_dice, = make_dice_roll(dice_pool)
         result_text = "(#{dice_pool}D10"

--- a/test/data/VampireTheMasquerade5th.toml
+++ b/test/data/VampireTheMasquerade5th.toml
@@ -2054,6 +2054,21 @@ rands = [
   { sides = 10, value = 10 },
 ]
 
+# 5ダイスちょうどのHungerダイス
+[[ test ]]
+game_system = "VampireTheMasquerade5th"
+input = "3VMF1+5"
+output = "(1D10+5D10) ＞ [4]+[6,6,5,3,10]  成功数=3 難易度=3 差分=0：判定成功!"
+success = true
+rands = [
+  { sides = 10, value = 4 },
+  { sides = 10, value = 6 },
+  { sides = 10, value = 6 },
+  { sides = 10, value = 5 },
+  { sides = 10, value = 3 },
+  { sides = 10, value = 10 },
+]
+
 # 5ダイスを超えるHungerダイス
 [[ test ]]
 game_system = "VampireTheMasquerade5th"
@@ -2064,6 +2079,21 @@ rands = [
   { sides = 10, value = 10 },
   { sides = 10, value = 10 },
   { sides = 10, value = 10 },
+  { sides = 10, value = 3 },
+  { sides = 10, value = 10 },
+]
+
+# 5ダイスちょうどのHungerダイス
+[[ test ]]
+game_system = "VampireTheMasquerade5th"
+input = "3VMI6H5"
+output = "(1D10+5D10) ＞ [4]+[6,6,5,3,10]  成功数=3 難易度=3 差分=0：判定成功!"
+success = true
+rands = [
+  { sides = 10, value = 4 },
+  { sides = 10, value = 6 },
+  { sides = 10, value = 6 },
+  { sides = 10, value = 5 },
   { sides = 10, value = 3 },
   { sides = 10, value = 10 },
 ]

--- a/test/data/VampireTheMasquerade5th.toml
+++ b/test/data/VampireTheMasquerade5th.toml
@@ -2039,3 +2039,31 @@ rands = [
   { sides = 10, value = 7 },
   { sides = 10, value = 5 },
 ]
+
+# 5ダイスを超えるHungerダイス
+[[ test ]]
+game_system = "VampireTheMasquerade5th"
+input = "3VMF6+6"
+output = "Hungerダイス指定は5ダイスが最大です。"
+rands = [
+  { sides = 10, value = 4 },
+  { sides = 10, value = 10 },
+  { sides = 10, value = 10 },
+  { sides = 10, value = 10 },
+  { sides = 10, value = 3 },
+  { sides = 10, value = 10 },
+]
+
+# 5ダイスを超えるHungerダイス
+[[ test ]]
+game_system = "VampireTheMasquerade5th"
+input = "3VMI6H6"
+output = "Hungerダイス指定は5ダイスが最大です。"
+rands = [
+  { sides = 10, value = 4 },
+  { sides = 10, value = 10 },
+  { sides = 10, value = 10 },
+  { sides = 10, value = 10 },
+  { sides = 10, value = 3 },
+  { sides = 10, value = 10 },
+]


### PR DESCRIPTION
**【背景】**
https://github.com/bcdice/BCDice/pull/644 に記載した通り、V5の現行ルールではHungerダイスの上限は5ダイスであるにも関わらず、6以上のダイス数を指定できてしまう。

**【対応】**
ルールを把握している限り運用上で大きな問題にはならないが、入力ミスに気付かない等のケースを拾うため、5ダイス以上のHungerダイス指定にエラーメッセージを出すように修正、テストケースの追加を行う。