### PR TITLE
Add d/v options to Korean CoC7 Full Auto

### DIFF
--- a/lib/bcdice/game_system/Cthulhu7th_Korean.rb
+++ b/lib/bcdice/game_system/Cthulhu7th_Korean.rb
@@ -17,23 +17,36 @@ module BCDice
         ・판정　CC(x)<=（목표치）
         　x：보너스, 패널티 주사위：Bonus/Penalty Dice (2~-2). 생략 가능.
         　대실패：Fumble／실패：Failure／보통 성공：Regular success／
-        　어려운 성공：Hard success／대단한 성공：Extreme success／
+        　어려운 성공：Hard success／극단적 성공：Extreme success／
         　대성공：Critical success　을 자동판정.
         예）CC<=30　CC(2)<=50　CC(-1)<=75
 
         ・조합 판정　(CBR(x,y))
         　목표치 x 와 y 로 동시에 ％판정을 한다.
-        　예）CBR(50,20)
+        예）CBR(50,20)
 
-        ・연사(Full Auto)판정　FAR(w,x,y,z)
-        　w：탄수(1~100), x：기능 수치(1~100), y：고장 넘버
+        ・연사(Full Auto)판정　FAR(w,x,y,z,d,v)
+          w：탄수(1~100)
+        　x：기능 수치(1~100)
+        　y：고장 넘버
         　z：보너스, 패널티 주사위(-2~2). 생략 가능.
-        　명중수와 관통수, 잔탄수만을 계산. 데미지는 계산하지 않습니다.
+        　d：지정 난이도에 도달하면 연사를 중단 (보통=r, 어려움=h, 극단적=e). 생략 가능.
+        　v：연발(Volley) 탄수 상한을 변경. 생략 가능.
+        　※ 명중수/관통수/잔탄만 계산하며, 데미지는 계산하지 않습니다.
         예）FAR(25,70,98)　FAR(50,80,98,-1)
+            FAR(30,70,99,1,r)　FAR(25,88,96,2,h,5)
       INFO_MESSAGE_TEXT
 
       register_prefix('CC', 'CBR', 'FAR')
 
+      # 대단한 성공 > 극단적 성공으로 용어 수정
+      # 난이도 임계 상수 정의 추가 (일본 원본: FullAuto::BONUS_DICE_RANGE 와 같은 역할)
+      ROLL_FULL_AUTO_DIFFICULTY_THRESHOLD = {
+        "r" => 0,  # 보통 성공
+        "h" => 1,  # 어려운 성공
+        "e" => 2   # 극단적 성공
+      }.freeze
+      
       def initialize(command)
         super(command)
 
@@ -110,7 +123,7 @@ module BCDice
       def getCheckResultText(total, diff, fumbleable = false)
         if total <= diff
           return "대성공" if total == 1
-          return "대단한 성공" if total <= (diff / 5)
+          return "극단적 성공" if total <= (diff / 5)
           return "어려운 성공" if total <= (diff / 2)
 
           return "보통 성공"
@@ -142,7 +155,7 @@ module BCDice
         result_1 = getCheckResultText(total, diff_1)
         result_2 = getCheckResultText(total, diff_2)
 
-        successList = ["대성공", "대단한 성공", "어려운 성공", "보통성공"]
+        successList = ["대성공", "극단적 성공", "어려운 성공", "보통 성공"]
 
         succesCount = 0
         succesCount += 1 if successList.include?(result_1)
@@ -162,24 +175,42 @@ module BCDice
       end
 
       def getFullAutoResult(command)
-        return nil unless /^FAR\((-?\d+)(,(-?\d+))(,(-?\d+))(,(-?\d+))?\)/i =~ command
+        #return nil unless /^FAR\((-?\d+)(,(-?\d+))(,(-?\d+))(,(-?\d+))?\)/i =~ command
+        # FAR 인자 파싱을 일본판과 같은 6인자 형식으로 확장
+        m = /^FAR\((-?\d+),(-?\d+),(-?\d+)(?:,(-?\d+)?)?(?:,(-?\w+)?)?(?:,(-?\d+)?)?\)$/i.match(command)
+        return nil unless m
 
-        bullet_count = Regexp.last_match(1).to_i
-        diff = Regexp.last_match(3).to_i
-        broken_number = Regexp.last_match(5).to_i
-        bonus_dice_count = (Regexp.last_match(7) || 0).to_i
-
+        #bullet_count = Regexp.last_match(1).to_i
+        #diff = Regexp.last_match(3).to_i
+        #broken_number = Regexp.last_match(5).to_i
+        #bonus_dice_count = (Regexp.last_match(7) || 0).to_i
+        
+        bullet_count = m[1].to_i               # w
+        diff         = m[2].to_i               # x
+        broken_number = m[3].to_i              # y
+        bonus_dice_count = m[4].to_i           # z
+        stop_count   = m[5]&.downcase || ""    # d
+        bullet_set_count_cap = m[6]&.to_i || (diff / 10) # v
+       
         output = ""
 
         # 최대(8번*(PC기능 수치 최대값/10))＝72발밖에 쏠 수 없으니 상한
         bullet_count_limit = 100
         if bullet_count > bullet_count_limit
