### PR TITLE
[RuneQuest:Roleplaying in Glorantha] システム名を英語から日本語に変更

### DIFF
--- a/lib/bcdice/game_system/RuneQuestRoleplayingInGlorantha.rb
+++ b/lib/bcdice/game_system/RuneQuestRoleplayingInGlorantha.rb
@@ -7,7 +7,7 @@ module BCDice
       ID = 'RuneQuestRoleplayingInGlorantha'
 
       # ゲームシステム名
-      NAME = 'RuneQuest：Roleplaying in Glorantha'
+      NAME = 'ルーンクエスト：ロールプレイング・イン・グローランサ'
 
       # ゲームシステム名の読みがな
       SORT_KEY = 'るうんくえすと4'


### PR DESCRIPTION
**【背景】**
RuneQuest:Roleplaying in Gloranthaが未訳だったこともあり、ダイスボット名を英語で作成していた。
しかし、「ルーンクエストスターターセット　日本語版」が2023/12/08に発売されたことで、ブック１、p1の囲み記事にて、システム名称の日本語名が「ルーンクエスト：ロールプレイング・イン・グローランサ」と判明した。
https://www.dlsite.com/home/work/=/product_id/RJ01110001.html

また、ダイスボット作成時の仕様( https://github.com/bcdice/BCDice/pull/637 )で日本語名にすることとしていたが、英語名を使用してしまっていた。

ルーンクエストスタートセット日本語版発売を受け、上記事情を鑑み、ダイスボット名称を「ルーンクエスト：ロールプレイング・イン・グローランサ」といたしたい。

**【修正】**
ダイスボット名称を日本語名称（「ルーンクエスト：ロールプレイング・イン・グローランサ」）に変更。