### PR TITLE
[ローグライクハーフ] 宝物表の実装

### DIFF
--- a/test/data/RogueLikeHalf.toml
+++ b/test/data/RogueLikeHalf.toml
@@ -109,3 +109,35 @@ rands = [
   { sides = 3, value = 1 },
 ]
 
+
+[[ test ]]
+game_system = "RogueLikeHalf"
+input = "NTT 宝物表"
+output = "宝物表:1:金貨１枚"
+rands = [
+  { sides = 6, value = 1 },
+]
+
+[[ test ]]
+game_system = "RogueLikeHalf"
+input = "NTT 宝物表"
+output = "宝物表:6:１個の宝石・大（２ｄ６×５枚の金貨と同等の価値。下限は金貨３０枚の価値）"
+rands = [
+  { sides = 6, value = 6 },
+]
+
+[[ test ]]
+game_system = "RogueLikeHalf"
+input = "NTT-1 宝物表,減算"
+output = "宝物表:1:金貨１枚"
+rands = [
+  { sides = 6, value = 1 },
+]
+
+[[ test ]]
+game_system = "RogueLikeHalf"
+input = "NTT+1 宝物表,加算"
+output = "宝物表:7:【魔法の宝物表】でダイスロールを行うこと。"
+rands = [
+  { sides = 6, value = 6 },
+]


### PR DESCRIPTION
ローグライクハーフ( https://booth.pm/ja/items/4671946 ) に「宝物表」を実装しました。

        ■宝物表　NTT+x     x:修正値

普通の表とちがって、修正値が入るのでサタスペを参考にしました。

お手隙の際に、ご確認くださいませ。