-          output += "\n탄약이 너무 많습니다. 장전된 탄약을 #{bullet_count_limit}개로 변경합니다.\n"
+          output += "\n탄약이 너무 많습니다. 장전된 탄약을 #{bullet_count_limit}발로 변경합니다.\n"
           bullet_count = bullet_count_limit
         end
 
         return "탄약은 1 이상입니다." if bullet_count <= 0
         return "목표치는 1 이상입니다." if diff <= 0
+
+        # 연발 상한은 (기능÷10(내림))
+        if (bullet_set_count_cap > diff / 10) && !m[6].nil?
+          bullet_set_count_cap = diff / 10
+          output += "연발 탄환 수 상한은 [기능÷10(내림)]발입니다. 그보다 높은 수를 지정할 수 없습니다. 연발 탄환 수를 #{bullet_set_count_cap}발로 변경합니다.\n"
+        end
+
+        return "연발 탄환 수는 1 이상이어야 합니다." if (bullet_set_count_cap <= 0) && !m[6].nil?
 
         if broken_number < 0
           output += "\n고장 넘버는 1 이상입니다. 마이너스 기호를 제거합니다.\n"
@@ -191,12 +222,15 @@ module BCDice
         end
 
         output += "보너스, 패널티 주사위 [#{bonus_dice_count}]"
-        output += rollFullAuto(bullet_count, diff, broken_number, bonus_dice_count)
-
+        #output += rollFullAuto(bullet_count, diff, broken_number, bonus_dice_count)
+        # d, v 추가
+        output += rollFullAuto(bullet_count, diff, broken_number, bonus_dice_count, stop_count, bullet_set_count_cap)
+        
         return output
       end
 
-      def rollFullAuto(bullet_count, diff, broken_number, dice_num)
+      # stop_count, bullet_set_count_cap 추가
+      def rollFullAuto(bullet_count, diff, broken_number, dice_num, stop_count, bullet_set_count_cap)
         output = ""
         loopCount = 0
 
@@ -223,7 +257,9 @@ module BCDice
             end
 
             hit_type = getHitType(more_difficlty, hit_result)
-            hit_bullet, impale_bullet, lost_bullet = getBulletResults(counts[:bullet], hit_type, diff)
+            #hit_bullet, impale_bullet, lost_bullet = getBulletResults(counts[:bullet], hit_type, diff)
+            # v 반영
+            hit_bullet, impale_bullet, lost_bullet = getBulletResults(counts[:bullet], hit_type, diff, bullet_set_count_cap)
 
             counts[:hit_bullet] += hit_bullet
             counts[:impale_bullet] += impale_bullet
@@ -234,10 +270,22 @@ module BCDice
             dice_num -= 1
           end
 
+          # d(지정 난이도) 도달 시 연사 중단
+          if shouldStopRollFullAuto?(stop_count, more_difficlty)
+            output += "\n지정 난이도에 도달하여 처리를 종료합니다."
+            break
+          end
+          
           dice_num += 1
         end
 
         return getHitResultText(output, counts)
+      end
+
+      # 일본판과 동일하게 d(난이도) 임계 도달 시 중단
+      def shouldStopRollFullAuto?(stop_count, difficulty)
+        threshold = ROLL_FULL_AUTO_DIFFICULTY_THRESHOLD[stop_count]
+        return threshold && difficulty >= threshold
       end
 
       def getHitResultInfos(dice_num, diff, more_difficlty)
@@ -264,8 +312,12 @@ module BCDice
         return ""
       end
 
-      def getBulletResults(bullet_count, hit_type, diff)
-        bullet_set_count = getSetOfBullet(diff)
+      # bullet_set_count_cap 추가
+      def getBulletResults(bullet_count, hit_type, diff, bullet_set_count_cap)
+        #bullet_set_count = getSetOfBullet(diff)
+        # 반영된 연발 계산
+        bullet_set_count = getSetOfBullet(diff, bullet_set_count_cap)
+        
         hit_bullet_count_base = getHitBulletCountBase(diff, bullet_set_count)
         impale_bullet_count_base = (bullet_set_count / 2.to_f)
 
