### PR TITLE
[HunterTheReckoning5th] H5の用語をV5日本語版準拠の訳語に変更

### DIFF
--- a/lib/bcdice/game_system/HunterTheReckoning5th.rb
+++ b/lib/bcdice/game_system/HunterTheReckoning5th.rb
@@ -15,16 +15,16 @@ module BCDice
       # ダイスボットの使い方
       HELP_MESSAGE = <<~MESSAGETEXT
         ・判定コマンド(nHRFx+x)
-          注意：難易度は必要成功数を表す
+          注意：難易度は必要達成数を表す
 
-          難易度指定：成功数のカウント、判定成功と失敗、Critical処理、Critical Win、Total Failureのチェックを行う
+          難易度指定：達成数のカウント、判定成功と失敗、クリティカル処理、クリティカル成功、完全失敗のチェックを行う
                      （Desperationダイスがある場合）OverreachとDespairの発生チェックを行う
           例) (難易度)HRF(通常ダイス)+(Desperationダイス)
               (難易度)HRF(通常ダイス)
 
-          難易度省略：成功数のカウント、判定失敗、Critical処理、Total Failure、（Desperationダイスがある場合）Despairチェックを行う
+          難易度省略：達成数のカウント、判定失敗、クリティカル処理、完全失敗、（Desperationダイスがある場合）Despairチェックを行う
                       判定成功、Overreachのチェックを行わない
-                      Critical Win、（Desperationダイスがある場合）Despair、Overreachのヒントを出力
+                      クリティカル成功、（Desperationダイスがある場合）Despair、Overreachのヒントを出力
           例) HRF(通常ダイス)+(Desperationダイス)
               HRF(通常ダイス)
 
@@ -82,7 +82,7 @@ module BCDice
       private
 
       def get_roll_result(result_text, success_dice, ten_dice, _desperaton_ten_dice, desperaton_botch_dice, difficulty)
-        result_text = "#{result_text} 成功数=#{success_dice}"
+        result_text = "#{result_text} 達成数=#{success_dice}"
         is_critical = ten_dice >= 2
         desperation_result = ""
 
@@ -90,14 +90,14 @@ module BCDice
           result_text = "#{result_text} 難易度=#{difficulty}"
 
           if success_dice >= difficulty
-            result_text = "#{result_text} 差分=#{success_dice - difficulty}"
+            result_text = "#{result_text} 上回り=#{success_dice - difficulty}"
 
             if desperaton_botch_dice > 0
               desperation_result = " [Overreach or Despair?]"
             end
 
             if is_critical
-              return Result.critical("#{result_text}：判定成功! [Critical Win]#{desperation_result}")
+              return Result.critical("#{result_text}：判定成功! [クリティカル成功/Critical Win]#{desperation_result}")
             else
               return Result.success("#{result_text}：判定成功!#{desperation_result}")
             end
@@ -107,7 +107,7 @@ module BCDice
               return Result.fumble("#{result_text}：判定失敗! [Despair]")
             end
             if success_dice == 0
-              return Result.fumble("#{result_text}：判定失敗! [Total Failure]")
+              return Result.fumble("#{result_text}：判定失敗! [完全失敗/Total Failure]")
             end
 
             return Result.failure("#{result_text}：判定失敗!")
@@ -118,7 +118,7 @@ module BCDice
               return Result.fumble("#{result_text}：判定失敗! [Despair]")
             end
 
-            return Result.fumble("#{result_text}：判定失敗! [Total Failure]")
+            return Result.fumble("#{result_text}：判定失敗! [完全失敗/Total Failure]")
           else
             if desperaton_botch_dice > 0
               result_text = "#{result_text}\n　判定失敗なら [Despair]"
@@ -126,7 +126,7 @@ module BCDice
             end
 
             if is_critical
-              result_text = "#{result_text}\n　判定成功なら [Critical Win]"
+              result_text = "#{result_text}\n　判定成功なら [クリティカル成功/Critical Win]"
             elsif desperaton_botch_dice > 0
               result_text = "#{result_text}\n　判定成功なら"
             end

--- a/test/data/HunterTheReckoning5th.toml
+++ b/test/data/HunterTheReckoning5th.toml
@@ -1,7 +1,7 @@
 [[ test ]]
 game_system = "HunterTheReckoning5th"
 input = "3HRF3"
