### PR TITLE
[ShinobiGami] RCT(ランダム分野表)において、一度に複数個のダイスを振るオプションを追加

### DIFF
--- a/lib/bcdice/game_system/ShinobiGami.rb
+++ b/lib/bcdice/game_system/ShinobiGami.rb
@@ -27,7 +27,10 @@ module BCDice
         ・ランダム特技決定表 RTTn (n:分野番号、省略可能)
         　1器術 2体術 3忍術 4謀術 5戦術 6妖術
 
-        ・ランダム分野表 RCT
+        ・ランダム分野表 nRCT
+        　ランダムに特技分野を決定する。
+        　n: 決定する特技分野の数 (省略時 1)
+        　例) RCT, 4RCT
 
         ・各種表(基本ルールブック以降)
         　ファンブル表 FT、変調表 WT、戦国変調表 GWT、戦場表 BT、感情表 ET
@@ -97,9 +100,10 @@ module BCDice
       end
 
       register_prefix('\d*SG')
+      register_prefix('\d*RCT')
 
       def eval_game_system_specific_command(command)
-        return action_roll(command) || roll_tables(command, TABLES) || roll_tables(command, SCENE_TABLES) ||
+        return action_roll(command) || rct_roll(command) || roll_tables(command, TABLES) || roll_tables(command, SCENE_TABLES) ||
                roll_tables(command, DEMON_SKILL_TABLES) || roll_tables(command, DEMON_SKILL_TABLES_NEW) || RTT.roll_command(@randomizer, command)
       end
 
@@ -162,6 +166,32 @@ module BCDice
 
         result.text = sequence.join(" ＞ ")
         result
+      end
+
+      # nRCT ランダム分野表
+      RCT = ["器術", "体術", "忍術", "謀術", "戦術", "妖術"].freeze
+
+      def rct_roll(command)
+        m = /^(\d*)RCT$/.match(command)
+        return nil unless m
+
+        times = m[1].to_i
+
+        if times <= 0
+          times = 1
+        end
+
+        die = @randomizer.roll_barabara(times, 6)
+        die = die.sort
+
+        results = []
+
+        die.each do |i|
+          results.push(RCT[i - 1])
+        end
+
+        result_text = "ランダム分野表(#{die.join(',')}) ＞ #{results.join(', ')}"
+        return result_text
       end
 
       # 妖魔忍法表A, B, C

--- a/test/data/ShinobiGami.toml
+++ b/test/data/ShinobiGami.toml
@@ -1075,21 +1075,21 @@ rands = [
 
 [[ test ]]
 game_system = "ShinobiGami"
-input = "2RCT"
-output = "ランダム分野表(2,3) ＞ 体術, 忍術"
-rands = [
-  { sides = 6, value = 2 },
-  { sides = 6, value = 3 },
-]
-
-[[ test ]]
-game_system = "ShinobiGami"
 input = "3RCT"
 output = "ランダム分野表(3,4,6) ＞ 忍術, 謀術, 妖術"
 rands = [
   { sides = 6, value = 6 },
   { sides = 6, value = 3 },
   { sides = 6, value = 4 },
+]
+
+[[ test ]]
+game_system = "ShinobiGami"
+input = "2RCT"
+output = "ランダム分野表(2,3) ＞ 体術, 忍術"
+rands = [
+  { sides = 6, value = 2 },
+  { sides = 6, value = 3 },
 ]
 
 [[ test ]]

--- a/test/data/ShinobiGami.toml
+++ b/test/data/ShinobiGami.toml
@@ -1075,6 +1075,25 @@ rands = [
 
 [[ test ]]
 game_system = "ShinobiGami"
+input = "2RCT"
+output = "ランダム分野表(2,3) ＞ 体術, 忍術"
+rands = [
+  { sides = 6, value = 2 },
+  { sides = 6, value = 3 },
+]
+
+[[ test ]]
+game_system = "ShinobiGami"
+input = "3RCT"
+output = "ランダム分野表(3,4,6) ＞ 忍術, 謀術, 妖術"
+rands = [
+  { sides = 6, value = 6 },
+  { sides = 6, value = 3 },
+  { sides = 6, value = 4 },
+]
+
+[[ test ]]
+game_system = "ShinobiGami"
 input = "PLST"
 output = "培養プラントシーン表(2) ＞ 巨大なガラス管の中に冒涜的な生物が蠢く実験室。《意気》で判定を行い、失敗すると《マヒ》の変調を受ける。"
 rands = [


### PR DESCRIPTION
システム上(詳細は権利等に配慮して伏せます)、一度に複数の特技を(被りありで)決定したい場面が多く存在し、これまではRCTを複数回振ることや、nB6を振ることで対応していました。

今回、```RCT```の前に振りたい数を付加し、```4RCT```や```2RCT```といった形で1コマンドで複数個の結果を出力できるようにしました。
従来通り```RCT```のみの形での入力も可能です。

また、この変更に伴って「ダイスボットの使い方」欄のRCTの説明も変更しました。
