### PR TITLE
[VampireTheMasquerade5th] Total Failureのヒント情報を追加

### DIFF
--- a/lib/bcdice/game_system/VampireTheMasquerade5th.rb
+++ b/lib/bcdice/game_system/VampireTheMasquerade5th.rb
@@ -129,7 +129,7 @@ module BCDice
               return Result.fumble("#{result_text}：判定失敗! [Bestial Failure]")
             end
             if success_dice == 0
-              return Result.failure("#{result_text}：判定失敗! [Total Failure]")
+              return Result.fumble("#{result_text}：判定失敗! [Total Failure]")
             end
 
             return Result.failure("#{result_text}：判定失敗!")
@@ -139,8 +139,7 @@ module BCDice
             if hunger_botch_dice > 0
               return Result.fumble("#{result_text}：判定失敗! [Bestial Failure]")
             end
-
-            return Result.failure("#{result_text}：判定失敗! [Total Failure]")
+            return Result.fumble("#{result_text}：判定失敗! [Total Failure]")
           else
             if hunger_botch_dice > 0
               result_text = "#{result_text}\n　判定失敗なら [Bestial Failure]"

--- a/lib/bcdice/game_system/VampireTheMasquerade5th.rb
+++ b/lib/bcdice/game_system/VampireTheMasquerade5th.rb
@@ -128,6 +128,9 @@ module BCDice
             if hunger_botch_dice > 0
               return Result.fumble("#{result_text}：判定失敗! [Bestial Failure]")
             end
+            if success_dice == 0
+              return Result.failure("#{result_text}：判定失敗! [Total Failure]")
+            end
 
             return Result.failure("#{result_text}：判定失敗!")
           end
@@ -137,7 +140,7 @@ module BCDice
               return Result.fumble("#{result_text}：判定失敗! [Bestial Failure]")
             end
 
-            return Result.failure("#{result_text}：判定失敗!")
+            return Result.failure("#{result_text}：判定失敗! [Total Failure]")
           else
             if hunger_botch_dice > 0
               result_text = "#{result_text}\n　判定失敗なら [Bestial Failure]"

--- a/lib/bcdice/game_system/VampireTheMasquerade5th.rb
+++ b/lib/bcdice/game_system/VampireTheMasquerade5th.rb
@@ -139,6 +139,7 @@ module BCDice
             if hunger_botch_dice > 0
               return Result.fumble("#{result_text}：判定失敗! [Bestial Failure]")
             end
+
             return Result.fumble("#{result_text}：判定失敗! [Total Failure]")
           else
             if hunger_botch_dice > 0

--- a/lib/bcdice/game_system/VampireTheMasquerade5th.rb
+++ b/lib/bcdice/game_system/VampireTheMasquerade5th.rb
@@ -22,14 +22,14 @@ module BCDice
             2VMF6+3
             2VMI9H3
 
-          難易度指定：成功数のカウント、判定成功と失敗、Critical処理、Critical Winのチェックを行う
+          難易度指定：成功数のカウント、判定成功と失敗、Critical処理、Critical Win、Total Failureのチェックを行う
                      （Hungerダイスがある場合）Messy CriticalとBestial Failureチェックを行う
           例) (難易度)VMF(通常ダイス)+(Hungerダイス)
               (難易度)VMF(通常ダイス)
               (難易度)VMI(通常ダイス)H(Hungerダイス)
               (難易度)VMI(通常ダイス)
 
-          難易度省略：成功数のカウント、判定失敗、Critical処理、（Hungerダイスがある場合）Bestial Failureチェックを行う
+          難易度省略：成功数のカウント、判定失敗、Critical処理、Total Failure、（Hungerダイスがある場合）Bestial Failureチェックを行う
                       判定成功、Messy Criticalのチェックを行わない
                       Critical Win、（Hungerダイスがある場合）Bestial Failure、Messy Criticalのヒントを出力
           例) VMF(通常ダイス)+(Hungerダイス)

--- a/test/data/VampireTheMasquerade5th.toml
+++ b/test/data/VampireTheMasquerade5th.toml
@@ -2,7 +2,7 @@
 [[ test ]]
 game_system = "VampireTheMasquerade5th"
 input = "3VMF0"
