### PR TITLE
[RuneQuest:Roleplaying in Glorantha] 決定的成功時の表示を変更

### DIFF
--- a/lib/bcdice/game_system/RuneQuestRoleplayingInGlorantha.rb
+++ b/lib/bcdice/game_system/RuneQuestRoleplayingInGlorantha.rb
@@ -125,7 +125,7 @@ module BCDice
         active_value = active_ability_value * 5 + modifiy_value
         result_prefix_str = "(1D100<=#{active_value}) ＞ #{roll_value} ＞"
 
-        note_str = "決定的成功/効果的成功、ファンブルは未処理。必要なら確認すること。"
+        note_str = "決定的成功、効果的成功、ファンブルは未処理。必要なら確認すること。"
 
         if roll_value >= 96
           # 96以上は無条件で失敗
@@ -147,7 +147,7 @@ module BCDice
 
         if (roll_value == 1) || (roll_value <= critical_value)
           # 決定的成功(01は必ず決定的成功)
-          Result.critical("#{result_str} 決定的成功/効果的成功")
+          Result.critical("#{result_str} 決定的成功")
         elsif (roll_value == 100) || (roll_value >= (100 - funmble_value + 1))
           # ファンブル(00は必ずファンブル)
           Result.fumble("#{result_str} ファンブル")

