### PR TITLE
[Werewolf: The Apocalypse5th] ダイスプールが0以下の場合に1ダイスプールを補償する修正

### DIFF
--- a/lib/bcdice/game_system/WerewolfTheApocalypse5th.rb
+++ b/lib/bcdice/game_system/WerewolfTheApocalypse5th.rb
@@ -57,15 +57,12 @@ module BCDice
       register_prefix('\d*(WAF|(WAI\d*(R\d?)?))')
 
       def eval_game_system_specific_command(command)
-        m = /\A(\d+)?(((WAF)(\d+)(\+(\d+))?)|((WAI)(\d+)(R(\d+))?))$/.match(command)
+        m = /\A(\d+)?(((WAF)(-?\d+)(\+(\d+))?)|((WAI)(-?\d+)(R(\d+))?))$/.match(command)
         unless m
           return ''
         end
 
         dice_pool, rage_dice_pool = get_dice_pools(m)
-        if dice_pool < 0
-          return "ダイスプール0のときにRageダイスは指定できません。"
-        end
         if rage_dice_pool > 5
           return "5を超えるRageダイス指定はできません。"
         end
@@ -102,6 +99,10 @@ module BCDice
           # Rage Diceを内数処理するの場合
           rage_dice_pool = m[RAGE_DICE_INCLUDED_INDEX].nil? ? -1 : m[RAGE_DICE_INCLUDED_INDEX].to_i
           dice_pool_value = m[DICE_POOL_RAGE_DICE_INCLUDED_INDEX].to_i
+          if dice_pool_value <= 0
+            # ダイスプールが0のとき、最低保証ダイスプールであるダイスプール1にする
+            dice_pool_value = 1
+          end
           dice_pool = dice_pool_value - (rage_dice_pool < 0 ? 0 : rage_dice_pool)
           if dice_pool_value > 0 && rage_dice_pool >= dice_pool_value
             # 1 以上のダイスプール、かつ、Rageダイスがダイスプール以上のとき、ダイスプールが全てRageダイスになる。
@@ -112,6 +113,10 @@ module BCDice
           # Rage DiceがPLによる内数指定の場合
           rage_dice_pool = m[RAGE_DICE_NO_INCLUDED_INDEX].nil? ? -1 : m[RAGE_DICE_NO_INCLUDED_INDEX].to_i
           dice_pool = m[DICE_POOL_RAGE_DICE_NO_INCLUDED_INDEX].to_i
+          if dice_pool <= 0 && rage_dice_pool <= 0
+            # ダイスプールとrageダイスどちらも0指定のとき、最低保証ダイスプールである1ダイスプールにする
+            dice_pool = 1
+          end
         end
         return dice_pool, rage_dice_pool
       end

--- a/test/data/WerewolfTheApocalypse5th.toml
+++ b/test/data/WerewolfTheApocalypse5th.toml
@@ -5,7 +5,7 @@
 [[ test ]]
 game_system = "WerewolfTheApocalypse5th"
 input = "3WAF0"