-output = "(0D10) ＞ []  成功数=0 難易度=3：判定失敗!"
+output = "(0D10) ＞ []  成功数=0 難易度=3：判定失敗! [Total Failure]"
 failure = true
 rands = [
   { sides = 10, value = 1 },
@@ -13,7 +13,7 @@ rands = [
 [[ test ]]
 game_system = "VampireTheMasquerade5th"
 input = "3VMF3"
-output = "(3D10) ＞ [1,2,5]  成功数=0 難易度=3：判定失敗!"
+output = "(3D10) ＞ [1,2,5]  成功数=0 難易度=3：判定失敗! [Total Failure]"
 failure = true
 rands = [
   { sides = 10, value = 1 },
@@ -210,7 +210,7 @@ rands = [
 [[ test ]]
 game_system = "VampireTheMasquerade5th"
 input = "VMF3"
-output = "(3D10) ＞ [2,5,1]  成功数=0：判定失敗!"
+output = "(3D10) ＞ [2,5,1]  成功数=0：判定失敗! [Total Failure]"
 failure = true
 rands = [
   { sides = 10, value = 2 },
@@ -221,7 +221,7 @@ rands = [
 [[ test ]]
 game_system = "VampireTheMasquerade5th"
 input = "VMF0"
-output = "(0D10) ＞ []  成功数=0：判定失敗!"
+output = "(0D10) ＞ []  成功数=0：判定失敗! [Total Failure]"
 failure = true
 rands = [
   { sides = 10, value = 2 },
@@ -252,7 +252,7 @@ rands = [
 [[ test ]]
 game_system = "VampireTheMasquerade5th"
 input = "VMF0+0"
-output = "(0D10+0D10) ＞ []+[]  成功数=0：判定失敗!"
+output = "(0D10+0D10) ＞ []+[]  成功数=0：判定失敗! [Total Failure]"
 failure = true
 rands = [
   { sides = 10, value = 2 },
@@ -312,7 +312,7 @@ rands = [
 [[ test ]]
 game_system = "VampireTheMasquerade5th"
 input = "VMF3+2"
-output = "(3D10+2D10) ＞ [2,5,1]+[4,3]  成功数=0：判定失敗!"
+output = "(3D10+2D10) ＞ [2,5,1]+[4,3]  成功数=0：判定失敗! [Total Failure]"
 failure = true
 rands = [
   { sides = 10, value = 2 },
@@ -489,7 +489,7 @@ rands = [
 [[ test ]]
 game_system = "VampireTheMasquerade5th"
 input = "S3VMF0"
-output = "(0D10) ＞ []  成功数=0 難易度=3：判定失敗!"
+output = "(0D10) ＞ []  成功数=0 難易度=3：判定失敗! [Total Failure]"
 failure = true
 secret = true
 rands = [
@@ -501,7 +501,7 @@ rands = [
 [[ test ]]
 game_system = "VampireTheMasquerade5th"
 input = "S3VMF3"
-output = "(3D10) ＞ [1,2,5]  成功数=0 難易度=3：判定失敗!"
+output = "(3D10) ＞ [1,2,5]  成功数=0 難易度=3：判定失敗! [Total Failure]"
 failure = true
 secret = true
 rands = [
@@ -704,7 +704,7 @@ rands = [
 [[ test ]]
 game_system = "VampireTheMasquerade5th"
 input = "SVMF0"
-output = "(0D10) ＞ []  成功数=0：判定失敗!"
+output = "(0D10) ＞ []  成功数=0：判定失敗! [Total Failure]"
 failure = true
 secret = true
 rands = [
@@ -716,7 +716,7 @@ rands = [
 [[ test ]]
 game_system = "VampireTheMasquerade5th"
 input = "SVMF3"
-output = "(3D10) ＞ [2,5,1]  成功数=0：判定失敗!"
+output = "(3D10) ＞ [2,5,1]  成功数=0：判定失敗! [Total Failure]"
 failure = true
 secret = true
 rands = [
@@ -750,7 +750,7 @@ rands = [
 [[ test ]]
 game_system = "VampireTheMasquerade5th"
 input = "SVMF3+2"
-output = "(3D10+2D10) ＞ [2,5,1]+[4,3]  成功数=0：判定失敗!"
+output = "(3D10+2D10) ＞ [2,5,1]+[4,3]  成功数=0：判定失敗! [Total Failure]"
 failure = true
 secret = true
 rands = [
@@ -996,7 +996,7 @@ rands = [
 [[ test ]]
 game_system = "VampireTheMasquerade5th"
 input = "3VMI0"
-output = "(0D10) ＞ []  成功数=0 難易度=3：判定失敗!"
+output = "(0D10) ＞ []  成功数=0 難易度=3：判定失敗! [Total Failure]"
 failure = true
 rands = [
   { sides = 10, value = 1 },
@@ -1007,7 +1007,7 @@ rands = [
 [[ test ]]
 game_system = "VampireTheMasquerade5th"
 input = "3VMI3"
-output = "(3D10) ＞ [1,2,5]  成功数=0 難易度=3：判定失敗!"
+output = "(3D10) ＞ [1,2,5]  成功数=0 難易度=3：判定失敗! [Total Failure]"
 failure = true
 rands = [
   { sides = 10, value = 1 },
@@ -1190,7 +1190,7 @@ rands = [
 [[ test ]]
 game_system = "VampireTheMasquerade5th"
 input = "VMI3"
-output = "(3D10) ＞ [2,5,1]  成功数=0：判定失敗!"
+output = "(3D10) ＞ [2,5,1]  成功数=0：判定失敗! [Total Failure]"
 failure = true
 rands = [
   { sides = 10, value = 2 },
@@ -1201,7 +1201,7 @@ rands = [
 [[ test ]]
 game_system = "VampireTheMasquerade5th"
 input = "VMI0"
-output = "(0D10) ＞ []  成功数=0：判定失敗!"
+output = "(0D10) ＞ []  成功数=0：判定失敗! [Total Failure]"
 failure = true
 rands = [
   { sides = 10, value = 2 },
@@ -1232,7 +1232,7 @@ rands = [
 [[ test ]]
 game_system = "VampireTheMasquerade5th"
 input = "VMI0H0"
-output = "(0D10+0D10) ＞ []+[]  成功数=0：判定失敗!"
+output = "(0D10+0D10) ＞ []+[]  成功数=0：判定失敗! [Total Failure]"
 failure = true
 rands = [
   { sides = 10, value = 2 },
@@ -1292,7 +1292,7 @@ rands = [
 [[ test ]]
 game_system = "VampireTheMasquerade5th"
 input = "VMI5H2"
-output = "(3D10+2D10) ＞ [2,5,1]+[4,3]  成功数=0：判定失敗!"
+output = "(3D10+2D10) ＞ [2,5,1]+[4,3]  成功数=0：判定失敗! [Total Failure]"
 failure = true
 rands = [
   { sides = 10, value = 2 },
@@ -1469,7 +1469,7 @@ rands = [
 [[ test ]]
 game_system = "VampireTheMasquerade5th"
 input = "S3VMI0"
-output = "(0D10) ＞ []  成功数=0 難易度=3：判定失敗!"
+output = "(0D10) ＞ []  成功数=0 難易度=3：判定失敗! [Total Failure]"
 failure = true
 secret = true
 rands = [
@@ -1481,7 +1481,7 @@ rands = [
 [[ test ]]
 game_system = "VampireTheMasquerade5th"
 input = "S3VMI3"
-output = "(3D10) ＞ [1,2,5]  成功数=0 難易度=3：判定失敗!"
+output = "(3D10) ＞ [1,2,5]  成功数=0 難易度=3：判定失敗! [Total Failure]"
 failure = true
 secret = true
 rands = [
@@ -1684,7 +1684,7 @@ rands = [
 [[ test ]]
 game_system = "VampireTheMasquerade5th"
 input = "SVMI0"
-output = "(0D10) ＞ []  成功数=0：判定失敗!"
+output = "(0D10) ＞ []  成功数=0：判定失敗! [Total Failure]"
 failure = true
 secret = true
 rands = [
@@ -1696,7 +1696,7 @@ rands = [
 [[ test ]]
 game_system = "VampireTheMasquerade5th"
 input = "SVMI3"
-output = "(3D10) ＞ [2,5,1]  成功数=0：判定失敗!"
+output = "(3D10) ＞ [2,5,1]  成功数=0：判定失敗! [Total Failure]"
 failure = true
 secret = true
 rands = [
@@ -1730,7 +1730,7 @@ rands = [
 [[ test ]]
 game_system = "VampireTheMasquerade5th"
 input = "SVMI5H2"
-output = "(3D10+2D10) ＞ [2,5,1]+[4,3]  成功数=0：判定失敗!"
+output = "(3D10+2D10) ＞ [2,5,1]+[4,3]  成功数=0：判定失敗! [Total Failure]"
 failure = true
 secret = true
 rands = [

--- a/test/data/VampireTheMasquerade5th.toml
+++ b/test/data/VampireTheMasquerade5th.toml
@@ -4,6 +4,7 @@ game_system = "VampireTheMasquerade5th"
 input = "3VMF0"
 output = "(0D10) ＞ []  成功数=0 難易度=3：判定失敗! [Total Failure]"
 failure = true
+fumble = true
 rands = [
   { sides = 10, value = 1 },
   { sides = 10, value = 2 },
@@ -15,6 +16,7 @@ game_system = "VampireTheMasquerade5th"
 input = "3VMF3"
 output = "(3D10) ＞ [1,2,5]  成功数=0 難易度=3：判定失敗! [Total Failure]"
 failure = true
+fumble = true
 rands = [
   { sides = 10, value = 1 },
   { sides = 10, value = 2 },
@@ -212,6 +214,7 @@ game_system = "VampireTheMasquerade5th"
 input = "VMF3"
 output = "(3D10) ＞ [2,5,1]  成功数=0：判定失敗! [Total Failure]"
 failure = true
+fumble = true
 rands = [
   { sides = 10, value = 2 },
   { sides = 10, value = 5 },
@@ -223,6 +226,7 @@ game_system = "VampireTheMasquerade5th"
 input = "VMF0"
 output = "(0D10) ＞ []  成功数=0：判定失敗! [Total Failure]"
 failure = true
+fumble = true
 rands = [
   { sides = 10, value = 2 },
   { sides = 10, value = 6 },
@@ -254,6 +258,7 @@ game_system = "VampireTheMasquerade5th"
 input = "VMF0+0"
 output = "(0D10+0D10) ＞ []+[]  成功数=0：判定失敗! [Total Failure]"
 failure = true
+fumble = true
 rands = [
   { sides = 10, value = 2 },
   { sides = 10, value = 6 },
@@ -314,6 +319,7 @@ game_system = "VampireTheMasquerade5th"
 input = "VMF3+2"
 output = "(3D10+2D10) ＞ [2,5,1]+[4,3]  成功数=0：判定失敗! [Total Failure]"
 failure = true
+fumble = true
 rands = [
   { sides = 10, value = 2 },
   { sides = 10, value = 5 },
@@ -491,6 +497,7 @@ game_system = "VampireTheMasquerade5th"
 input = "S3VMF0"
 output = "(0D10) ＞ []  成功数=0 難易度=3：判定失敗! [Total Failure]"
 failure = true
+fumble = true
 secret = true
 rands = [
   { sides = 10, value = 1 },
@@ -503,6 +510,7 @@ game_system = "VampireTheMasquerade5th"
 input = "S3VMF3"
 output = "(3D10) ＞ [1,2,5]  成功数=0 難易度=3：判定失敗! [Total Failure]"
 failure = true
+fumble = true
 secret = true
 rands = [
   { sides = 10, value = 1 },
@@ -706,6 +714,7 @@ game_system = "VampireTheMasquerade5th"
 input = "SVMF0"
 output = "(0D10) ＞ []  成功数=0：判定失敗! [Total Failure]"
 failure = true
+fumble = true
 secret = true
 rands = [
   { sides = 10, value = 2 },
@@ -718,6 +727,7 @@ game_system = "VampireTheMasquerade5th"
 input = "SVMF3"
 output = "(3D10) ＞ [2,5,1]  成功数=0：判定失敗! [Total Failure]"
 failure = true
+fumble = true
 secret = true
 rands = [
   { sides = 10, value = 2 },
@@ -752,6 +762,7 @@ game_system = "VampireTheMasquerade5th"
 input = "SVMF3+2"
 output = "(3D10+2D10) ＞ [2,5,1]+[4,3]  成功数=0：判定失敗! [Total Failure]"
 failure = true
+fumble = true
 secret = true
 rands = [
   { sides = 10, value = 2 },
@@ -998,6 +1009,7 @@ game_system = "VampireTheMasquerade5th"
 input = "3VMI0"
 output = "(0D10) ＞ []  成功数=0 難易度=3：判定失敗! [Total Failure]"
 failure = true
+fumble = true
 rands = [
   { sides = 10, value = 1 },
   { sides = 10, value = 2 },
@@ -1009,6 +1021,7 @@ game_system = "VampireTheMasquerade5th"
 input = "3VMI3"
 output = "(3D10) ＞ [1,2,5]  成功数=0 難易度=3：判定失敗! [Total Failure]"
 failure = true
+fumble = true
 rands = [
   { sides = 10, value = 1 },
   { sides = 10, value = 2 },
@@ -1192,6 +1205,7 @@ game_system = "VampireTheMasquerade5th"
 input = "VMI3"
 output = "(3D10) ＞ [2,5,1]  成功数=0：判定失敗! [Total Failure]"
 failure = true
+fumble = true
 rands = [
   { sides = 10, value = 2 },
   { sides = 10, value = 5 },
@@ -1203,6 +1217,7 @@ game_system = "VampireTheMasquerade5th"
 input = "VMI0"
 output = "(0D10) ＞ []  成功数=0：判定失敗! [Total Failure]"
 failure = true
+fumble = true
 rands = [
   { sides = 10, value = 2 },
   { sides = 10, value = 6 },
@@ -1234,6 +1249,7 @@ game_system = "VampireTheMasquerade5th"
 input = "VMI0H0"
 output = "(0D10+0D10) ＞ []+[]  成功数=0：判定失敗! [Total Failure]"
 failure = true
+fumble = true
 rands = [
   { sides = 10, value = 2 },
   { sides = 10, value = 6 },
@@ -1294,6 +1310,7 @@ game_system = "VampireTheMasquerade5th"
 input = "VMI5H2"
 output = "(3D10+2D10) ＞ [2,5,1]+[4,3]  成功数=0：判定失敗! [Total Failure]"
 failure = true
+fumble = true
 rands = [
   { sides = 10, value = 2 },
   { sides = 10, value = 5 },
@@ -1471,6 +1488,7 @@ game_system = "VampireTheMasquerade5th"
 input = "S3VMI0"
 output = "(0D10) ＞ []  成功数=0 難易度=3：判定失敗! [Total Failure]"
 failure = true
+fumble = true
 secret = true
 rands = [
   { sides = 10, value = 1 },
@@ -1483,6 +1501,7 @@ game_system = "VampireTheMasquerade5th"
 input = "S3VMI3"
 output = "(3D10) ＞ [1,2,5]  成功数=0 難易度=3：判定失敗! [Total Failure]"
 failure = true
+fumble = true
 secret = true
 rands = [
   { sides = 10, value = 1 },
@@ -1686,6 +1705,7 @@ game_system = "VampireTheMasquerade5th"
 input = "SVMI0"
 output = "(0D10) ＞ []  成功数=0：判定失敗! [Total Failure]"
 failure = true
+fumble = true
 secret = true
 rands = [
   { sides = 10, value = 2 },
@@ -1698,6 +1718,7 @@ game_system = "VampireTheMasquerade5th"
 input = "SVMI3"
 output = "(3D10) ＞ [2,5,1]  成功数=0：判定失敗! [Total Failure]"
 failure = true
+fumble = true
 secret = true
 rands = [
   { sides = 10, value = 2 },
@@ -1732,6 +1753,7 @@ game_system = "VampireTheMasquerade5th"
 input = "SVMI5H2"
 output = "(3D10+2D10) ＞ [2,5,1]+[4,3]  成功数=0：判定失敗! [Total Failure]"
 failure = true
+fumble = true
 secret = true
 rands = [
   { sides = 10, value = 2 },


### PR DESCRIPTION
**【背景】**
全てのダイスで成功がない(=6未満)の時、Total Failureというファンブル状態になる。
他の状態でヒント情報を出力しているため、Total Failureもチェックし、ヒント情報を表示したい。

**【対応】**
難易度指定、未指定のコマンドにおいて、全てのダイスに成功が無かった時、Total Failureのヒントを出力するように実装。また、Total Failureはfumbleとして処理するようにし、それに伴い、該当するテストケース、ヘルプも修正を行った。
判定失敗時のHungerダイスの"1"でBestial FailureとTotal Failureが同時発生する可能性があるが、以下の理由により排他として実装する。

1. Messy CriticalがCritical Winを上書きするため。
V5,p206にて、Messy CriticalがCritical Winを上書きすることが記述されており、Total Failureもこれに倣うと考えられる。
Critical Win、Total Failureは汎用判定の結果、Messy CriticalとBestial Failureは種族特有(この場合はヴァンパイア)処理。
以下引用。
> However, the presence of the turns the critical win into a messy critical! Martin has a hard choice to make. 
2. V5 DiceRoller( https://realmofdarkness.app/v5/ ) でも、排他として実装されているため。