--- a/test/data/RuneQuestRoleplayingInGlorantha.toml
+++ b/test/data/RuneQuestRoleplayingInGlorantha.toml
@@ -23,7 +23,7 @@ rands = [
 [[ test ]]
 game_system = "RuneQuestRoleplayingInGlorantha"
 input = "RQG<=10"
-output = "(1D100<=10) ＞ 1 ＞ 決定的成功/効果的成功"
+output = "(1D100<=10) ＞ 1 ＞ 決定的成功"
 success = true
 critical = true
 rands = [
@@ -145,7 +145,7 @@ rands = [
 [[ test ]]
 game_system = "RuneQuestRoleplayingInGlorantha"
 input = "RQG<=70"
-output = "(1D100<=70) ＞ 4 ＞ 決定的成功/効果的成功"
+output = "(1D100<=70) ＞ 4 ＞ 決定的成功"
 success = true
 critical = true
 rands = [
@@ -227,7 +227,7 @@ rands = [
 [[ test ]]
 game_system = "RuneQuestRoleplayingInGlorantha"
 input = "RQG<=122"
-output = "(1D100<=122) ＞ 6 ＞ 決定的成功/効果的成功"
+output = "(1D100<=122) ＞ 6 ＞ 決定的成功"
 success = true
 critical = true
 rands = [
@@ -341,7 +341,7 @@ rands = [
 [[ test ]]
 game_system = "RuneQuestRoleplayingInGlorantha"
 input = "SRQG<=10"
-output = "(1D100<=10) ＞ 1 ＞ 決定的成功/効果的成功"
+output = "(1D100<=10) ＞ 1 ＞ 決定的成功"
 success = true
 critical = true
 secret = true
@@ -475,7 +475,7 @@ rands = [
 [[ test ]]
 game_system = "RuneQuestRoleplayingInGlorantha"
 input = "SRQG<=70"
-output = "(1D100<=70) ＞ 4 ＞ 決定的成功/効果的成功"
+output = "(1D100<=70) ＞ 4 ＞ 決定的成功"
 success = true
 critical = true
 secret = true
@@ -565,7 +565,7 @@ rands = [
 [[ test ]]
 game_system = "RuneQuestRoleplayingInGlorantha"
 input = "SRQG<=122"
-output = "(1D100<=122) ＞ 6 ＞ 決定的成功/効果的成功"
+output = "(1D100<=122) ＞ 6 ＞ 決定的成功"
 success = true
 critical = true
 secret = true
@@ -667,7 +667,7 @@ rands = [
 [[ test ]]
 game_system = "RuneQuestRoleplayingInGlorantha"
 input = "RES(9-19)"
-output = "(1D100<=0) ＞ 1 ＞ 決定的成功/効果的成功"
+output = "(1D100<=0) ＞ 1 ＞ 決定的成功"
 success = true
 critical = true
 rands = [
@@ -789,7 +789,7 @@ rands = [
 [[ test ]]
 game_system = "RuneQuestRoleplayingInGlorantha"
 input = "RES(9-9)"
-output = "(1D100<=50) ＞ 3 ＞ 決定的成功/効果的成功"
+output = "(1D100<=50) ＞ 3 ＞ 決定的成功"
 success = true
 critical = true
 rands = [
@@ -841,7 +841,7 @@ rands = [
 [[ test ]]
 game_system = "RuneQuestRoleplayingInGlorantha"
 input = "RES(23-9)"
-output = "(1D100<=120) ＞ 6 ＞ 決定的成功/効果的成功"
+output = "(1D100<=120) ＞ 6 ＞ 決定的成功"
 success = true
 critical = true
 rands = [
@@ -934,7 +934,7 @@ rands = [
 [[ test ]]
 game_system = "RuneQuestRoleplayingInGlorantha"
 input = "SRES(9-19)"
-output = "(1D100<=0) ＞ 1 ＞ 決定的成功/効果的成功"
+output = "(1D100<=0) ＞ 1 ＞ 決定的成功"
 success = true
 critical = true
 secret = true
@@ -1068,7 +1068,7 @@ rands = [
 [[ test ]]
 game_system = "RuneQuestRoleplayingInGlorantha"
 input = "SRES(9-9)"
-output = "(1D100<=50) ＞ 3 ＞ 決定的成功/効果的成功"
+output = "(1D100<=50) ＞ 3 ＞ 決定的成功"
 success = true
 critical = true
 secret = true
@@ -1125,7 +1125,7 @@ rands = [
 [[ test ]]
 game_system = "RuneQuestRoleplayingInGlorantha"
 input = "SRES(23-9)"
-output = "(1D100<=120) ＞ 6 ＞ 決定的成功/効果的成功"
+output = "(1D100<=120) ＞ 6 ＞ 決定的成功"
 success = true
 critical = true
 secret = true
@@ -1236,7 +1236,7 @@ rands = [
 [[ test ]]
 game_system = "RuneQuestRoleplayingInGlorantha"
 input = "RSA11"
-output = "(1D100<=55) ＞ 1 ＞ 成功\n決定的成功/効果的成功、ファンブルは未処理。必要なら確認すること。"
+output = "(1D100<=55) ＞ 1 ＞ 成功\n決定的成功、効果的成功、ファンブルは未処理。必要なら確認すること。"
 success = true
 rands = [
   { sides = 100, value = 1 },
@@ -1246,7 +1246,7 @@ rands = [
 [[ test ]]
 game_system = "RuneQuestRoleplayingInGlorantha"
 input = "RSA11"
-output = "(1D100<=55) ＞ 2 ＞ 成功\n決定的成功/効果的成功、ファンブルは未処理。必要なら確認すること。"
+output = "(1D100<=55) ＞ 2 ＞ 成功\n決定的成功、効果的成功、ファンブルは未処理。必要なら確認すること。"
 success = true
 rands = [
   { sides = 100, value = 2 },
@@ -1256,7 +1256,7 @@ rands = [
 [[ test ]]
 game_system = "RuneQuestRoleplayingInGlorantha"
 input = "RSA11"
-output = "(1D100<=55) ＞ 3 ＞ 成功\n決定的成功/効果的成功、ファンブルは未処理。必要なら確認すること。"
+output = "(1D100<=55) ＞ 3 ＞ 成功\n決定的成功、効果的成功、ファンブルは未処理。必要なら確認すること。"
 success = true
 rands = [
   { sides = 100, value = 3 },
@@ -1266,7 +1266,7 @@ rands = [
 [[ test ]]
 game_system = "RuneQuestRoleplayingInGlorantha"
 input = "RSA11"
-output = "(1D100<=55) ＞ 4 ＞ 成功\n決定的成功/効果的成功、ファンブルは未処理。必要なら確認すること。"
+output = "(1D100<=55) ＞ 4 ＞ 成功\n決定的成功、効果的成功、ファンブルは未処理。必要なら確認すること。"
 success = true
 rands = [
   { sides = 100, value = 4 },
@@ -1276,7 +1276,7 @@ rands = [
 [[ test ]]
 game_system = "RuneQuestRoleplayingInGlorantha"
 input = "RSA11"
-output = "(1D100<=55) ＞ 5 ＞ 成功\n決定的成功/効果的成功、ファンブルは未処理。必要なら確認すること。"
+output = "(1D100<=55) ＞ 5 ＞ 成功\n決定的成功、効果的成功、ファンブルは未処理。必要なら確認すること。"
 success = true
 rands = [
   { sides = 100, value = 5 },
@@ -1286,7 +1286,7 @@ rands = [
 [[ test ]]
 game_system = "RuneQuestRoleplayingInGlorantha"
 input = "RSA11"
-output = "(1D100<=55) ＞ 6 ＞ 相手側能力値19まで成功\n決定的成功/効果的成功、ファンブルは未処理。必要なら確認すること。"
+output = "(1D100<=55) ＞ 6 ＞ 相手側能力値19まで成功\n決定的成功、効果的成功、ファンブルは未処理。必要なら確認すること。"
 rands = [
   { sides = 100, value = 6 },
 ]
@@ -1295,7 +1295,7 @@ rands = [
 [[ test ]]
 game_system = "RuneQuestRoleplayingInGlorantha"
 input = "RSA11"
-output = "(1D100<=55) ＞ 11 ＞ 相手側能力値18まで成功\n決定的成功/効果的成功、ファンブルは未処理。必要なら確認すること。"
+output = "(1D100<=55) ＞ 11 ＞ 相手側能力値18まで成功\n決定的成功、効果的成功、ファンブルは未処理。必要なら確認すること。"
 rands = [
   { sides = 100, value = 11 },
 ]
@@ -1304,7 +1304,7 @@ rands = [
 [[ test ]]
 game_system = "RuneQuestRoleplayingInGlorantha"
 input = "RSA11"
-output = "(1D100<=55) ＞ 16 ＞ 相手側能力値17まで成功\n決定的成功/効果的成功、ファンブルは未処理。必要なら確認すること。"
+output = "(1D100<=55) ＞ 16 ＞ 相手側能力値17まで成功\n決定的成功、効果的成功、ファンブルは未処理。必要なら確認すること。"
 rands = [
   { sides = 100, value = 16 },
 ]
@@ -1313,7 +1313,7 @@ rands = [
 [[ test ]]
 game_system = "RuneQuestRoleplayingInGlorantha"
 input = "RSA11"
-output = "(1D100<=55) ＞ 21 ＞ 相手側能力値16まで成功\n決定的成功/効果的成功、ファンブルは未処理。必要なら確認すること。"
+output = "(1D100<=55) ＞ 21 ＞ 相手側能力値16まで成功\n決定的成功、効果的成功、ファンブルは未処理。必要なら確認すること。"
 rands = [
   { sides = 100, value = 21 },
 ]
@@ -1322,7 +1322,7 @@ rands = [
 [[ test ]]
 game_system = "RuneQuestRoleplayingInGlorantha"
 input = "RSA11"
-output = "(1D100<=55) ＞ 26 ＞ 相手側能力値15まで成功\n決定的成功/効果的成功、ファンブルは未処理。必要なら確認すること。"
+output = "(1D100<=55) ＞ 26 ＞ 相手側能力値15まで成功\n決定的成功、効果的成功、ファンブルは未処理。必要なら確認すること。"
 rands = [
   { sides = 100, value = 26 },
 ]
@@ -1331,7 +1331,7 @@ rands = [
 [[ test ]]
 game_system = "RuneQuestRoleplayingInGlorantha"
 input = "RSA11"
-output = "(1D100<=55) ＞ 31 ＞ 相手側能力値14まで成功\n決定的成功/効果的成功、ファンブルは未処理。必要なら確認すること。"
+output = "(1D100<=55) ＞ 31 ＞ 相手側能力値14まで成功\n決定的成功、効果的成功、ファンブルは未処理。必要なら確認すること。"
 rands = [
   { sides = 100, value = 31 },
 ]
@@ -1340,7 +1340,7 @@ rands = [
 [[ test ]]
 game_system = "RuneQuestRoleplayingInGlorantha"
 input = "RSA11"
-output = "(1D100<=55) ＞ 36 ＞ 相手側能力値13まで成功\n決定的成功/効果的成功、ファンブルは未処理。必要なら確認すること。"
+output = "(1D100<=55) ＞ 36 ＞ 相手側能力値13まで成功\n決定的成功、効果的成功、ファンブルは未処理。必要なら確認すること。"
 rands = [
   { sides = 100, value = 36 },
 ]
@@ -1349,7 +1349,7 @@ rands = [
 [[ test ]]
 game_system = "RuneQuestRoleplayingInGlorantha"
 input = "RSA11"
-output = "(1D100<=55) ＞ 41 ＞ 相手側能力値12まで成功\n決定的成功/効果的成功、ファンブルは未処理。必要なら確認すること。"
+output = "(1D100<=55) ＞ 41 ＞ 相手側能力値12まで成功\n決定的成功、効果的成功、ファンブルは未処理。必要なら確認すること。"
 rands = [
   { sides = 100, value = 41 },
 ]
@@ -1358,7 +1358,7 @@ rands = [
 [[ test ]]
 game_system = "RuneQuestRoleplayingInGlorantha"
 input = "RSA11"
-output = "(1D100<=55) ＞ 46 ＞ 相手側能力値11まで成功\n決定的成功/効果的成功、ファンブルは未処理。必要なら確認すること。"
+output = "(1D100<=55) ＞ 46 ＞ 相手側能力値11まで成功\n決定的成功、効果的成功、ファンブルは未処理。必要なら確認すること。"
 rands = [
   { sides = 100, value = 46 },
 ]
@@ -1367,7 +1367,7 @@ rands = [
 [[ test ]]
 game_system = "RuneQuestRoleplayingInGlorantha"
 input = "RSA11"
-output = "(1D100<=55) ＞ 51 ＞ 相手側能力値10まで成功\n決定的成功/効果的成功、ファンブルは未処理。必要なら確認すること。"
+output = "(1D100<=55) ＞ 51 ＞ 相手側能力値10まで成功\n決定的成功、効果的成功、ファンブルは未処理。必要なら確認すること。"
 rands = [
   { sides = 100, value = 51 },
 ]
@@ -1376,7 +1376,7 @@ rands = [
 [[ test ]]
 game_system = "RuneQuestRoleplayingInGlorantha"
 input = "RSA11"
-output = "(1D100<=55) ＞ 56 ＞ 相手側能力値9まで成功\n決定的成功/効果的成功、ファンブルは未処理。必要なら確認すること。"
+output = "(1D100<=55) ＞ 56 ＞ 相手側能力値9まで成功\n決定的成功、効果的成功、ファンブルは未処理。必要なら確認すること。"
 rands = [
   { sides = 100, value = 56 },
 ]
@@ -1385,7 +1385,7 @@ rands = [
 [[ test ]]
 game_system = "RuneQuestRoleplayingInGlorantha"
 input = "RSA11"
-output = "(1D100<=55) ＞ 61 ＞ 相手側能力値8まで成功\n決定的成功/効果的成功、ファンブルは未処理。必要なら確認すること。"
+output = "(1D100<=55) ＞ 61 ＞ 相手側能力値8まで成功\n決定的成功、効果的成功、ファンブルは未処理。必要なら確認すること。"
 rands = [
   { sides = 100, value = 61 },
 ]
@@ -1394,7 +1394,7 @@ rands = [
 [[ test ]]
 game_system = "RuneQuestRoleplayingInGlorantha"
 input = "RSA11"
-output = "(1D100<=55) ＞ 66 ＞ 相手側能力値7まで成功\n決定的成功/効果的成功、ファンブルは未処理。必要なら確認すること。"
+output = "(1D100<=55) ＞ 66 ＞ 相手側能力値7まで成功\n決定的成功、効果的成功、ファンブルは未処理。必要なら確認すること。"
 rands = [
   { sides = 100, value = 66 },
 ]
@@ -1403,7 +1403,7 @@ rands = [
 [[ test ]]
 game_system = "RuneQuestRoleplayingInGlorantha"
 input = "RSA11"
-output = "(1D100<=55) ＞ 71 ＞ 相手側能力値6まで成功\n決定的成功/効果的成功、ファンブルは未処理。必要なら確認すること。"
+output = "(1D100<=55) ＞ 71 ＞ 相手側能力値6まで成功\n決定的成功、効果的成功、ファンブルは未処理。必要なら確認すること。"
 rands = [
   { sides = 100, value = 71 },
 ]
@@ -1412,7 +1412,7 @@ rands = [
 [[ test ]]
 game_system = "RuneQuestRoleplayingInGlorantha"
 input = "RSA11"
-output = "(1D100<=55) ＞ 76 ＞ 相手側能力値5まで成功\n決定的成功/効果的成功、ファンブルは未処理。必要なら確認すること。"
+output = "(1D100<=55) ＞ 76 ＞ 相手側能力値5まで成功\n決定的成功、効果的成功、ファンブルは未処理。必要なら確認すること。"
 rands = [
   { sides = 100, value = 76 },
 ]
@@ -1421,7 +1421,7 @@ rands = [
 [[ test ]]
 game_system = "RuneQuestRoleplayingInGlorantha"
 input = "RSA11"
-output = "(1D100<=55) ＞ 81 ＞ 相手側能力値4まで成功\n決定的成功/効果的成功、ファンブルは未処理。必要なら確認すること。"
+output = "(1D100<=55) ＞ 81 ＞ 相手側能力値4まで成功\n決定的成功、効果的成功、ファンブルは未処理。必要なら確認すること。"
 rands = [
   { sides = 100, value = 81 },
 ]
@@ -1430,7 +1430,7 @@ rands = [
 [[ test ]]
 game_system = "RuneQuestRoleplayingInGlorantha"
 input = "RSA11"
-output = "(1D100<=55) ＞ 86 ＞ 相手側能力値3まで成功\n決定的成功/効果的成功、ファンブルは未処理。必要なら確認すること。"
+output = "(1D100<=55) ＞ 86 ＞ 相手側能力値3まで成功\n決定的成功、効果的成功、ファンブルは未処理。必要なら確認すること。"
 rands = [
   { sides = 100, value = 86 },
 ]
@@ -1439,7 +1439,7 @@ rands = [
 [[ test ]]
 game_system = "RuneQuestRoleplayingInGlorantha"
 input = "RSA11"
-output = "(1D100<=55) ＞ 95 ＞ 相手側能力値2まで成功\n決定的成功/効果的成功、ファンブルは未処理。必要なら確認すること。"
+output = "(1D100<=55) ＞ 95 ＞ 相手側能力値2まで成功\n決定的成功、効果的成功、ファンブルは未処理。必要なら確認すること。"
 rands = [
   { sides = 100, value = 95 },
 ]
@@ -1448,7 +1448,7 @@ rands = [
 [[ test ]]
 game_system = "RuneQuestRoleplayingInGlorantha"
 input = "RSA11"
-output = "(1D100<=55) ＞ 96 ＞ 失敗\n決定的成功/効果的成功、ファンブルは未処理。必要なら確認すること。"
+output = "(1D100<=55) ＞ 96 ＞ 失敗\n決定的成功、効果的成功、ファンブルは未処理。必要なら確認すること。"
 failure = true
 rands = [
   { sides = 100, value = 96 },
@@ -1458,7 +1458,7 @@ rands = [
 [[ test ]]
 game_system = "RuneQuestRoleplayingInGlorantha"
 input = "RSA11"
-output = "(1D100<=55) ＞ 97 ＞ 失敗\n決定的成功/効果的成功、ファンブルは未処理。必要なら確認すること。"
+output = "(1D100<=55) ＞ 97 ＞ 失敗\n決定的成功、効果的成功、ファンブルは未処理。必要なら確認すること。"
 failure = true
 rands = [
   { sides = 100, value = 97 },
@@ -1468,7 +1468,7 @@ rands = [
 [[ test ]]
 game_system = "RuneQuestRoleplayingInGlorantha"
 input = "RSA11"
-output = "(1D100<=55) ＞ 98 ＞ 失敗\n決定的成功/効果的成功、ファンブルは未処理。必要なら確認すること。"
+output = "(1D100<=55) ＞ 98 ＞ 失敗\n決定的成功、効果的成功、ファンブルは未処理。必要なら確認すること。"
 failure = true
 rands = [
   { sides = 100, value = 98 },
@@ -1478,7 +1478,7 @@ rands = [
 [[ test ]]
 game_system = "RuneQuestRoleplayingInGlorantha"
 input = "RSA11"
-output = "(1D100<=55) ＞ 99 ＞ 失敗\n決定的成功/効果的成功、ファンブルは未処理。必要なら確認すること。"
+output = "(1D100<=55) ＞ 99 ＞ 失敗\n決定的成功、効果的成功、ファンブルは未処理。必要なら確認すること。"
 failure = true
 rands = [
   { sides = 100, value = 99 },
@@ -1488,7 +1488,7 @@ rands = [
 [[ test ]]
 game_system = "RuneQuestRoleplayingInGlorantha"
 input = "RSA11"
-output = "(1D100<=55) ＞ 100 ＞ 失敗\n決定的成功/効果的成功、ファンブルは未処理。必要なら確認すること。"
+output = "(1D100<=55) ＞ 100 ＞ 失敗\n決定的成功、効果的成功、ファンブルは未処理。必要なら確認すること。"
 failure = true
 rands = [
   { sides = 100, value = 100 },


### PR DESCRIPTION
**【背景】**
これまで決定的成功時には「決定的成功/効果的成功」と表示していた。これは、攻撃時に決定的成功に効果的成功両方の効果が入っているとして、それを明示する意図であった。しかし、ルーンクエスト ロールプレイング イン グローランサ の 日本語版スタートセットp32において、決定的成功が効果的成功を含んだ形で記述されており、効果的成功が二重に適用されるような誤解を招きかねない表記であることがわかった。

**【修正】**
上記の問題に対応するため決定的成功時の表示を「決定的成功」のみとして、誤解を引き起こさないようルールブック通りの表記に修正した。
また、この修正に伴い、コメント、テストケースなどの文言も修正した。