### PR TITLE
Arianrhod Korean dicebot 

### DIFF
--- a/test/data/Arianrhod_Korean.toml
+++ b/test/data/Arianrhod_Korean.toml
@@ -27,7 +27,7 @@ rands = [
 ]
 
 [[ test ]]
-game_system = "Arianrhod_Korean"
+game_system = "Arianrhod:Korean"
 input = "1D6>=3"
 output = "(1D6>=3) ＞ 6 ＞ 성공"
 success = true
@@ -36,7 +36,7 @@ rands = [
 ]
 
 [[ test ]]
-game_system = "Arianrhod_Korean"
+game_system = "Arianrhod:Korean"
 input = "2D6>=7"
 output = "(2D6>=7) ＞ 5[2,3] ＞ 5 ＞ 실패"
 failure = true
@@ -46,7 +46,7 @@ rands = [
 ]
 
 [[ test ]]
-game_system = "Arianrhod_Korean"
+game_system = "Arianrhod:Korean"
 input = "2D6>=7"
 output = "(2D6>=7) ＞ 7[3,4] ＞ 7 ＞ 성공"
 success = true
@@ -56,7 +56,7 @@ rands = [
 ]
 
 [[ test ]]
-game_system = "Arianrhod_Korean"
+game_system = "Arianrhod:Korean"
 input = "2D6>=7"
 output = "(2D6>=7) ＞ 2[1,1] ＞ 2 ＞ 펌블"
 failure = true
@@ -67,7 +67,7 @@ rands = [
 ]
 
 [[ test ]]
-game_system = "Arianrhod_Korean"
+game_system = "Arianrhod:Korean"
 input = "2D6>=7"
 output = "(2D6>=7) ＞ 12[6,6] ＞ 12 ＞ 크리티컬(+2D6)"
 success = true
@@ -78,7 +78,7 @@ rands = [
 ]
 
 [[ test ]]
-game_system = "Arianrhod_Korean"
+game_system = "Arianrhod:Korean"
 input = "3D6>=10"
 output = "(3D6>=10) ＞ 4[1,1,2] ＞ 4 ＞ 실패"
 failure = true

