### PR TITLE
[Hunter:the Reckoning 5th] Desperation ダイスのリミット実装

### DIFF
--- a/lib/bcdice/game_system/HunterTheReckoning5th.rb
+++ b/lib/bcdice/game_system/HunterTheReckoning5th.rb
@@ -56,6 +56,10 @@ module BCDice
 
         desperaton_dice_pool = m[DESPERATION_DICE_INDEX]&.to_i
         if desperaton_dice_pool
+          if desperaton_dice_pool > 5
+            return "Desperationダイス指定は5ダイスが最大です。"
+          end
+
           desperaton_dice_text, desperaton_success_dice, desperaton_ten_dice, desperaton_botch_dice = make_dice_roll(desperaton_dice_pool)
 
           ten_dice += desperaton_ten_dice

--- a/test/data/HunterTheReckoning5th.toml
+++ b/test/data/HunterTheReckoning5th.toml
@@ -792,3 +792,33 @@ rands = [
   { sides = 10, value = 6 },
   { sides = 10, value = 6 },
 ]
+
+# 不正コマンド確認
+# 5ダイスを超えるDesperationダイス
+[[ test ]]
+game_system = "HunterTheReckoning5th"
+input = "3HRF6+6"
+output = "Desperationダイス指定は5ダイスが最大です。"
+rands = [
+  { sides = 10, value = 4 },
+  { sides = 10, value = 10 },
+  { sides = 10, value = 10 },
+  { sides = 10, value = 10 },
+  { sides = 10, value = 3 },
+  { sides = 10, value = 10 },
+]
+
+# 5ダイスちょうどのDesperationダイス
+[[ test ]]
+game_system = "HunterTheReckoning5th"
+input = "3HRF1+5"
+output = "(1D10+5D10) ＞ [4]+[6,6,5,3,10]  成功数=3 難易度=3 差分=0：判定成功!"
+success = true
+rands = [
+  { sides = 10, value = 4 },
+  { sides = 10, value = 6 },
+  { sides = 10, value = 6 },
+  { sides = 10, value = 5 },
+  { sides = 10, value = 3 },
+  { sides = 10, value = 10 },
+]


### PR DESCRIPTION
【背景】
H5にも https://github.com/bcdice/BCDice/pull/649 と同様の問題が存在する。

【対応】
同様に5ダイス以上のDesperation ダイス指定にエラーメッセージを出すように修正、テストケースの追加を行う。