### PR TITLE
[TORG Eternity]コズムポシビリティに対応

### DIFF
--- a/test/data/TorgEternity.toml
+++ b/test/data/TorgEternity.toml
@@ -782,3 +782,33 @@ game_system = "TorgEternity"
 input = "POS"
 output = ""
 rands = []
+
+[[ test ]]
+game_system = "TorgEternity"
+input = "CPOS0"
+output = "d20ロール（ポシビリティ） ＞ 0+1d20[1] ＞ -10[1]"
+rands = [
+  { sides = 20, value = 1 },
+]
+
+[[ test ]]
+game_system = "TorgEternity"
+input = "CPOS8"
+output = "d20ロール（ポシビリティ） ＞ 8+1d20[5] ＞ +1[13]"
+rands = [
+  { sides = 20, value = 5 },
+]
+
+[[ test ]]
+game_system = "TorgEternity"
+input = "CPOS12"
+output = "d20ロール（ポシビリティ） ＞ 12+1d20[15] ＞ +9[27]"
+rands = [
+  { sides = 20, value = 15 },
+]
+
+[[ test ]]
+game_system = "TorgEternity"
+input = "CPOS"
+output = ""
+rands = []


### PR DESCRIPTION
TORG Eternity( http://www.shinkigensha.co.jp/book/978-4-7753-1928-4/ )に「コズムポシビリティ」のコマンドを追加しました。

        　・CPOS
        　　"CPOSm"で、コズムポシビリティ使用による1d20のロールを行います。
        　　mはポシビリティを使用する前のロール結果を入れて下さい。
        　　出目が10未満の場合でも、10への読み替えが行われません。
        　　振り足しは自動で行い、20の出目が出たときには技能無し値も並記します。

通常のポシビリティーとは違い、10未満の時に読み替えが発生しません。
また、ArithmeticEvaluatorをArithmeticに置き換えました。

以上、ご確認ください。