### PR TITLE
[SwordWorld,SwordWorld2_0,SwordWorld2_5] 首切り刀をマイナスで振った時に、威力100に一周せず0で固定されるように変更

### DIFF
--- a/lib/bcdice/game_system/SwordWorld.rb
+++ b/lib/bcdice/game_system/SwordWorld.rb
@@ -113,7 +113,7 @@ module BCDice
           dice = 2 if dice < 2
           dice = 12 if dice > 12
 
-          currentKey = [command.rate + round * command.rateup, keyMax].min
+          currentKey = (command.rate + round * command.rateup).clamp(0, keyMax)
           debug("currentKey", currentKey)
           rateValue = newRates[dice][currentKey]
           debug("rateValue", rateValue)

--- a/test/data/SwordWorld2_0.toml
+++ b/test/data/SwordWorld2_0.toml
@@ -146,6 +146,24 @@ rands = [
 
 [[ test ]]
 game_system = "SwordWorld2.0"
+input = "K10r-5"
+output = "KeyNo.10c[10]r[-5] ＞ 2D:[5,5 5,5 5,5 5,5 5,4]=10,10,10,10,9 ＞ 5,5,3,3,3 ＞ 4回転 ＞ 19"
+critical = true
+rands = [
+  { sides = 6, value = 5 },
+  { sides = 6, value = 5 },
+  { sides = 6, value = 5 },
+  { sides = 6, value = 5 },
+  { sides = 6, value = 5 },
+  { sides = 6, value = 5 },
+  { sides = 6, value = 5 },
+  { sides = 6, value = 5 },
+  { sides = 6, value = 5 },
+  { sides = 6, value = 4 },
+]
+
+[[ test ]]
+game_system = "SwordWorld2.0"
 input = "K10gf"
 output = "KeyNo.10c[10]gf ＞ 2D:[5,5 2,2]=10,4 ＞ 5,1 ＞ 1回転 ＞ 6"
 critical = true

--- a/test/data/SwordWorld2_5.toml
+++ b/test/data/SwordWorld2_5.toml
@@ -146,6 +146,24 @@ rands = [
 
 [[ test ]]
 game_system = "SwordWorld2.5"
+input = "K10r-5"
+output = "KeyNo.10c[10]r[-5] ＞ 2D:[5,5 5,5 5,5 5,5 5,4]=10,10,10,10,9 ＞ 5,5,3,3,3 ＞ 4回転 ＞ 19"
+critical = true
+rands = [
+  { sides = 6, value = 5 },
+  { sides = 6, value = 5 },
+  { sides = 6, value = 5 },
+  { sides = 6, value = 5 },
+  { sides = 6, value = 5 },
+  { sides = 6, value = 5 },
+  { sides = 6, value = 5 },
+  { sides = 6, value = 5 },
+  { sides = 6, value = 5 },
+  { sides = 6, value = 4 },
+]
+
+[[ test ]]
+game_system = "SwordWorld2.5"
 input = "K10gf"
 output = "KeyNo.10c[10]gf ＞ 2D:[5,5 2,2]=10,4 ＞ 5,1 ＞ 1回転 ＞ 6"
 critical = true


### PR DESCRIPTION
ルールにない挙動であるが、これまでの実装は明らかにおかしいので、より妥当性のある挙動とする