### PR TITLE
[Cthulhu7th]新・クトゥルフ神話TRPGのCCコマンドの表記揺れ修正

### DIFF
--- a/lib/bcdice/game_system/Cthulhu7th.rb
+++ b/lib/bcdice/game_system/Cthulhu7th.rb
@@ -203,7 +203,7 @@ module BCDice
 
         if bonus_dice == 0 && difficulty.nil?
           dice = @randomizer.roll_once(100)
-          return "1D100 ＞ #{dice}"
+          return "(1D100) ＞ #{dice}"
         end
 
         if bonus_dice.abs > 100

--- a/test/data/Cthulhu7th.toml
+++ b/test/data/Cthulhu7th.toml
@@ -349,7 +349,7 @@ rands = []
 [[ test ]]
 game_system = "Cthulhu7th"
 input = "CC<=0"
-output = "1D100 ＞ 33"
+output = "(1D100) ＞ 33"
 rands = [
   { sides = 100, value = 33 },
 ]
@@ -1379,7 +1379,7 @@ rands = [
 [[ test ]]
 game_system = "Cthulhu7th"
 input = "cc    ccのみで可能に"
-output = "1D100 ＞ 19"
+output = "(1D100) ＞ 19"
 rands = [
   { sides = 100, value = 19 },
 ]

--- a/test/data/PulpCthulhu.toml
+++ b/test/data/PulpCthulhu.toml
@@ -182,7 +182,7 @@ rands = [
 [[ test ]]
 game_system = "PulpCthulhu"
 input = "cc"
-output = "1D100 ＞ 19"
+output = "(1D100) ＞ 19"
 rands = [
   { sides = 100, value = 19 },
 ]


### PR DESCRIPTION
こんにちは、いつもお世話になっています。

HelpサーバにてD-51様より指摘があった新・クトゥルフ神話TRPGのCCコマンドの表記揺れを修正しました。
https://discord.com/channels/757618761854484591/757624116965670993/1340675183564034069