-output = "(3D10) ＞ [1,2,5]  成功数=0 難易度=3：判定失敗! [Total Failure]"
+output = "(3D10) ＞ [1,2,5]  達成数=0 難易度=3：判定失敗! [完全失敗/Total Failure]"
 failure = true
 fumble = true
 rands = [
@@ -13,7 +13,7 @@ rands = [
 [[ test ]]
 game_system = "HunterTheReckoning5th"
 input = "3HRF3"
-output = "(3D10) ＞ [2,6,10]  成功数=2 難易度=3：判定失敗!"
+output = "(3D10) ＞ [2,6,10]  達成数=2 難易度=3：判定失敗!"
 failure = true
 rands = [
   { sides = 10, value = 2 },
@@ -24,7 +24,7 @@ rands = [
 [[ test ]]
 game_system = "HunterTheReckoning5th"
 input = "3HRF3"
-output = "(3D10) ＞ [7,9,6]  成功数=3 難易度=3 差分=0：判定成功!"
+output = "(3D10) ＞ [7,9,6]  達成数=3 難易度=3 上回り=0：判定成功!"
 success = true
 rands = [
   { sides = 10, value = 7 },
@@ -35,7 +35,7 @@ rands = [
 [[ test ]]
 game_system = "HunterTheReckoning5th"
 input = "3HRF3"
-output = "(3D10) ＞ [2,10,10]  成功数=4 難易度=3 差分=1：判定成功! [Critical Win]"
+output = "(3D10) ＞ [2,10,10]  達成数=4 難易度=3 上回り=1：判定成功! [クリティカル成功/Critical Win]"
 success = true
 critical = true
 rands = [
@@ -47,7 +47,7 @@ rands = [
 [[ test ]]
 game_system = "HunterTheReckoning5th"
 input = "3HRF5"
-output = "(5D10) ＞ [10,10,10,10,10]  成功数=9 難易度=3 差分=6：判定成功! [Critical Win]"
+output = "(5D10) ＞ [10,10,10,10,10]  達成数=9 難易度=3 上回り=6：判定成功! [クリティカル成功/Critical Win]"
 success = true
 critical = true
 rands = [
@@ -61,7 +61,7 @@ rands = [
 [[ test ]]
 game_system = "HunterTheReckoning5th"
 input = "3HRF3+2"
-output = "(3D10+2D10) ＞ [2,5,9]+[2,6]  成功数=2 難易度=3：判定失敗!"
+output = "(3D10+2D10) ＞ [2,5,9]+[2,6]  達成数=2 難易度=3：判定失敗!"
 failure = true
 rands = [
   { sides = 10, value = 2 },
@@ -74,7 +74,7 @@ rands = [
 [[ test ]]
 game_system = "HunterTheReckoning5th"
 input = "3HRF3+2"
-output = "(3D10+2D10) ＞ [2,5,9]+[1,2]  成功数=1 難易度=3：判定失敗! [Despair]"
+output = "(3D10+2D10) ＞ [2,5,9]+[1,2]  達成数=1 難易度=3：判定失敗! [Despair]"
 failure = true
 fumble = true
 rands = [
@@ -88,7 +88,7 @@ rands = [
 [[ test ]]
 game_system = "HunterTheReckoning5th"
 input = "3HRF3+2"
-output = "(3D10+2D10) ＞ [8,2,6]+[1,7]  成功数=3 難易度=3 差分=0：判定成功! [Overreach or Despair?]"
+output = "(3D10+2D10) ＞ [8,2,6]+[1,7]  達成数=3 難易度=3 上回り=0：判定成功! [Overreach or Despair?]"
 success = true
 rands = [
   { sides = 10, value = 8 },
@@ -101,7 +101,7 @@ rands = [
 [[ test ]]
 game_system = "HunterTheReckoning5th"
 input = "3HRF3+2"
-output = "(3D10+2D10) ＞ [10,10,10]+[4,7]  成功数=6 難易度=3 差分=3：判定成功! [Critical Win]"
+output = "(3D10+2D10) ＞ [10,10,10]+[4,7]  達成数=6 難易度=3 上回り=3：判定成功! [クリティカル成功/Critical Win]"
 success = true
 critical = true
 rands = [
@@ -115,7 +115,7 @@ rands = [
 [[ test ]]
 game_system = "HunterTheReckoning5th"
 input = "3HRF3+2"
-output = "(3D10+2D10) ＞ [10,10,6]+[1,10]  成功数=6 難易度=3 差分=3：判定成功! [Critical Win] [Overreach or Despair?]"
+output = "(3D10+2D10) ＞ [10,10,6]+[1,10]  達成数=6 難易度=3 上回り=3：判定成功! [クリティカル成功/Critical Win] [Overreach or Despair?]"
 success = true
 critical = true
 rands = [
@@ -129,7 +129,7 @@ rands = [
 [[ test ]]
 game_system = "HunterTheReckoning5th"
 input = "3HRF3+2"
-output = "(3D10+2D10) ＞ [10,8,6]+[1,10]  成功数=6 難易度=3 差分=3：判定成功! [Critical Win] [Overreach or Despair?]"
+output = "(3D10+2D10) ＞ [10,8,6]+[1,10]  達成数=6 難易度=3 上回り=3：判定成功! [クリティカル成功/Critical Win] [Overreach or Despair?]"
 success = true
 critical = true
 rands = [
@@ -143,7 +143,7 @@ rands = [
 [[ test ]]
 game_system = "HunterTheReckoning5th"
 input = "3HRF3+2"
-output = "(3D10+2D10) ＞ [1,4,5]+[10,10]  成功数=4 難易度=3 差分=1：判定成功! [Critical Win]"
+output = "(3D10+2D10) ＞ [1,4,5]+[10,10]  達成数=4 難易度=3 上回り=1：判定成功! [クリティカル成功/Critical Win]"
 success = true
 critical = true
 rands = [
@@ -157,7 +157,7 @@ rands = [
 [[ test ]]
 game_system = "HunterTheReckoning5th"
 input = "3HRF3+2"
-output = "(3D10+2D10) ＞ [1,4,7]+[6,6]  成功数=3 難易度=3 差分=0：判定成功!"
+output = "(3D10+2D10) ＞ [1,4,7]+[6,6]  達成数=3 難易度=3 上回り=0：判定成功!"
 success = true
 rands = [
   { sides = 10, value = 1 },
@@ -170,7 +170,7 @@ rands = [
 [[ test ]]
 game_system = "HunterTheReckoning5th"
 input = "HRF3"
-output = "(3D10) ＞ [2,5,1]  成功数=0：判定失敗! [Total Failure]"
+output = "(3D10) ＞ [2,5,1]  達成数=0：判定失敗! [完全失敗/Total Failure]"
 failure = true
 fumble = true
 rands = [
@@ -182,7 +182,7 @@ rands = [
 [[ test ]]
 game_system = "HunterTheReckoning5th"
 input = "HRF3"
-output = "(3D10) ＞ [2,6,1]  成功数=1"
+output = "(3D10) ＞ [2,6,1]  達成数=1"
 rands = [
   { sides = 10, value = 2 },
   { sides = 10, value = 6 },
@@ -192,7 +192,7 @@ rands = [
 [[ test ]]
 game_system = "HunterTheReckoning5th"
 input = "HRF3"
-output = "(3D10) ＞ [10,10,4]  成功数=4\n　判定成功なら [Critical Win]"
+output = "(3D10) ＞ [10,10,4]  達成数=4\n　判定成功なら [クリティカル成功/Critical Win]"
 rands = [
   { sides = 10, value = 10 },
   { sides = 10, value = 10 },
@@ -202,7 +202,7 @@ rands = [
 [[ test ]]
 game_system = "HunterTheReckoning5th"
 input = "HRF3+2"
-output = "(3D10+2D10) ＞ [2,5,1]+[6,3]  成功数=1"
+output = "(3D10+2D10) ＞ [2,5,1]+[6,3]  達成数=1"
 rands = [
   { sides = 10, value = 2 },
   { sides = 10, value = 5 },
@@ -214,7 +214,7 @@ rands = [
 [[ test ]]
 game_system = "HunterTheReckoning5th"
 input = "HRF3+2"
-output = "(3D10+2D10) ＞ [2,5,1]+[4,3]  成功数=0：判定失敗! [Total Failure]"
+output = "(3D10+2D10) ＞ [2,5,1]+[4,3]  達成数=0：判定失敗! [完全失敗/Total Failure]"
 failure = true
 fumble = true
 rands = [
@@ -228,7 +228,7 @@ rands = [
 [[ test ]]
 game_system = "HunterTheReckoning5th"
 input = "HRF3+2"
-output = "(3D10+2D10) ＞ [2,5,1]+[4,1]  成功数=0：判定失敗! [Despair]"
+output = "(3D10+2D10) ＞ [2,5,1]+[4,1]  達成数=0：判定失敗! [Despair]"
 failure = true
 fumble = true
 rands = [
@@ -242,7 +242,7 @@ rands = [
 [[ test ]]
 game_system = "HunterTheReckoning5th"
 input = "HRF3+2"
-output = "(3D10+2D10) ＞ [2,5,8]+[1,6]  成功数=2\n　判定失敗なら [Despair]\n　判定成功なら [Overreach or Despair?]"
+output = "(3D10+2D10) ＞ [2,5,8]+[1,6]  達成数=2\n　判定失敗なら [Despair]\n　判定成功なら [Overreach or Despair?]"
 rands = [
   { sides = 10, value = 2 },
   { sides = 10, value = 5 },
@@ -254,7 +254,7 @@ rands = [
 [[ test ]]
 game_system = "HunterTheReckoning5th"
 input = "HRF3+2"
-output = "(3D10+2D10) ＞ [2,5,8]+[10,10]  成功数=5\n　判定成功なら [Critical Win]"
+output = "(3D10+2D10) ＞ [2,5,8]+[10,10]  達成数=5\n　判定成功なら [クリティカル成功/Critical Win]"
 rands = [
   { sides = 10, value = 2 },
   { sides = 10, value = 5 },
@@ -266,7 +266,7 @@ rands = [
 [[ test ]]
 game_system = "HunterTheReckoning5th"
 input = "HRF3+2"
-output = "(3D10+2D10) ＞ [2,10,10]+[1,6]  成功数=5\n　判定失敗なら [Despair]\n　判定成功なら [Critical Win] [Overreach or Despair?]"
+output = "(3D10+2D10) ＞ [2,10,10]+[1,6]  達成数=5\n　判定失敗なら [Despair]\n　判定成功なら [クリティカル成功/Critical Win] [Overreach or Despair?]"
 rands = [
   { sides = 10, value = 2 },
   { sides = 10, value = 10 },
@@ -278,7 +278,7 @@ rands = [
 [[ test ]]
 game_system = "HunterTheReckoning5th"
 input = "HRF3+2"
-output = "(3D10+2D10) ＞ [2,10,10]+[10,1]  成功数=5\n　判定失敗なら [Despair]\n　判定成功なら [Critical Win] [Overreach or Despair?]"
+output = "(3D10+2D10) ＞ [2,10,10]+[10,1]  達成数=5\n　判定失敗なら [Despair]\n　判定成功なら [クリティカル成功/Critical Win] [Overreach or Despair?]"
 rands = [
   { sides = 10, value = 2 },
   { sides = 10, value = 10 },
@@ -290,7 +290,7 @@ rands = [
 [[ test ]]
 game_system = "HunterTheReckoning5th"
 input = "HRF3+2"
-output = "(3D10+2D10) ＞ [1,4,7]+[6,6]  成功数=3"
+output = "(3D10+2D10) ＞ [1,4,7]+[6,6]  達成数=3"
 rands = [
   { sides = 10, value = 1 },
   { sides = 10, value = 4 },
@@ -302,7 +302,7 @@ rands = [
 [[ test ]]
 game_system = "HunterTheReckoning5th"
 input = "0HRF3"
-output = "(3D10) ＞ [5,4,3]  成功数=0"
+output = "(3D10) ＞ [5,4,3]  達成数=0"
 rands = [
   { sides = 10, value = 5 },
   { sides = 10, value = 4 },
@@ -312,7 +312,7 @@ rands = [
 [[ test ]]
 game_system = "HunterTheReckoning5th"
 input = "0HRF3"
-output = "(3D10) ＞ [6,4,8]  成功数=2"
+output = "(3D10) ＞ [6,4,8]  達成数=2"
 rands = [
   { sides = 10, value = 6 },
   { sides = 10, value = 4 },
@@ -322,7 +322,7 @@ rands = [
 [[ test ]]
 game_system = "HunterTheReckoning5th"
 input = "0HRF3+3"
-output = "(3D10+3D10) ＞ [1,4,2]+[5,1,3]  成功数=0"
+output = "(3D10+3D10) ＞ [1,4,2]+[5,1,3]  達成数=0"
 rands = [
   { sides = 10, value = 1 },
   { sides = 10, value = 4 },
@@ -335,7 +335,7 @@ rands = [
 [[ test ]]
 game_system = "HunterTheReckoning5th"
 input = "0HRF3+3"
-output = "(3D10+3D10) ＞ [1,8,2]+[5,1,6]  成功数=2"
+output = "(3D10+3D10) ＞ [1,8,2]+[5,1,6]  達成数=2"
 rands = [
   { sides = 10, value = 1 },
   { sides = 10, value = 8 },
@@ -348,7 +348,7 @@ rands = [
 [[ test ]]
 game_system = "HunterTheReckoning5th"
 input = "0HRF3+3"
-output = "(3D10+3D10) ＞ [1,10,10]+[2,1,7]  成功数=5"
+output = "(3D10+3D10) ＞ [1,10,10]+[2,1,7]  達成数=5"
 rands = [
   { sides = 10, value = 1 },
   { sides = 10, value = 10 },
@@ -361,7 +361,7 @@ rands = [
 [[ test ]]
 game_system = "HunterTheReckoning5th"
 input = "0HRF3+3"
-output = "(3D10+3D10) ＞ [4,10,10]+[10,3,10]  成功数=8"
+output = "(3D10+3D10) ＞ [4,10,10]+[10,3,10]  達成数=8"
 rands = [
   { sides = 10, value = 4 },
   { sides = 10, value = 10 },
@@ -374,7 +374,7 @@ rands = [
 [[ test ]]
 game_system = "HunterTheReckoning5th"
 input = "0HRF3+2"
-output = "(3D10+2D10) ＞ [1,4,7]+[6,6]  成功数=3"
+output = "(3D10+2D10) ＞ [1,4,7]+[6,6]  達成数=3"
 rands = [
   { sides = 10, value = 1 },
   { sides = 10, value = 4 },
@@ -386,7 +386,7 @@ rands = [
 [[ test ]]
 game_system = "HunterTheReckoning5th"
 input = "S3HRF3"
-output = "(3D10) ＞ [1,2,5]  成功数=0 難易度=3：判定失敗! [Total Failure]"
+output = "(3D10) ＞ [1,2,5]  達成数=0 難易度=3：判定失敗! [完全失敗/Total Failure]"
 failure = true
 fumble = true
 secret = true
@@ -399,7 +399,7 @@ rands = [
 [[ test ]]
 game_system = "HunterTheReckoning5th"
 input = "S3HRF3"
-output = "(3D10) ＞ [2,6,10]  成功数=2 難易度=3：判定失敗!"
+output = "(3D10) ＞ [2,6,10]  達成数=2 難易度=3：判定失敗!"
 failure = true
 secret = true
 rands = [
@@ -411,7 +411,7 @@ rands = [
 [[ test ]]
 game_system = "HunterTheReckoning5th"
 input = "S3HRF3"
-output = "(3D10) ＞ [7,9,6]  成功数=3 難易度=3 差分=0：判定成功!"
+output = "(3D10) ＞ [7,9,6]  達成数=3 難易度=3 上回り=0：判定成功!"
 success = true
 secret = true
 rands = [
@@ -423,7 +423,7 @@ rands = [
 [[ test ]]
 game_system = "HunterTheReckoning5th"
 input = "S3HRF3"
-output = "(3D10) ＞ [2,10,10]  成功数=4 難易度=3 差分=1：判定成功! [Critical Win]"
+output = "(3D10) ＞ [2,10,10]  達成数=4 難易度=3 上回り=1：判定成功! [クリティカル成功/Critical Win]"
 success = true
 critical = true
 secret = true
@@ -436,7 +436,7 @@ rands = [
 [[ test ]]
 game_system = "HunterTheReckoning5th"
 input = "S3HRF5"
-output = "(5D10) ＞ [10,10,10,10,10]  成功数=9 難易度=3 差分=6：判定成功! [Critical Win]"
+output = "(5D10) ＞ [10,10,10,10,10]  達成数=9 難易度=3 上回り=6：判定成功! [クリティカル成功/Critical Win]"
 success = true
 critical = true
 secret = true
@@ -451,7 +451,7 @@ rands = [
 [[ test ]]
 game_system = "HunterTheReckoning5th"
 input = "S3HRF3+2"
-output = "(3D10+2D10) ＞ [2,5,9]+[2,6]  成功数=2 難易度=3：判定失敗!"
+output = "(3D10+2D10) ＞ [2,5,9]+[2,6]  達成数=2 難易度=3：判定失敗!"
 failure = true
 secret = true
 rands = [
@@ -465,7 +465,7 @@ rands = [
 [[ test ]]
 game_system = "HunterTheReckoning5th"
 input = "S3HRF3+2"
-output = "(3D10+2D10) ＞ [2,5,9]+[1,2]  成功数=1 難易度=3：判定失敗! [Despair]"
+output = "(3D10+2D10) ＞ [2,5,9]+[1,2]  達成数=1 難易度=3：判定失敗! [Despair]"
 failure = true
 fumble = true
 secret = true
@@ -480,7 +480,7 @@ rands = [
 [[ test ]]
 game_system = "HunterTheReckoning5th"
 input = "S3HRF3+2"
-output = "(3D10+2D10) ＞ [8,2,6]+[1,7]  成功数=3 難易度=3 差分=0：判定成功! [Overreach or Despair?]"
+output = "(3D10+2D10) ＞ [8,2,6]+[1,7]  達成数=3 難易度=3 上回り=0：判定成功! [Overreach or Despair?]"
 success = true
 secret = true
 rands = [
@@ -494,7 +494,7 @@ rands = [
 [[ test ]]
 game_system = "HunterTheReckoning5th"
 input = "S3HRF3+2"
-output = "(3D10+2D10) ＞ [10,10,10]+[4,7]  成功数=6 難易度=3 差分=3：判定成功! [Critical Win]"
+output = "(3D10+2D10) ＞ [10,10,10]+[4,7]  達成数=6 難易度=3 上回り=3：判定成功! [クリティカル成功/Critical Win]"
 success = true
 critical = true
 secret = true
@@ -509,7 +509,7 @@ rands = [
 [[ test ]]
 game_system = "HunterTheReckoning5th"
 input = "S3HRF3+2"
-output = "(3D10+2D10) ＞ [10,10,6]+[1,10]  成功数=6 難易度=3 差分=3：判定成功! [Critical Win] [Overreach or Despair?]"
+output = "(3D10+2D10) ＞ [10,10,6]+[1,10]  達成数=6 難易度=3 上回り=3：判定成功! [クリティカル成功/Critical Win] [Overreach or Despair?]"
 success = true
 critical = true
 secret = true
@@ -524,7 +524,7 @@ rands = [
 [[ test ]]
 game_system = "HunterTheReckoning5th"
 input = "S3HRF3+2"
-output = "(3D10+2D10) ＞ [10,8,6]+[1,10]  成功数=6 難易度=3 差分=3：判定成功! [Critical Win] [Overreach or Despair?]"
+output = "(3D10+2D10) ＞ [10,8,6]+[1,10]  達成数=6 難易度=3 上回り=3：判定成功! [クリティカル成功/Critical Win] [Overreach or Despair?]"
 success = true
 critical = true
 secret = true
@@ -539,7 +539,7 @@ rands = [
 [[ test ]]
 game_system = "HunterTheReckoning5th"
 input = "S3HRF3+2"
-output = "(3D10+2D10) ＞ [1,4,5]+[10,10]  成功数=4 難易度=3 差分=1：判定成功! [Critical Win]"
+output = "(3D10+2D10) ＞ [1,4,5]+[10,10]  達成数=4 難易度=3 上回り=1：判定成功! [クリティカル成功/Critical Win]"
 success = true
 critical = true
 secret = true
@@ -554,7 +554,7 @@ rands = [
 [[ test ]]
 game_system = "HunterTheReckoning5th"
 input = "S3HRF3+2"
-output = "(3D10+2D10) ＞ [1,4,7]+[6,6]  成功数=3 難易度=3 差分=0：判定成功!"
+output = "(3D10+2D10) ＞ [1,4,7]+[6,6]  達成数=3 難易度=3 上回り=0：判定成功!"
 success = true
 secret = true
 rands = [
@@ -568,7 +568,7 @@ rands = [
 [[ test ]]
 game_system = "HunterTheReckoning5th"
 input = "SHRF3"
-output = "(3D10) ＞ [2,5,1]  成功数=0：判定失敗! [Total Failure]"
+output = "(3D10) ＞ [2,5,1]  達成数=0：判定失敗! [完全失敗/Total Failure]"
 failure = true
 fumble = true
 secret = true
@@ -581,7 +581,7 @@ rands = [
 [[ test ]]
 game_system = "HunterTheReckoning5th"
 input = "SHRF3"
-output = "(3D10) ＞ [2,6,1]  成功数=1"
+output = "(3D10) ＞ [2,6,1]  達成数=1"
 secret = true
 rands = [
   { sides = 10, value = 2 },
@@ -592,7 +592,7 @@ rands = [
 [[ test ]]
 game_system = "HunterTheReckoning5th"
 input = "SHRF3"
-output = "(3D10) ＞ [10,10,4]  成功数=4\n　判定成功なら [Critical Win]"
+output = "(3D10) ＞ [10,10,4]  達成数=4\n　判定成功なら [クリティカル成功/Critical Win]"
 secret = true
 rands = [
   { sides = 10, value = 10 },
@@ -603,7 +603,7 @@ rands = [
 [[ test ]]
 game_system = "HunterTheReckoning5th"
 input = "SHRF3+2"
-output = "(3D10+2D10) ＞ [2,5,1]+[4,3]  成功数=0：判定失敗! [Total Failure]"
+output = "(3D10+2D10) ＞ [2,5,1]+[4,3]  達成数=0：判定失敗! [完全失敗/Total Failure]"
 failure = true
 fumble = true
 secret = true
@@ -618,7 +618,7 @@ rands = [
 [[ test ]]
 game_system = "HunterTheReckoning5th"
 input = "SHRF3+2"
-output = "(3D10+2D10) ＞ [2,5,1]+[6,3]  成功数=1"
+output = "(3D10+2D10) ＞ [2,5,1]+[6,3]  達成数=1"
 secret = true
 rands = [
   { sides = 10, value = 2 },
@@ -631,7 +631,7 @@ rands = [
 [[ test ]]
 game_system = "HunterTheReckoning5th"
 input = "SHRF3+2"
-output = "(3D10+2D10) ＞ [2,5,1]+[4,1]  成功数=0：判定失敗! [Despair]"
+output = "(3D10+2D10) ＞ [2,5,1]+[4,1]  達成数=0：判定失敗! [Despair]"
 failure = true
 fumble = true
 secret = true
@@ -646,7 +646,7 @@ rands = [
 [[ test ]]
 game_system = "HunterTheReckoning5th"
 input = "SHRF3+2"
-output = "(3D10+2D10) ＞ [2,5,8]+[1,6]  成功数=2\n　判定失敗なら [Despair]\n　判定成功なら [Overreach or Despair?]"
+output = "(3D10+2D10) ＞ [2,5,8]+[1,6]  達成数=2\n　判定失敗なら [Despair]\n　判定成功なら [Overreach or Despair?]"
 secret = true
 rands = [
   { sides = 10, value = 2 },
@@ -659,7 +659,7 @@ rands = [
 [[ test ]]
 game_system = "HunterTheReckoning5th"
 input = "SHRF3+2"
-output = "(3D10+2D10) ＞ [2,5,8]+[10,10]  成功数=5\n　判定成功なら [Critical Win]"
+output = "(3D10+2D10) ＞ [2,5,8]+[10,10]  達成数=5\n　判定成功なら [クリティカル成功/Critical Win]"
 secret = true
 rands = [
   { sides = 10, value = 2 },
@@ -672,7 +672,7 @@ rands = [
 [[ test ]]
 game_system = "HunterTheReckoning5th"
 input = "SHRF3+2"
-output = "(3D10+2D10) ＞ [2,10,10]+[1,6]  成功数=5\n　判定失敗なら [Despair]\n　判定成功なら [Critical Win] [Overreach or Despair?]"
+output = "(3D10+2D10) ＞ [2,10,10]+[1,6]  達成数=5\n　判定失敗なら [Despair]\n　判定成功なら [クリティカル成功/Critical Win] [Overreach or Despair?]"
 secret = true
 rands = [
   { sides = 10, value = 2 },
@@ -685,7 +685,7 @@ rands = [
 [[ test ]]
 game_system = "HunterTheReckoning5th"
 input = "SHRF3+2"
-output = "(3D10+2D10) ＞ [2,10,10]+[10,1]  成功数=5\n　判定失敗なら [Despair]\n　判定成功なら [Critical Win] [Overreach or Despair?]"
+output = "(3D10+2D10) ＞ [2,10,10]+[10,1]  達成数=5\n　判定失敗なら [Despair]\n　判定成功なら [クリティカル成功/Critical Win] [Overreach or Despair?]"
 secret = true
 rands = [
   { sides = 10, value = 2 },
@@ -698,7 +698,7 @@ rands = [
 [[ test ]]
 game_system = "HunterTheReckoning5th"
 input = "SHRF3+2"
-output = "(3D10+2D10) ＞ [1,4,7]+[6,6]  成功数=3"
+output = "(3D10+2D10) ＞ [1,4,7]+[6,6]  達成数=3"
 secret = true
 rands = [
   { sides = 10, value = 1 },
@@ -711,7 +711,7 @@ rands = [
 [[ test ]]
 game_system = "HunterTheReckoning5th"
 input = "S0HRF3"
-output = "(3D10) ＞ [5,4,3]  成功数=0"
+output = "(3D10) ＞ [5,4,3]  達成数=0"
 secret = true
 rands = [
   { sides = 10, value = 5 },
@@ -722,7 +722,7 @@ rands = [
 [[ test ]]
 game_system = "HunterTheReckoning5th"
 input = "S0HRF3"
-output = "(3D10) ＞ [6,4,8]  成功数=2"
+output = "(3D10) ＞ [6,4,8]  達成数=2"
 secret = true
 rands = [
   { sides = 10, value = 6 },
@@ -733,7 +733,7 @@ rands = [
 [[ test ]]
 game_system = "HunterTheReckoning5th"
 input = "S0HRF3+3"
-output = "(3D10+3D10) ＞ [1,4,2]+[5,1,3]  成功数=0"
+output = "(3D10+3D10) ＞ [1,4,2]+[5,1,3]  達成数=0"
 secret = true
 rands = [
   { sides = 10, value = 1 },
@@ -747,7 +747,7 @@ rands = [
 [[ test ]]
 game_system = "HunterTheReckoning5th"
 input = "S0HRF3+3"
-output = "(3D10+3D10) ＞ [1,8,2]+[5,1,6]  成功数=2"
+output = "(3D10+3D10) ＞ [1,8,2]+[5,1,6]  達成数=2"
 secret = true
 rands = [
   { sides = 10, value = 1 },
@@ -761,7 +761,7 @@ rands = [
 [[ test ]]
 game_system = "HunterTheReckoning5th"
 input = "S0HRF3+3"
-output = "(3D10+3D10) ＞ [1,10,10]+[2,1,7]  成功数=5"
+output = "(3D10+3D10) ＞ [1,10,10]+[2,1,7]  達成数=5"
 secret = true
 rands = [
   { sides = 10, value = 1 },
@@ -775,7 +775,7 @@ rands = [
 [[ test ]]
 game_system = "HunterTheReckoning5th"
 input = "S0HRF3+3"
-output = "(3D10+3D10) ＞ [4,10,10]+[10,3,10]  成功数=8"
+output = "(3D10+3D10) ＞ [4,10,10]+[10,3,10]  達成数=8"
 secret = true
 rands = [
   { sides = 10, value = 4 },
@@ -789,7 +789,7 @@ rands = [
 [[ test ]]
 game_system = "HunterTheReckoning5th"
 input = "S0HRF3+2"
-output = "(3D10+2D10) ＞ [1,4,7]+[6,6]  成功数=3"
+output = "(3D10+2D10) ＞ [1,4,7]+[6,6]  達成数=3"
 secret = true
 rands = [
   { sides = 10, value = 1 },
@@ -818,7 +818,7 @@ rands = [
 [[ test ]]
 game_system = "HunterTheReckoning5th"
 input = "3HRF1+5"
-output = "(1D10+5D10) ＞ [4]+[6,6,5,3,10]  成功数=3 難易度=3 差分=0：判定成功!"
+output = "(1D10+5D10) ＞ [4]+[6,6,5,3,10]  達成数=3 難易度=3 上回り=0：判定成功!"
 success = true
 rands = [
   { sides = 10, value = 4 },


### PR DESCRIPTION
**【背景】**
ヴァンパイア：ザ マスカレード第五版の日本語版が出たため、同じ基本判定システムを使用しているH5も一部の訳語が準用可能となったため、これを適用する（将来、もしH5日本語版で変更が入った場合は、その時に対応を行う）。

**【対応】**
以下の訳語と文言をヴァンパイア：ザ マスカレード第五版の訳語に準拠するよう修正。
・Critical Win → クリティカル成功/Critical Win
・Total Failure→完全失敗/Total Failure
・成功数→達成数
・差分→上回り