### PR TITLE
[ConvictorDrive] 目標値のデフォルト値を5とする

### DIFF
--- a/lib/bcdice/game_system/ConvictorDrive.rb
+++ b/lib/bcdice/game_system/ConvictorDrive.rb
@@ -19,7 +19,7 @@ module BCDice
 
       # ダイスボットの使い方
       HELP_MESSAGE = <<~MESSAGETEXT
-        xCD@z>=y: x個の10面ダイスで目標値y、クリティカルラインzの判定を行う
+        xCD@z>=y: x個の10面ダイスで目標値y（省略時5）、クリティカルラインz（省略時10）の判定を行う。
         SLT: 技能レベル表を振る
         DCT: 遅延イベント表を振る
       MESSAGETEXT
@@ -87,7 +87,7 @@ module BCDice
         parser = Command::Parser.new('CD', round_type: round_type)
                                 .has_prefix_number
                                 .enable_critical
-                                .restrict_cmp_op_to(:>=)
+                                .restrict_cmp_op_to(:>=, nil)
         cmd = parser.parse(command)
 
         unless cmd
@@ -95,8 +95,9 @@ module BCDice
         end
 
         dice_list = @randomizer.roll_barabara(cmd.prefix_number, 10)
-        critical = cmd.critical&.clamp(cmd.target_number, 10) || 10
-        succeed_num = dice_list.count { |x| x >= cmd.target_number }
+        target_num = cmd.target_number || 5
+        critical = cmd.critical&.clamp(target_num, 10) || 10
+        succeed_num = dice_list.count { |x| x >= target_num }
         critical_num = dice_list.count { |x| x >= critical }
 
         text = [

--- a/test/data/ConvictorDrive.toml
+++ b/test/data/ConvictorDrive.toml
@@ -68,6 +68,18 @@ rands = [
 
 [[ test ]]
 game_system = "ConvictorDrive"
+input = "4CD デフォルトの目標は5"
+output = "4CD ＞ 4,6,5,1 ＞ 成功数2"
+success = true
+rands = [
+  { sides = 10, value = 4 },
+  { sides = 10, value = 6 },
+  { sides = 10, value = 5 },
+  { sides = 10, value = 1 },
+]
+
+[[ test ]]
+game_system = "ConvictorDrive"
 input = "SLT"
 output = "技能ランク表(8) ＞ D+"
 rands = [
@@ -99,4 +111,3 @@ output = "遅延イベント表(9) ＞ 緊急出撃Ⅲ（ランダムなPC2人�
 rands = [
   { sides = 10, value = 9 },
 ]
-


### PR DESCRIPTION
discord-helpチャンネルにおいての要望を実装しました。

> 調査フェイズではクリティカルラインと目標値が固定になるため

という利便性の観点での実装となります。