### PR TITLE
[fate core system](Update) Fudgeダイスにデフォルト値を設定など

### DIFF
--- a/lib/bcdice/game_system/FateCoreSystem.rb
+++ b/lib/bcdice/game_system/FateCoreSystem.rb
@@ -55,24 +55,7 @@ module BCDice
           end
         end
 
-        fate_dice_positive = 0
-        dice_list.each do |i|
-          if i.positive?
-            fate_dice_positive += 1
-          end
-        end
-
-        remarks = ""
-        target = 0
-        target = parsed.target_number if parsed.target_number
-        if fate_dice_positive == target
-          remarks = "(+0)"
-        elsif fate_dice_positive == target + 1
-          remarks = "(+1)"
-        end
-
         result = outcome(total, parsed.target_number)
-        result.text += remarks if result.text
         sequence = [
           "(#{parsed})",
           "#{fate_dice_list.join()}#{Format.modifier(parsed.modify_number)}",
@@ -122,7 +105,9 @@ module BCDice
         if target.nil?
           Result.new
         elsif total == target
-          Result.success("Tie")
+          Result.success("Tie(+0)")
+        elsif total == target + 1
+          Result.success("Succeed(+1)")
         elsif total >= target + 3
           Result.critical("Succeed with Style")
         elsif total >= target

--- a/test/data/FateCoreSystem.toml
+++ b/test/data/FateCoreSystem.toml
@@ -160,7 +160,7 @@ rands = [
 [[ test ]]
 game_system = "FateCoreSystem"
 input = "4DF>=3"
-output = "(4DF>=3) ＞ [+][+][+][+] ＞ Great(+4) ＞ Succeed"
+output = "(4DF>=3) ＞ [+][+][+][+] ＞ Great(+4) ＞ Succeed(+1)"
 success = true
 rands = [
   { sides = 3, value = 3 },
@@ -197,7 +197,7 @@ rands = [
 [[ test ]]
 game_system = "FateCoreSystem"
 input = "4DF+1>=3"
-output = "(4DF+1>=3) ＞ [+][+][+][-]+1 ＞ Good(+3) ＞ Tie"
+output = "(4DF+1>=3) ＞ [+][+][+][-]+1 ＞ Good(+3) ＞ Tie(+0)"
 success = true
 rands = [
   { sides = 3, value = 3 },
@@ -244,7 +244,7 @@ rands = [
 [[ test ]]
 game_system = "FateCoreSystem"
 input = "DF+1+2>=3"
-output = "(DF+3>=3) ＞ [+][ ][+][-]+3 ＞ Great(+4) ＞ Succeed"
+output = "(DF+3>=3) ＞ [+][ ][+][-]+3 ＞ Great(+4) ＞ Succeed(+1)"
 success = true
 rands = [
   { sides = 3, value = 3 },


### PR DESCRIPTION
Fate Core System( https://fate-srd.com/fate-core/basics )に以下の改修を加えました。

・Fudgeダイスをロールする際は、ダイスの数がデフォルトで4なのでダイスの個数を省略した際は4でロールするようにした。
・Fudgeダイス+修正値が、目標値と「同じ」か「1大きい」際にルール処理が特殊になるので、表示を目立つようにした。

コマンドはほぼ従来通りで、

        ■ ファッジダイスによる判定 (xDF+y>=t)
          ファッジダイスをx個ダイスロールし、結果を判定します。
          x: ダイス数(省略時4)
          y: 修正値（省略可）
          t: 目標値（省略可）
          例）4DF, 4DF>=3, 4DF+1>=3, DF, DF>=3, DF+1>=3

となります。

お手すきの際にでも、ご確認くださいませ。
