### PR TITLE
Arianrhod Korean dicebot

### DIFF
--- a/i18n/Arianrhod/ko_kr.yml
+++ b/i18n/Arianrhod/ko_kr.yml
@@ -1,0 +1,3 @@
+ko_kr:
+  Arianrhod:
+    critical: "크리티컬(+%{dice}D6)"


### PR DESCRIPTION
アリアンロッド(Arianrhod RPG)の日本語ファイルを韓国語に翻訳しました。
これが無礼でなければ、韓国語のダイスボットを追加したいです。
Githubのルールが少し苦手な点があるので、いつも失礼しています。

i18n/Arianrhod/ko_kr.yml
lib/bcdice/game_system/Arianrhod_Korean.rb
test/data/Arianrhod_Korean.toml

lib/bcdice/game_system.rb