--- a/test/data/Arianrhod_Korean.toml
+++ b/test/data/Arianrhod_Korean.toml
@@ -1,0 +1,302 @@
+[[ test ]]
+game_system = "Arianrhod:Korean"
+input = "1D6>=3"
+output = "(1D6>=3) ＞ 2 ＞ 실패"
+failure = true
+rands = [
+  { sides = 6, value = 2 },
+]
+
+[[ test ]]
+game_system = "Arianrhod:Korean"
+input = "1D6>=3"
+output = "(1D6>=3) ＞ 5 ＞ 성공"
+success = true
+rands = [
+  { sides = 6, value = 5 },
+]
+
+[[ test ]]
+game_system = "Arianrhod:Korean"
+input = "1D6>=3"
+output = "(1D6>=3) ＞ 1 ＞ 펌블"
+failure = true
+fumble = true
+rands = [
+  { sides = 6, value = 1 },
+]
+
+[[ test ]]
+game_system = "Arianrhod_Korean"
+input = "1D6>=3"
+output = "(1D6>=3) ＞ 6 ＞ 성공"
+success = true
+rands = [
+  { sides = 6, value = 6 },
+]
+
+[[ test ]]
+game_system = "Arianrhod_Korean"
+input = "2D6>=7"
+output = "(2D6>=7) ＞ 5[2,3] ＞ 5 ＞ 실패"
+failure = true
+rands = [
+  { sides = 6, value = 2 },
+  { sides = 6, value = 3 },
+]
+
+[[ test ]]
+game_system = "Arianrhod_Korean"
+input = "2D6>=7"
+output = "(2D6>=7) ＞ 7[3,4] ＞ 7 ＞ 성공"
+success = true
+rands = [
+  { sides = 6, value = 3 },
+  { sides = 6, value = 4 },
+]
+
+[[ test ]]
+game_system = "Arianrhod_Korean"
+input = "2D6>=7"
+output = "(2D6>=7) ＞ 2[1,1] ＞ 2 ＞ 펌블"
+failure = true
+fumble = true
+rands = [
+  { sides = 6, value = 1 },
+  { sides = 6, value = 1 },
+]
+
+[[ test ]]
+game_system = "Arianrhod_Korean"
+input = "2D6>=7"
+output = "(2D6>=7) ＞ 12[6,6] ＞ 12 ＞ 크리티컬(+2D6)"
+success = true
+critical = true
+rands = [
+  { sides = 6, value = 6 },
+  { sides = 6, value = 6 },
+]
+
+[[ test ]]
+game_system = "Arianrhod_Korean"
+input = "3D6>=10"
+output = "(3D6>=10) ＞ 4[1,1,2] ＞ 4 ＞ 실패"
+failure = true
+rands = [
+  { sides = 6, value = 2 },
+  { sides = 6, value = 1 },
+  { sides = 6, value = 1 },
+]
+
+[[ test ]]
+game_system = "Arianrhod:Korean"
+input = "3D6>=10"
+output = "(3D6>=10) ＞ 12[3,3,6] ＞ 12 ＞ 성공"
+success = true
+rands = [
+  { sides = 6, value = 3 },
+  { sides = 6, value = 3 },
+  { sides = 6, value = 6 },
+]
+
+[[ test ]]
+game_system = "Arianrhod:Korean"
+input = "3D6>=10"
+output = "(3D6>=10) ＞ 3[1,1,1] ＞ 3 ＞ 펌블"
+failure = true
+fumble = true
+rands = [
+  { sides = 6, value = 1 },
+  { sides = 6, value = 1 },
+  { sides = 6, value = 1 },
+]
+
+[[ test ]]
+game_system = "Arianrhod:Korean"
+input = "3D6>=10"
+output = "(3D6>=10) ＞ 15[3,6,6] ＞ 15 ＞ 크리티컬(+2D6)"
+success = true
+critical = true
+rands = [
+  { sides = 6, value = 6 },
+  { sides = 6, value = 3 },
+  { sides = 6, value = 6 },
+]
+
+[[ test ]]
+game_system = "Arianrhod:Korean"
+input = "3D6>=10"
+output = "(3D6>=10) ＞ 18[6,6,6] ＞ 18 ＞ 크리티컬(+3D6)"
+success = true
+critical = true
+rands = [
+  { sides = 6, value = 6 },
+  { sides = 6, value = 6 },
+  { sides = 6, value = 6 },
+]
+
+[[ test ]]
+game_system = "Arianrhod:Korean"
+input = "10D6>=35"
+output = "(10D6>=35) ＞ 44[2,2,3,5,5,5,5,5,6,6] ＞ 44 ＞ 크리티컬(+2D6)"
+success = true
+critical = true
+rands = [
+  { sides = 6, value = 5 },
+  { sides = 6, value = 5 },
+  { sides = 6, value = 6 },
+  { sides = 6, value = 3 },
+  { sides = 6, value = 5 },
+  { sides = 6, value = 5 },
+  { sides = 6, value = 6 },
+  { sides = 6, value = 5 },
+  { sides = 6, value = 2 },
+  { sides = 6, value = 2 },
+]
+
+[[ test ]]
+game_system = "Arianrhod:Korean"
+input = "10D6>=35"
+output = "(10D6>=35) ＞ 46[2,2,3,5,5,5,6,6,6,6] ＞ 46 ＞ 크리티컬(+4D6)"
+success = true
+critical = true
+rands = [
+  { sides = 6, value = 6 },
+  { sides = 6, value = 6 },
+  { sides = 6, value = 6 },
+  { sides = 6, value = 3 },
+  { sides = 6, value = 5 },
+  { sides = 6, value = 5 },
+  { sides = 6, value = 6 },
+  { sides = 6, value = 5 },
+  { sides = 6, value = 2 },
+  { sides = 6, value = 2 },
+]
+
+[[ test ]]
+game_system = "Arianrhod:Korean"
+input = "10D6>=35"
+output = "(10D6>=35) ＞ 10[1,1,1,1,1,1,1,1,1,1] ＞ 10 ＞ 펌블"
+failure = true
+fumble = true
+rands = [
+  { sides = 6, value = 1 },
+  { sides = 6, value = 1 },
+  { sides = 6, value = 1 },
+  { sides = 6, value = 1 },
+  { sides = 6, value = 1 },
+  { sides = 6, value = 1 },
+  { sides = 6, value = 1 },
+  { sides = 6, value = 1 },
+  { sides = 6, value = 1 },
+  { sides = 6, value = 1 },
+]
+
+[[ test ]]
+game_system = "Arianrhod:Korean"
+input = "10D6>=35"
+output = "(10D6>=35) ＞ 11[1,1,1,1,1,1,1,1,1,2] ＞ 11 ＞ 실패"
+failure = true
+rands = [
+  { sides = 6, value = 1 },
+  { sides = 6, value = 2 },
+  { sides = 6, value = 1 },
+  { sides = 6, value = 1 },
+  { sides = 6, value = 1 },
+  { sides = 6, value = 1 },
+  { sides = 6, value = 1 },
+  { sides = 6, value = 1 },
+  { sides = 6, value = 1 },
+  { sides = 6, value = 1 },
+]
+
+[[ test ]]
+game_system = "Arianrhod:Korean"
+input = "D66"
+output = "(D66) ＞ 35"
+rands = [
+  { sides = 6, value = 3 },
+  { sides = 6, value = 5 },
+]
+
+[[ test ]]
+game_system = "Arianrhod:Korean"
+input = "d66"
+output = "(D66) ＞ 51"
+rands = [
+  { sides = 6, value = 5 },
+  { sides = 6, value = 1 },
+]
+
+[[ test ]]
+game_system = "Arianrhod:Korean"
+input = "D66"
+output = "(D66) ＞ 15"
+rands = [
+  { sides = 6, value = 1 },
+  { sides = 6, value = 5 },
+]
+
+[[ test ]]
+game_system = "Arianrhod:Korean"
+input = "D66"
+output = "(D66) ＞ 53"
+rands = [
+  { sides = 6, value = 5 },
+  { sides = 6, value = 3 },
+]
+
+[[ test ]]
+game_system = "Arianrhod:Korean"
+input = "D66"
+output = "(D66) ＞ 53"
+rands = [
+  { sides = 6, value = 5 },
+  { sides = 6, value = 3 },
+]
+
+[[ test ]]
+game_system = "Arianrhod:Korean"
+input = "D66"
+output = "(D66) ＞ 31"
+rands = [
+  { sides = 6, value = 3 },
+  { sides = 6, value = 1 },
+]
+
+[[ test ]]
+game_system = "Arianrhod:Korean"
+input = "D66"
+output = "(D66) ＞ 63"
+rands = [
+  { sides = 6, value = 6 },
+  { sides = 6, value = 3 },
+]
+
+[[ test ]]
+game_system = "Arianrhod:Korean"
+input = "D66"
+output = "(D66) ＞ 42"
+rands = [
+  { sides = 6, value = 4 },
+  { sides = 6, value = 2 },
+]
+
+[[ test ]]
+game_system = "Arianrhod:Korean"
+input = "D66"
+output = "(D66) ＞ 55"
+rands = [
+  { sides = 6, value = 5 },
+  { sides = 6, value = 5 },
+]
+
+[[ test ]]
+game_system = "Arianrhod:Korean"
+input = "3D6>=? 目標値?でバグらない"
+output = "(3D6>=?) ＞ 9[3,3,3] ＞ 9"
+rands = [
+  { sides = 6, value = 3 },
+  { sides = 6, value = 3 },
+  { sides = 6, value = 3 },
+]


### PR DESCRIPTION
アリアンロッド(Arianrhod RPG)の日本語ファイルを韓国語に翻訳しました。
これが無礼でなければ、韓国語のダイスボットを追加したいです。
Githubのルールが少し苦手な点があるので、いつも失礼しています。

i18n/Arianrhod/ko_kr.yml
lib/bcdice/game_system/Arianrhod_Korean.rb
test/data/Arianrhod_Korean.toml

lib/bcdice/game_system.rb
