### PR TITLE
[HunterTheReckoning5th] ダイスプールが0以下の場合に1ダイスプールを補償の機能追加

### DIFF
--- a/lib/bcdice/game_system/HunterTheReckoning5th.rb
+++ b/lib/bcdice/game_system/HunterTheReckoning5th.rb
@@ -45,12 +45,15 @@ module BCDice
       register_prefix('\d*HRF')
 
       def eval_game_system_specific_command(command)
-        m = /\A(\d+)?(HRF)(\d+)(\+(\d+))?$/.match(command)
+        m = /\A(\d+)?(HRF)(-?\d+)(\+(\d+))?$/.match(command)
         unless m
           return ''
         end
 
         dice_pool = m[DICE_POOL_INDEX].to_i
+        if dice_pool <= 0
+          dice_pool = 1
+        end
         dice_text, success_dice, ten_dice, = make_dice_roll(dice_pool)
         result_text = "(#{dice_pool}D10"
 

--- a/lib/bcdice/game_system/HunterTheReckoning5th.rb
+++ b/lib/bcdice/game_system/HunterTheReckoning5th.rb
@@ -52,6 +52,7 @@ module BCDice
 
         dice_pool = m[DICE_POOL_INDEX].to_i
         if dice_pool <= 0
+          # ダイスプールが0以下のとき、最低保証ダイスプールであるダイスプール1にする
           dice_pool = 1
         end
         dice_text, success_dice, ten_dice, = make_dice_roll(dice_pool)

--- a/test/data/HunterTheReckoning5th.toml
+++ b/test/data/HunterTheReckoning5th.toml
@@ -828,3 +828,33 @@ rands = [
   { sides = 10, value = 3 },
   { sides = 10, value = 10 },
 ]
+
+# ダイスプールが0指定
+[[ test ]]
+game_system = "HunterTheReckoning5th"
+input = "3HRF0+5"
+output = "(1D10+5D10) ＞ [4]+[6,6,5,3,10]  成功数=3 難易度=3 差分=0：判定成功!"
+success = true
+rands = [
+  { sides = 10, value = 4 },
+  { sides = 10, value = 6 },
+  { sides = 10, value = 6 },
+  { sides = 10, value = 5 },
+  { sides = 10, value = 3 },
+  { sides = 10, value = 10 },
+]
+
+# ダイスプールがマイナス指定
+[[ test ]]
+game_system = "HunterTheReckoning5th"
+input = "3HRF-1+5"
+output = "(1D10+5D10) ＞ [4]+[6,6,5,3,10]  成功数=3 難易度=3 差分=0：判定成功!"
+success = true
+rands = [
+  { sides = 10, value = 4 },
+  { sides = 10, value = 6 },
+  { sides = 10, value = 6 },
+  { sides = 10, value = 5 },
+  { sides = 10, value = 3 },
+  { sides = 10, value = 10 },
+]


### PR DESCRIPTION
【背景】
H5の判定ルールでは、ダイスプールが0以下にならない（判定可能なものは必ずダイスプール１での判定となる）、またダイスプール修正でも0以下にならないとなっている（下記参照）。なお、反対解釈としては大きくマイナスに食い込むほどのペナルティならST判断で「判定不可能」としてもよい、という運用かと思われる（無駄な判定はそもそもさせない、という思想は５版系システムに通底している）。
現状のH5ダイスボットは、0～マイナスのダイスプールを正常に受け付けていなかったため、0からマイナスのダイスプール指定を受け付ける機能を追加する。マイナスのダイスプール指定を受けつけることによって、オンラインセッションツール上などでダイスプールを計算して指定する際も問題なく判定を行うことが可能となる。

【対応】
・ダイスプールのマイナス指定を受け入れるように修正
・0以下のダイスプールを指定しても1d10で判定を行うように修正

【参考】
H5コアルール、該当部分抜粋

p111-112 Dice Pools
> Traits usually have ratings between 0 and 5, so pools generally range from one die (the minimum pool size, if you can roll at all) to ten dice or more.

p114 Modifiers
> Penalties can never cause a pool to drop below one die.