@@ -293,10 +345,14 @@ module BCDice
             hit_bullet_count = getLastHitBulletCount(bullet_count)
 
           when :impale
-            halfbull = bullet_count / 2.to_f
-
-            hit_bullet_count = halfbull.floor
-            impale_bullet_count = halfbull.ceil
+            #halfbull = bullet_count / 2.to_f
+            #hit_bullet_count = halfbull.floor
+            #impale_bullet_count = halfbull.ceil
+            
+            # 일본판과 동일하게 수정
+            imp = getLastHitBulletCount(bullet_count) # 관통 수            
+            hit_bullet_count = bullet_count - imp # 나머지는 명중
+            impale_bullet_count = imp
           end
 
           lost_bullet_count = bullet_count
@@ -312,13 +368,13 @@ module BCDice
         case more_difficlty
         when 0
           successList = ["어려운 성공", "보통 성공"]
-          impaleBulletList = ["대성공", "대단한 성공"]
+          impaleBulletList = ["대성공", "극단적 성공"]
         when 1
           successList = ["어려운 성공"]
-          impaleBulletList = ["대성공", "대단한 성공"]
+          impaleBulletList = ["대성공", "극단적 성공"]
         when 2
           successList = []
-          impaleBulletList = ["대성공", "대단한 성공"]
+          impaleBulletList = ["대성공", "극단적 성공"]
         when 3
           successList = ["대성공"]
           impaleBulletList = []
@@ -332,7 +388,7 @@ module BCDice
         when 1
           return "\n    난이도가 어려운 성공으로 변경"
         when 2
-          return "\n    난이도가 대단한 성공으로 변경"
+          return "\n    난이도가 극단적 성공으로 변경"
         when 3
           return "\n    난이도가 대성공으로 변경"
         end
@@ -340,9 +396,15 @@ module BCDice
         return ""
       end
 
-      def getSetOfBullet(diff)
+      # bullet_set_count_cap 추가
+      def getSetOfBullet(diff, bullet_set_count_cap)
         bullet_set_count = diff / 10
 
+        # v(상한) 추가, 지정 상한이 기본값보다 작으면 상한으로 덮어쓰기
+        if bullet_set_count_cap && bullet_set_count_cap > 0 && bullet_set_count_cap < bullet_set_count
+          bullet_set_count = bullet_set_count_cap
+        end
+        
         if (diff >= 1) && (diff < 10)
           bullet_set_count = 1 # 기능 수치가 9 이하일 때의 최저수치 보장 처리
         end


### PR DESCRIPTION
### **變更內容**
韓国語版 『クトゥルフの呼び声 第7版』フルオート判定に、
日本語版で実装されている d（難易度で中断）、v（ボレー弾数上限）機能を追加しました。

**主なポイント**
- FAR(w,x,y,z) を FAR(w,x,y,z,d,v) へ拡張。
- d: 指定した難易度（r=レギュラー、h=ハード、e=イクストリーム）に到達したら連射を停止。
- v: ボレー（Volley）の弾数上限を変更可能。
- 既存の入力形式 FAR(w,x,y,z) はそのまま互換性を維持。

**期待効果**
日本語版と同等の機能を韓国語版でも利用可能にし、
ユーザーの混乱を減らし、多言語間のルールセット整合性を高めます。


### **변경 내용**
한국어판 「크툴루의 부름 7판」 Full Auto 판정에
일본어판에서 구현되어 있던 d(난이도 중단), v(연발 탄수 상한) 기능을 추가했습니다.

**주요 포인트**
- 기존 FAR(w,x,y,z) 인자 형식을 FAR(w,x,y,z,d,v)로 확장.
- d : 지정 난이도(r=보통, h=어려움, e=극단적)에 도달하면 연사 중단.
- v : 연발(Volley) 탄환 수 상한을 변경 가능.
- 기존 입력(FAR(w,x,y,z))은 그대로 호환됩니다.

**기대 효과**
일본어판과 동일한 기능을 한국어판에서도 활용할 수 있어,
사용자 혼란을 줄이고 국제 룰셋 호환성을 확보합니다.


### **Changes**
Added d (difficulty stop) and v (volley cap) options to the Korean version of Call of Cthulhu 7th Edition Full Auto roll, aligning with the Japanese implementation.

**Key Points**
- Extended FAR(w,x,y,z) → FAR(w,x,y,z,d,v).
- d: Stop rolling when reaching the specified difficulty (r=regular, h=hard, e=extreme).
- v: Change the maximum number of bullets per volley.
- Backward compatibility: existing FAR(w,x,y,z) calls remain valid.

**Expected Impact**
Provides feature parity with the Japanese version.
Reduces confusion for Korean users and improves cross-language ruleset consistency.