### PR TITLE
[ウタカゼ] 対抗判定用コマンドの追加

### DIFF
--- a/lib/bcdice/game_system/Utakaze.rb
+++ b/lib/bcdice/game_system/Utakaze.rb
@@ -28,10 +28,11 @@ module BCDice
           例）3UK@5 ：龍のダイス「月」でクリティカルコール宣言したサイコロ3個の行為判定
          ・対抗判定ロール(nUR[@c]) n:ダイス数 c:クリティカルコール
          　行為判定ロールと同様にロールするが、最期に成功レベルとセット数から求めたマジックナンバーが表示される。
-         　マジックナンバーの最も大きいものが成功、同値は引き分け。
+         　マジックナンバーの大きいものが成功、同値は引き分け。
+         　ダイスは18個まで対応。
       MESSAGETEXT
 
-      register_prefix('\d*U[KR]')
+      register_prefix('\d*U[KRO]')
 
       def eval_game_system_specific_command(command)
         debug('eval_game_system_specific_command command', command)
@@ -109,7 +110,7 @@ module BCDice
 
       # 対抗判定
       def opposed_roll(command)
-        m = /^(\d+)?UR(@?(\d))?$/i.match(command)
+        m = /^(\d+)?U[R|O](@?(\d))?$/i.match(command)
         return nil unless m
 
         base = (m[1] || 2).to_i

--- a/lib/bcdice/game_system/Utakaze.rb
+++ b/lib/bcdice/game_system/Utakaze.rb
@@ -26,14 +26,18 @@ module BCDice
           cに「龍のダイス目」を指定した行為判定ロール。
           ゾロ目ではなく、cと同じ値の出目数x2が成功レベルとなります。難易度の指定も可能です。
           例）3UK@5 ：龍のダイス「月」でクリティカルコール宣言したサイコロ3個の行為判定
+         ・対抗判定ロール(nUR[@c]) n:ダイス数 c:クリティカルコール
+         　行為判定ロールと同様にロールするが、最期に成功レベルとセット数から求めたマジックナンバーが表示される。
+         　マジックナンバーの最も大きいものが成功、同値は引き分け。
       MESSAGETEXT
 
-      register_prefix('\d*UK')
+      register_prefix('\d*U[KR]')
 
       def eval_game_system_specific_command(command)
         debug('eval_game_system_specific_command command', command)
 
-        check_roll(command)
+        check_roll(command) ||
+          opposed_roll(command)
       end
 
       private
@@ -99,6 +103,54 @@ module BCDice
           return Result.success(sequence.join(" ＞ "))
         else
           sequence.push("失敗")
+          return Result.failure(sequence.join(" ＞ "))
+        end
+      end
+
+      # 対抗判定
+      def opposed_roll(command)
+        m = /^(\d+)?UR(@?(\d))?$/i.match(command)
+        return nil unless m
+
+        base = (m[1] || 2).to_i
+        crit = m[3].to_i
+
+        base = getValue(base)
+        crit = getValue(crit)
+
+        return nil if base < 1
+
+        crit = 6 if crit > 6
+
+        dice_list = @randomizer.roll_barabara(base, 6).sort
+        result = get_opposed_roll_result(dice_list, crit)
+
+        sequence = [
+          command,
+          "(#{base}D6)",
+          "[#{dice_list.join(',')}]",
+          result.text
+        ]
+        result.text = sequence.join(" ＞ ")
+
+        return result
+      end
+
+      def get_opposed_roll_result(diceList, crit)
+        success, maxnum, setCount = getSuccessInfo(diceList, crit)
+
+        sequence = []
+
+        if isDragonDice(crit)
+          sequence.push("龍のダイス「#{DRAGON_DICE_NAME[crit]}」(#{crit})を使用")
+        end
+
+        if success
+          sequence.push("成功レベル:#{maxnum} (#{setCount}セット)")
+          sequence.push("(" + format("%#02d%#1d", maxnum, setCount) + ")")
+          return Result.success(sequence.join(" ＞ ")) # 出力上は成功として扱う
+        else
+          sequence.push("(000)")
           return Result.failure(sequence.join(" ＞ "))
         end
       end

--- a/lib/bcdice/game_system/Utakaze.rb
+++ b/lib/bcdice/game_system/Utakaze.rb
@@ -118,7 +118,7 @@ module BCDice
         base = getValue(base)
         crit = getValue(crit)
 
-        return nil if base < 1
+        return nil if base < 1 || base > 18
 
         crit = 6 if crit > 6
 

--- a/test/data/Utakaze.toml
+++ b/test/data/Utakaze.toml
@@ -476,3 +476,71 @@ rands = [
   { sides = 6, value = 2 },
   { sides = 6, value = 2 },
 ]
