### PR TITLE
simplecov-coberturaのバージョンを3.1.0に変更

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,7 @@ group :development, :test do
   gem "rake", "~> 13.1.0"
   gem "rubocop", "~> 1.59.0", require: false
   gem "simplecov", "~> 0.21.2", require: false
-  gem "simplecov-cobertura", "~> 2.1.0", require: false
+  gem "simplecov-cobertura", "~> 3.1.0", require: false
   gem "test-unit", "~> 3.6.1", require: false
   gem "tomlrb", "~> 2.0.3", require: false
   gem "yard", "~> 0.9.34", require: false


### PR DESCRIPTION
https://github.com/bcdice/BCDice/actions/runs/17382920131 で発生したエラー対策
ruby/rexml#287 と同様のエラーのため、simplecov-coberturaのバージョンを jessebs/simplecov-cobertura#44 を含む3.1.0に変更