-output = "(0D10) ＞ []  成功数=0 難易度=3：判定失敗! [Total Failure]"
+output = "(1D10) ＞ [1]  成功数=0 難易度=3：判定失敗! [Total Failure]"
 failure = true
 fumble = true
 rands = [
@@ -147,7 +147,7 @@ rands = [
 [[ test ]]
 game_system = "WerewolfTheApocalypse5th"
 input = "3WAI0"
-output = "(0D10) ＞ []  成功数=0 難易度=3：判定失敗! [Total Failure]"
+output = "(1D10) ＞ [1]  成功数=0 難易度=3：判定失敗! [Total Failure]"
 failure = true
 fumble = true
 rands = [
@@ -290,7 +290,7 @@ rands = [
 [[ test ]]
 game_system = "WerewolfTheApocalypse5th"
 input = "WAF0"
-output = "(0D10) ＞ []  成功数=0：判定失敗! [Total Failure]"
+output = "(1D10) ＞ [1]  成功数=0：判定失敗! [Total Failure]"
 failure = true
 fumble = true
 rands = [
@@ -394,7 +394,7 @@ rands = [
 [[ test ]]
 game_system = "WerewolfTheApocalypse5th"
 input = "WAI0"
-output = "(0D10) ＞ []  成功数=0：判定失敗! [Total Failure]"
+output = "(1D10) ＞ [1]  成功数=0：判定失敗! [Total Failure]"
 failure = true
 fumble = true
 rands = [
@@ -1399,7 +1399,7 @@ rands = [
 [[ test ]]
 game_system = "WerewolfTheApocalypse5th"
 input = "S3WAF0"
-output = "(0D10) ＞ []  成功数=0 難易度=3：判定失敗! [Total Failure]"
+output = "(1D10) ＞ [1]  成功数=0 難易度=3：判定失敗! [Total Failure]"
 failure = true
 fumble = true
 secret = true
@@ -1550,7 +1550,7 @@ rands = [
 [[ test ]]
 game_system = "WerewolfTheApocalypse5th"
 input = "S3WAI0"
-output = "(0D10) ＞ []  成功数=0 難易度=3：判定失敗! [Total Failure]"
+output = "(1D10) ＞ [1]  成功数=0 難易度=3：判定失敗! [Total Failure]"
 failure = true
 fumble = true
 secret = true
@@ -1702,7 +1702,7 @@ rands = [
 [[ test ]]
 game_system = "WerewolfTheApocalypse5th"
 input = "SWAF0"
-output = "(0D10) ＞ []  成功数=0：判定失敗! [Total Failure]"
+output = "(1D10) ＞ [1]  成功数=0：判定失敗! [Total Failure]"
 failure = true
 fumble = true
 secret = true
@@ -1813,7 +1813,7 @@ rands = [
 [[ test ]]
 game_system = "WerewolfTheApocalypse5th"
 input = "SWAI0"
-output = "(0D10) ＞ []  成功数=0：判定失敗! [Total Failure]"
+output = "(1D10) ＞ [1]  成功数=0：判定失敗! [Total Failure]"
 failure = true
 fumble = true
 secret = true
@@ -2990,18 +2990,20 @@ rands = [
   { sides = 10, value = 5 },
 ]
 
-# ========== エラーコマンド ========== #
-
 # ダイスプール0の時のRageダイス指定
 [[ test ]]
 game_system = "WerewolfTheApocalypse5th"
 input = "WAI0R4"
-output = "ダイスプール0のときにRageダイスは指定できません。"
+output = "(0D10+1D10) ＞ []+[1]  成功数=0：判定失敗! [Total Failure]"
+failure = true
+fumble = true
 rands = [
   { sides = 10, value = 1 },
   { sides = 10, value = 2 },
   { sides = 10, value = 6 },
 ]
+
+# ========== エラーコマンド ========== #
 
 # 5を超えるRageダイス指定(WAI)
 [[ test ]]
@@ -3029,4 +3031,24 @@ rands = [
   { sides = 10, value = 8 },
   { sides = 10, value = 2 },
   { sides = 10, value = 10 },
+]
+
+# ダイスプール0以下指定で成功するパターン
+[[ test ]]
+game_system = "WerewolfTheApocalypse5th"
+input = "1WAF-1+0"
+output = "(1D10+0D10) ＞ [6]+[]  成功数=1 難易度=1 差分=0：判定成功!"
+success = true
+rands = [
+  { sides = 10, value = 6 },
+]
+
+# ダイスプール0以下指定で成功するパターン
+[[ test ]]
+game_system = "WerewolfTheApocalypse5th"
+input = "1WAI-1R4"
+output = "(0D10+1D10) ＞ []+[6]  成功数=1 難易度=1 差分=0：判定成功!"
+success = true
+rands = [
+  { sides = 10, value = 6 },
 ]


### PR DESCRIPTION
【背景】
W5の判定ルールでは、ダイスプールが0以下にならない（判定可能なものは必ずダイスプール１での判定となる）、またダイスプール修正でも0以下にならないとなっている（下記参照）。
現状のW5ダイスボットは、0～マイナスのダイスプールはエラーメッセージを出して判定停止するため、ルールと不整合となっていた。マイナスのダイスプール指定を受けつけることによって、オンラインセッションツール上などでダイスプールを計算して指定する際も問題なく判定を行うことが可能となる。

【対応】
・ダイスプールのマイナス指定を受け入れるように修正
・0以下のダイスプールを指定しても1d10で判定を行うように修正

【参考】
W5コアルール、該当部分抜粋

p118 Dice Pools
> Traits usually have ratings between 0 and 5, so pools generally range from one die (the minimum pool size, if you can roll at all) to 10 dice or more.

p119 Modifiers
> Penalties can never cause a pool to drop below one die.