### PR TITLE
[VampireTheMasquerade5th] ダイスプールよりHungerダイスよりが大きい時に全てのダイスがHungerダイスになるよう変更

### DIFF
--- a/test/data/VampireTheMasquerade5th.toml
+++ b/test/data/VampireTheMasquerade5th.toml
@@ -2011,7 +2011,7 @@ rands = [
 [[ test ]]
 game_system = "VampireTheMasquerade5th"
 input = "3VMI0H3"
-output = "ダイスプールより多いHungerダイスは指定できません。"
+output = "ダイスプール0のときにHungerダイスは指定できません。"
 rands = [
   { sides = 10, value = 4 },
   { sides = 10, value = 10 },
@@ -2118,4 +2118,128 @@ rands = [
   { sides = 10, value = 5 },
   { sides = 10, value = 3 },
   { sides = 10, value = 10 },
+]
+
+# 内数指定とHungerダイスが同じ(難易度あり)
+[[ test ]]
+game_system = "VampireTheMasquerade5th"
+input = "2VMI5H5"
+output = "(0D10+5D10) ＞ []+[4,6,6,6,1]  成功数=3 難易度=2 差分=1：判定成功!"
+success = true
+rands = [
+  { sides = 10, value = 4 },
+  { sides = 10, value = 6 },
+  { sides = 10, value = 6 },
+  { sides = 10, value = 6 },
+  { sides = 10, value = 1 },
+]
+
+# 内数指定とHungerダイスが同じ(難易度なし)
+[[ test ]]
+game_system = "VampireTheMasquerade5th"
+input = "VMI5H5"
+output = "(0D10+5D10) ＞ []+[4,6,6,6,1]  成功数=3\n　判定失敗なら [Bestial Failure]"
+rands = [
+  { sides = 10, value = 4 },
+  { sides = 10, value = 6 },
+  { sides = 10, value = 6 },
+  { sides = 10, value = 6 },
+  { sides = 10, value = 1 },
+]
+
+# 内数指定においてHungerダイスがダイスプールを上回る指定(難易度あり)
+[[ test ]]
+game_system = "VampireTheMasquerade5th"
+input = "2VMI3H5"
+output = "(0D10+3D10) ＞ []+[4,6,6]  成功数=2 難易度=2 差分=0：判定成功!"
+success = true
+rands = [
+  { sides = 10, value = 4 },
+  { sides = 10, value = 6 },
+  { sides = 10, value = 6 },
+]
+
+# 内数指定においてHungerダイスがダイスプールを上回る指定(難易度なし)
+[[ test ]]
+game_system = "VampireTheMasquerade5th"
+input = "VMI3H5"
+output = "(0D10+3D10) ＞ []+[4,6,6]  成功数=2"
+rands = [
+  { sides = 10, value = 4 },
+  { sides = 10, value = 6 },
+  { sides = 10, value = 6 },
+]
+
+# 内数指定においてHungerダイスがダイスプールを上回る指定(難易度あり、Messy Critical)
+[[ test ]]
+game_system = "VampireTheMasquerade5th"
+input = "2VMI3H5"
+output = "(0D10+3D10) ＞ []+[4,10,10]  成功数=4 難易度=2 差分=2：判定成功! [Messy Critical]"
+success = true
+critical = true
+rands = [
+  { sides = 10, value = 4 },
+  { sides = 10, value = 10 },
+  { sides = 10, value = 10 },
+]
+
+# 内数指定においてHungerダイスがダイスプールを上回る指定(難易度なし、Messy Critical)
+[[ test ]]
+game_system = "VampireTheMasquerade5th"
+input = "VMI3H5"
+output = "(0D10+3D10) ＞ []+[4,10,10]  成功数=4\n　判定成功なら [Messy Critical]"
+rands = [
+  { sides = 10, value = 4 },
+  { sides = 10, value = 10 },
+  { sides = 10, value = 10 },
+]
+
+# 内数指定においてHungerダイスがダイスプールを上回る指定(難易度あり、Bestial Failure)
+[[ test ]]
+game_system = "VampireTheMasquerade5th"
+input = "2VMI3H4"
+output = "(0D10+3D10) ＞ []+[4,1,10]  成功数=1 難易度=2：判定失敗! [Bestial Failure]"
+failure = true
+fumble = true
+rands = [
+  { sides = 10, value = 4 },
+  { sides = 10, value = 1 },
+  { sides = 10, value = 10 },
+]
+
+# 内数指定においてHungerダイスがダイスプールを上回る指定(難易度なし、Bestial Failure)
+[[ test ]]
+game_system = "VampireTheMasquerade5th"
+input = "VMI3H4"
+output = "(0D10+3D10) ＞ []+[4,1,10]  成功数=1\n　判定失敗なら [Bestial Failure]"
+rands = [
+  { sides = 10, value = 4 },
+  { sides = 10, value = 1 },
+  { sides = 10, value = 10 },
+]
+
+# 内数指定においてHungerダイスがダイスプールを上回る指定(難易度あり、Total Failure)
+[[ test ]]
+game_system = "VampireTheMasquerade5th"
+input = "2VMI3H4"
+output = "(0D10+3D10) ＞ []+[4,2,5]  成功数=0 難易度=2：判定失敗! [Total Failure]"
+failure = true
+fumble = true
+rands = [
+  { sides = 10, value = 4 },
+  { sides = 10, value = 2 },
+  { sides = 10, value = 5 },
+]
+
+# 内数指定においてHungerダイスがダイスプールを上回る指定(難易度なし、Total Failure)
+[[ test ]]
+game_system = "VampireTheMasquerade5th"
+input = "VMI3H4"
+output = "(0D10+3D10) ＞ []+[4,2,5]  成功数=0：判定失敗! [Total Failure]"
+failure = true
+fumble = true
+rands = [
+  { sides = 10, value = 4 },
+  { sides = 10, value = 2 },
+  { sides = 10, value = 5 },
 ]


### PR DESCRIPTION
**【背景】**
https://github.com/bcdice/BCDice/pull/615 の修正にて、内数でのHungerダイス指定(VMIコマンド)がダイスプールを上回った時にエラーとするようにした。しかし、以下のようにルール上は全てのダイスプールがHungerダイスとして扱われるだけで判定不能になるわけではない。

V5,p205から引用
> When a player builds a dice pool for a vampire character, they exchange regular dice from that pool for Hunger dice on a one-for-one basis.
> If the dice pool for the roll is lower than the character’s Hunger, simply roll a number of Hunger dice equal to the dice pool.

このため、エラーにならないように修正を行う必要がある。

**【対応】**
上記の通り、VMIコマンドにてダイスプールより大きなHungerダイスが指定されてもエラーとせず、ダイスプールと同数のダイスがHungerダイスとして扱われるように修正した。
ただし、ダイスプールが0指定のときにHungerダイスが指定されたときは、従来通りエラーとして処理する。