### PR TITLE
NightWizard3rd: Fix help message

### DIFF
--- a/lib/bcdice/game_system/NightWizard.rb
+++ b/lib/bcdice/game_system/NightWizard.rb
@@ -123,7 +123,7 @@ module BCDice
 
       # @return [ParsedNW, nil]
       def parse_nw(string)
-        m = /^([-+]?\d+)?#{@nw_command}((?:[-+]\d+)+)?(?:@(\d+(?:,\d+)*))?(?:#(\d+(?:,\d+)*))?(?:\$(\d+(?:,\d+)*))?((?:[-+]\d+)+)?(?:([>=]+)(\d+))?$/.match(string)
+        m = /^([-+]?\d+)?#{@nw_command}((?:[-+]\d+)+)?(?:@(\d+(?:,\d+)*))?(?:#(\d+(?:,\d+)*))?(?:\$(\d+))?((?:[-+]\d+)+)?(?:([>=]+)(\d+))?$/.match(string)
         unless m
           return nil
         end

--- a/lib/bcdice/game_system/NightWizard3rd.rb
+++ b/lib/bcdice/game_system/NightWizard3rd.rb
@@ -5,14 +5,27 @@ require 'bcdice/game_system/NightWizard'
 module BCDice
   module GameSystem
     class NightWizard3rd < NightWizard
+      # ゲームシステムの識別子
+      ID = 'NightWizard3rd'
+
       # ゲームシステム名
       NAME = 'ナイトウィザード The 3rd Edition'
 
       # ゲームシステム名の読みがな
       SORT_KEY = 'ないとういさあと3'
 
-      # ゲームシステムの識別子
-      ID = 'NightWizard3rd'
+      # ダイスボットの使い方
+      HELP_MESSAGE = <<~INFO_MESSAGE_TEXT
+        ・判定用コマンド　(aNW+b@x#y$z+c)
+        　　a : 基本値
+        　　b : 常時に準じる特技による補正
+        　　c : 常時以外の特技、および支援効果による補正
+        　　x : クリティカル値のカンマ区切り（省略時 10）
+        　　y : ファンブル値のカンマ区切り（省略時 5）
+        　　z : プラーナによる達成値補正のプラーナ消費数（ファンブル時には適用されない）
+        　クリティカル値、ファンブル値が無い場合は1や13などのあり得ない数値を入れてください。
+        　例）12NW-5@7#2$3 1NW 50nw+5@7,10#2,5 50nw-5+10@7,10#2,5+15+25
+      INFO_MESSAGE_TEXT
 
       register_prefix('([-+]?\d+)?NW', '2R6')
 


### PR DESCRIPTION
ナイトウィザード3rdに関して
https://github.com/bcdice/BCDice/pull/252
```
ファンブルのとき、常時発動ではない（能動的な）効果による修正値は適用されない。
「ナイトウィザード The 3rd Edition」ではファンブルでも適用される
```
この記述通り、ルール上、2rdと若干違いがある。
そして、3rdの`HELP_MESSAGE`は2rdを継承しており、同じになっている。
つまり、3rdの処理は正しいのだけど、説明文が間違っている。
なので、3rd側に`HELP_MESSAGE`を追加して、訂正した。

ナイトウィザード2ndに関して
```
aNW+b@x#y$z+c
x : クリティカル値のカンマ区切り（省略時 10）
y : ファンブル値のカンマ区切り（省略時 5）
z : プラーナによる達成値補正のプラーナ消費数（ファンブル時には適用されない）
```
そして、正規表現上`@x#y$z`はカンマ区切りのリストで指定できるように書かれているのだけど、
```ruby
        command.critical_numbers = m[3] ? m[3].split(',').map(&:to_i) : [10]
        command.fumble_numbers = m[4] ? m[4].split(',').map(&:to_i) : [5]
        command.prana = m[5]&.to_i
```
ここで、`command.prana`はリストを取れないので、マッチしないように正規表現を変更した。
