### PR TITLE
[VampireTheMasquerade5th] 日本語版発売に伴うタイトルの日本語化

### DIFF
--- a/lib/bcdice/game_system/VampireTheMasquerade5th.rb
+++ b/lib/bcdice/game_system/VampireTheMasquerade5th.rb
@@ -7,7 +7,7 @@ module BCDice
       ID = 'VampireTheMasquerade5th'
 
       # ゲームシステム名
-      NAME = 'Vampire: The Masquerade 5th Edition'
+      NAME = 'ヴァンパイア：ザ・マスカレード第５版'
 
       # ゲームシステム名の読みがな
       SORT_KEY = 'うあんはいあさますかれえと5'


### PR DESCRIPTION
**【背景】**
2026年4月16日、FrogGames公式アカウントより、日本語版が発売された。

https://x.com/Froggames_jp/status/2044575690813829205?s=20

**【対応】**
よって、タイトルを上記Tweet記載の「ヴァンパイア：ザ・マスカレード第５版」という日本語文言に変更する。