### PR TITLE
[RuneQuest:Roleplaying in Glorantha] 略記判定コマンドを追加

### DIFF
--- a/lib/bcdice/game_system/RuneQuestRoleplayingInGlorantha.rb
+++ b/lib/bcdice/game_system/RuneQuestRoleplayingInGlorantha.rb
@@ -15,10 +15,13 @@ module BCDice
       # ダイスボットの使い方
       HELP_MESSAGE = <<~MESSAGETEXT
         ・判定コマンド 決定的成功、効果的成功、ファンブルを含めた判定を行う。
-        RQG<=成功率
+        RQG<=成功率      (基本書式)
+        RQG成功率        (省略記法)
 
-        例1：RQG<=80 （技能値80で判定）
+        例1：RQG<=80    （技能値80で判定）
         例2：RQG<=80+20 （技能値100で判定）
+        例3：RQG80      （省略書式で技能値80の判定）
+        例4：RQG80+20   （省略書式で技能値100の判定）
 
         ・抵抗判定コマンド（能動-受動） 決定的成功、効果的成功、ファンブルを含めた判定を行う。
         RES(能動能力-受動能力)m増強値
@@ -55,18 +58,18 @@ module BCDice
 
       # 技能などの一般判定
       def do_ability_roll(command)
-        m = %r{\A(RQG)(<=([+-/*\d]+))?$}.match(command)
+        m = %r{\A(RQG)((<=)?([+-/*\d]+))?$}.match(command)
         unless m
           return nil
         end
 
         roll_value = @randomizer.roll_once(100)
-        unless m[3]
+        unless m[4]
           # RQGのみ指定された場合は1d100を振ったのと同じ挙動
           return "(1D100) ＞ #{roll_value}"
         end
 
-        ability_value = Arithmetic.eval(m[3], RoundType::ROUND)
+        ability_value = Arithmetic.eval(m[4], RoundType::ROUND)
         result_prefix_str = "(1D100<=#{ability_value}) ＞"
 
         if ability_value == 0

--- a/test/data/RuneQuestRoleplayingInGlorantha.toml
+++ b/test/data/RuneQuestRoleplayingInGlorantha.toml
@@ -1467,7 +1467,7 @@ rands = [
 # 98の出目は失敗
 [[ test ]]
 game_system = "RuneQuestRoleplayingInGlorantha"
-input = "RSA11"
+input = "RSA11" 
 output = "(1D100<=55) ＞ 98 ＞ 失敗\n決定的成功、効果的成功、ファンブルは未処理。必要なら確認すること。"
 failure = true
 rands = [
@@ -1492,6 +1492,161 @@ output = "(1D100<=55) ＞ 100 ＞ 失敗\n決定的成功、効果的成功、�
 failure = true
 rands = [
   { sides = 100, value = 100 },
+]
+
+#======= RQG省略書式コマンド =======#
+
+# 失敗(技能値0は判定できない＝失敗とする)
+[[ test ]]
+game_system = "RuneQuestRoleplayingInGlorantha"
+input = "RQG0"
+output = "(1D100<=0) ＞ 失敗"
+failure = true
+rands = [
+  { sides = 100, value = 1 },
+]
+
+# 成功
+[[ test ]]
+game_system = "RuneQuestRoleplayingInGlorantha"
+input = "RQG67"
+output = "(1D100<=67) ＞ 67 ＞ 成功"
+success = true
+rands = [
+  { sides = 100, value = 67 },
+]
+
+# 失敗
+[[ test ]]
+game_system = "RuneQuestRoleplayingInGlorantha"
+input = "RQG67"
+output = "(1D100<=67) ＞ 68 ＞ 失敗"
+failure = true
+rands = [
+  { sides = 100, value = 68 },
+]
+
+# ファンブル(00の出目でファンブル)
+[[ test ]]
+game_system = "RuneQuestRoleplayingInGlorantha"
+input = "RQG120"
+output = "(1D100<=120) ＞ 100 ＞ ファンブル"
+failure = true
+fumble = true
+rands = [
+  { sides = 100, value = 100 },
+]
+
+# 決定的成功(境界の出目)
+[[ test ]]
+game_system = "RuneQuestRoleplayingInGlorantha"
+input = "RQG70"
+output = "(1D100<=70) ＞ 4 ＞ 決定的成功"
+success = true
+critical = true
+rands = [
+  { sides = 100, value = 4 },
+]
+
+# 決定的成功にならず効果的成功になる(境界の出目)
+[[ test ]]
+game_system = "RuneQuestRoleplayingInGlorantha"
+input = "RQG70"
+output = "(1D100<=70) ＞ 5 ＞ 効果的成功"
+success = true
+rands = [
+  { sides = 100, value = 5 },
+]
+
+# 四則演算 全部入り(成功率40%)
+[[ test ]]
+game_system = "RuneQuestRoleplayingInGlorantha"
+input = "RQG60*2/4+20-10"
+output = "(1D100<=40) ＞ 40 ＞ 成功"
+success = true
+rands = [
+  { sides = 100, value = 40 },
+]
+
+#======= RQG省略書式シークレットコマンド =======#
+
+# 失敗(技能値0は判定できない＝失敗とする)
+[[ test ]]
+game_system = "RuneQuestRoleplayingInGlorantha"
+input = "SRQG0"
+output = "(1D100<=0) ＞ 失敗"
+failure = true
+secret = true
+rands = [
+  { sides = 100, value = 1 },
+]
+
+# 成功
+[[ test ]]
+game_system = "RuneQuestRoleplayingInGlorantha"
+input = "SRQG67"
+output = "(1D100<=67) ＞ 67 ＞ 成功"
+success = true
+secret = true
+rands = [
+  { sides = 100, value = 67 },
+]
+
+# 失敗
+[[ test ]]
+game_system = "RuneQuestRoleplayingInGlorantha"
+input = "SRQG67"
+output = "(1D100<=67) ＞ 68 ＞ 失敗"
+failure = true
+secret = true
+rands = [
+  { sides = 100, value = 68 },
+]
+
+# ファンブル(00の出目でファンブル)
+[[ test ]]
+game_system = "RuneQuestRoleplayingInGlorantha"
+input = "SRQG120"
+output = "(1D100<=120) ＞ 100 ＞ ファンブル"
+failure = true
+fumble = true
+secret = true
+rands = [
+  { sides = 100, value = 100 },
+]
+
+# 決定的成功(境界の出目)
+[[ test ]]
+game_system = "RuneQuestRoleplayingInGlorantha"
+input = "SRQG70"
+output = "(1D100<=70) ＞ 4 ＞ 決定的成功"
+success = true
+critical = true
+secret = true
+rands = [
+  { sides = 100, value = 4 },
+]
+
+# 決定的成功にならず効果的成功になる(境界の出目)
+[[ test ]]
+game_system = "RuneQuestRoleplayingInGlorantha"
+input = "SRQG70"
+output = "(1D100<=70) ＞ 5 ＞ 効果的成功"
+success = true
+secret = true
+rands = [
+  { sides = 100, value = 5 },
+]
+
+# 四則演算 全部入り(成功率40%)
+[[ test ]]
+game_system = "RuneQuestRoleplayingInGlorantha"
+input = "SRQG60*2/4+20-10"
+output = "(1D100<=40) ＞ 40 ＞ 成功"
+success = true
+secret = true
+rands = [
+  { sides = 100, value = 40 },
 ]
 
 #===== バグ対応 ======#


### PR DESCRIPTION
【背景】
ルーンクエスト：ロールプレイイング イン グローランサ(以下RQG)のコマンドの記法は、同じBRPシステムであるクトゥルフ神話TRPGのものを参考にある程度の互換性を持つように実装した。その結果、RQGでも「CC<=90」と同じような「RQG<=90」というコマンド書式となったが、しかしこれはチャットパレットを自動生成可能なキャラクターシートサイトを持つクトゥルフ神話TRPGに比べて、手でコマンド入力する機会が多いRQGでは手間であった。

【修正】
そこで、手入力の手間を軽減するために新たな略記判定コマンド RQG[判定確率] を追加することとし、ヘルプ、テストケースも略記判定コマンドに対応した。