+
+
+[[ test ]]
+game_system = "Utakaze"
+input = "UR"
+output = "UR ＞ (2D6) ＞ [4,4] ＞ 成功レベル:2 (1セット) ＞ (021)"
+success = true
+rands = [
+  { sides = 6, value = 4 },
+  { sides = 6, value = 4 },
+]
+
+[[ test ]]
+game_system = "Utakaze"
+input = "6UR"
+output = "6UR ＞ (6D6) ＞ [1,2,3,3,3,3] ＞ 成功レベル:4 (1セット) ＞ (041)"
+success = true
+rands = [
+  { sides = 6, value = 3 },
+  { sides = 6, value = 3 },
+  { sides = 6, value = 3 },
+  { sides = 6, value = 3 },
+  { sides = 6, value = 2 },
+  { sides = 6, value = 1 },
+]
+
+[[ test ]]
+game_system = "Utakaze"
+input = "6UR"
+output = "6UR ＞ (6D6) ＞ [1,2,3,4,5,6] ＞ (000)"
+failure = true
+rands = [
+  { sides = 6, value = 6 },
+  { sides = 6, value = 5 },
+  { sides = 6, value = 4 },
+  { sides = 6, value = 3 },
+  { sides = 6, value = 2 },
+  { sides = 6, value = 1 },
+]
+
+[[ test ]]
+game_system = "Utakaze"
+input = "6UR@1"
+output = "6UR@1 ＞ (6D6) ＞ [1,1,2,2,2,2] ＞ 龍のダイス「風」(1)を使用 ＞ 成功レベル:4 (1セット) ＞ (041)"
+success = true
+rands = [
+  { sides = 6, value = 2 },
+  { sides = 6, value = 1 },
+  { sides = 6, value = 1 },
+  { sides = 6, value = 2 },
+  { sides = 6, value = 2 },
+  { sides = 6, value = 2 },
+]
+
+[[ test ]]
+game_system = "Utakaze"
+input = "6UR1"
+output = "6UR1 ＞ (6D6) ＞ [1,1,2,2,2,2] ＞ 龍のダイス「風」(1)を使用 ＞ 成功レベル:4 (1セット) ＞ (041)"
+success = true
+rands = [
+  { sides = 6, value = 2 },
+  { sides = 6, value = 1 },
+  { sides = 6, value = 1 },
+  { sides = 6, value = 2 },
+  { sides = 6, value = 2 },
+  { sides = 6, value = 2 },
+]
+

--- a/test/data/Utakaze.toml
+++ b/test/data/Utakaze.toml
@@ -544,3 +544,70 @@ rands = [
   { sides = 6, value = 2 },
 ]
 
+[[ test ]]
+game_system = "Utakaze"
+input = "UO"
+output = "UO ＞ (2D6) ＞ [4,4] ＞ 成功レベル:2 (1セット) ＞ (021)"
+success = true
+rands = [
+  { sides = 6, value = 4 },
+  { sides = 6, value = 4 },
+]
+
+[[ test ]]
+game_system = "Utakaze"
+input = "6UO"
+output = "6UO ＞ (6D6) ＞ [1,2,3,3,3,3] ＞ 成功レベル:4 (1セット) ＞ (041)"
+success = true
+rands = [
+  { sides = 6, value = 3 },
+  { sides = 6, value = 3 },
+  { sides = 6, value = 3 },
+  { sides = 6, value = 3 },
+  { sides = 6, value = 2 },
+  { sides = 6, value = 1 },
+]
+
+[[ test ]]
+game_system = "Utakaze"
+input = "6UO"
+output = "6UO ＞ (6D6) ＞ [1,2,3,4,5,6] ＞ (000)"
+failure = true
+rands = [
+  { sides = 6, value = 6 },
+  { sides = 6, value = 5 },
+  { sides = 6, value = 4 },
+  { sides = 6, value = 3 },
+  { sides = 6, value = 2 },
+  { sides = 6, value = 1 },
+]
+
+[[ test ]]
+game_system = "Utakaze"
+input = "6UO@1"
+output = "6UO@1 ＞ (6D6) ＞ [1,1,2,2,2,2] ＞ 龍のダイス「風」(1)を使用 ＞ 成功レベル:4 (1セット) ＞ (041)"
+success = true
+rands = [
+  { sides = 6, value = 2 },
+  { sides = 6, value = 1 },
+  { sides = 6, value = 1 },
+  { sides = 6, value = 2 },
+  { sides = 6, value = 2 },
+  { sides = 6, value = 2 },
+]
+
+[[ test ]]
+game_system = "Utakaze"
+input = "6UO1"
+output = "6UO1 ＞ (6D6) ＞ [1,1,2,2,2,2] ＞ 龍のダイス「風」(1)を使用 ＞ 成功レベル:4 (1セット) ＞ (041)"
+success = true
+rands = [
+  { sides = 6, value = 2 },
+  { sides = 6, value = 1 },
+  { sides = 6, value = 1 },
+  { sides = 6, value = 2 },
+  { sides = 6, value = 2 },
+  { sides = 6, value = 2 },
+]
+
+


### PR DESCRIPTION
『ウタカゼ』( https://r-r.arclight.co.jp/rpg/utakaze/ )用のダイスに「対抗判定用のコマンド」を追加しました。

コマンド名をどうするか悩みましたが、一般的にBCdiceでは対抗判定・抵抗判定には〇Rと付けることが多いので、判り易さのために「UR」とし、ルール通りの名称からtypoする可能性を考慮してOpposedのOでも受け付けるよう「UO」でもロールできるようにしてみました。

         ・対抗判定ロール(nUR[@c]) n:ダイス数 c:クリティカルコール
         　行為判定ロールと同様にロールするが、最期に成功レベルとセット数から求めたマジックナンバーが表示される。
         　マジックナンバーの大きいものが成功、同値は引き分け。
         　ダイスは18個まで対応。

なお、rubocopは通過済みです。

お手隙の際にご確認ください。