### PR TITLE
[HunterTheReckoning5th] Total Failureのヒント情報を追加

### DIFF
--- a/lib/bcdice/game_system/HunterTheReckoning5th.rb
+++ b/lib/bcdice/game_system/HunterTheReckoning5th.rb
@@ -17,12 +17,12 @@ module BCDice
         ・判定コマンド(nHRFx+x)
           注意：難易度は必要成功数を表す
 
-          難易度指定：成功数のカウント、判定成功と失敗、Critical処理、Critical Winのチェックを行う
+          難易度指定：成功数のカウント、判定成功と失敗、Critical処理、Critical Win、Total Failureのチェックを行う
                      （Desperationダイスがある場合）OverreachとDespairの発生チェックを行う
           例) (難易度)HRF(通常ダイス)+(Desperationダイス)
               (難易度)HRF(通常ダイス)
 
-          難易度省略：成功数のカウント、判定失敗、Critical処理、（Desperationダイスがある場合）Despairチェックを行う
+          難易度省略：成功数のカウント、判定失敗、Critical処理、Total Failure、（Desperationダイスがある場合）Despairチェックを行う
                       判定成功、Overreachのチェックを行わない
                       Critical Win、（Desperationダイスがある場合）Despair、Overreachのヒントを出力
           例) HRF(通常ダイス)+(Desperationダイス)
@@ -102,6 +102,9 @@ module BCDice
             if desperaton_botch_dice > 0
               return Result.fumble("#{result_text}：判定失敗! [Despair]")
             end
+            if success_dice == 0
+              return Result.fumble("#{result_text}：判定失敗! [Total Failure]")
+            end
 
             return Result.failure("#{result_text}：判定失敗!")
           end
@@ -111,7 +114,7 @@ module BCDice
               return Result.fumble("#{result_text}：判定失敗! [Despair]")
             end
 
-            return Result.failure("#{result_text}：判定失敗!")
+            return Result.fumble("#{result_text}：判定失敗! [Total Failure]")
           else
             if desperaton_botch_dice > 0
               result_text = "#{result_text}\n　判定失敗なら [Despair]"

--- a/test/data/HunterTheReckoning5th.toml
+++ b/test/data/HunterTheReckoning5th.toml
@@ -1,8 +1,9 @@
 [[ test ]]
 game_system = "HunterTheReckoning5th"
 input = "3HRF3"
-output = "(3D10) ＞ [1,2,5]  成功数=0 難易度=3：判定失敗!"
+output = "(3D10) ＞ [1,2,5]  成功数=0 難易度=3：判定失敗! [Total Failure]"
 failure = true
+fumble = true
 rands = [
   { sides = 10, value = 1 },
   { sides = 10, value = 2 },
@@ -169,8 +170,9 @@ rands = [
 [[ test ]]
 game_system = "HunterTheReckoning5th"
 input = "HRF3"
-output = "(3D10) ＞ [2,5,1]  成功数=0：判定失敗!"
+output = "(3D10) ＞ [2,5,1]  成功数=0：判定失敗! [Total Failure]"
 failure = true
+fumble = true
 rands = [
   { sides = 10, value = 2 },
   { sides = 10, value = 5 },
@@ -212,8 +214,9 @@ rands = [
 [[ test ]]
 game_system = "HunterTheReckoning5th"
 input = "HRF3+2"
-output = "(3D10+2D10) ＞ [2,5,1]+[4,3]  成功数=0：判定失敗!"
+output = "(3D10+2D10) ＞ [2,5,1]+[4,3]  成功数=0：判定失敗! [Total Failure]"
 failure = true
+fumble = true
 rands = [
   { sides = 10, value = 2 },
   { sides = 10, value = 5 },
@@ -383,8 +386,9 @@ rands = [
 [[ test ]]
 game_system = "HunterTheReckoning5th"
 input = "S3HRF3"
-output = "(3D10) ＞ [1,2,5]  成功数=0 難易度=3：判定失敗!"
+output = "(3D10) ＞ [1,2,5]  成功数=0 難易度=3：判定失敗! [Total Failure]"
 failure = true
+fumble = true
 secret = true
 rands = [
   { sides = 10, value = 1 },
@@ -564,8 +568,9 @@ rands = [
 [[ test ]]
 game_system = "HunterTheReckoning5th"
 input = "SHRF3"
-output = "(3D10) ＞ [2,5,1]  成功数=0：判定失敗!"
+output = "(3D10) ＞ [2,5,1]  成功数=0：判定失敗! [Total Failure]"
 failure = true
+fumble = true
 secret = true
 rands = [
   { sides = 10, value = 2 },
@@ -598,8 +603,9 @@ rands = [
 [[ test ]]
 game_system = "HunterTheReckoning5th"
 input = "SHRF3+2"
-output = "(3D10+2D10) ＞ [2,5,1]+[4,3]  成功数=0：判定失敗!"
+output = "(3D10+2D10) ＞ [2,5,1]+[4,3]  成功数=0：判定失敗! [Total Failure]"
 failure = true
+fumble = true
 secret = true
 rands = [
   { sides = 10, value = 2 },


### PR DESCRIPTION
**【背景】**
全てのダイスで成功がない(=6未満)の時、Total Failureというファンブル状態になる。
他の状態でヒント情報を出力しているため、Total Failureもチェックし、ヒント情報を表示したい。
関連( https://github.com/bcdice/BCDice/pull/651 )。

**【対応】**
難易度指定、未指定のコマンドにおいて、全てのダイスに成功が無かった時、Total Failureのヒントを出力するように実装。また、Total Failureはfumbleとして処理するようにし、それに伴い、該当するテストケース、ヘルプも修正を行った。
判定失敗時のDesperationダイスの"1"でDespairとTotal Failureが同時発生する可能性があるが、以下の理由により排他として実装する。

1. V5 DiceRoller( https://realmofdarkness.app/v5/ ) のH5コマンドでも、排他として実装されているため。

