### PR TITLE
Arithmeticに対数とべき乗のコマンドを追加しました。

### DIFF
--- a/lib/bcdice/arithmetic/node.rb
+++ b/lib/bcdice/arithmetic/node.rb
@@ -191,42 +191,6 @@ module BCDice
         end
       end
 
-      # 常用対数（xLOGn）のノード
-      #
-      # x を底、n を真数とした対数 log_x(n) を計算する。
-      # 結果は切り捨てにより整数化する。
-      class Log
-        # ノードを初期化する
-        # @param [Object] base 底のノード
-        # @param [Object] value 真数のノード
-        def initialize(base, value)
-          @base = base
-          @value = value
-        end
-
-        # @param round_type [Symbol] 端数処理方法
-        # @return [Integer] 評価結果（切り捨て）
-        # @raise [ArgumentError] 底または真数が対数の定義域外の場合
-        def eval(round_type)
-          b = @base.eval(round_type).to_f
-          v = @value.eval(round_type).to_f
-          raise ArgumentError, "対数の底は1より大きい値でなければなりません: #{b}" if b <= 1.0
-          raise ArgumentError, "対数の真数は正の値でなければなりません: #{v}" unless v.positive?
-
-          (Math.log(v) / Math.log(b)).floor
-        end
-
-        # @return [String] メッセージへの出力
-        def output
-          "#{@base.output}LOG#{@value.output}"
-        end
-
-        # @return [String] ノードのS式
-        def s_exp
-          "(LOG #{@base.s_exp} #{@value.s_exp})"
-        end
-      end
-
       class Negative
         def initialize(body)
           @body = body

--- a/lib/bcdice/arithmetic/node.rb
+++ b/lib/bcdice/arithmetic/node.rb
@@ -159,6 +159,74 @@ module BCDice
         end
       end
 
+      # べき乗（x^n）のノード
+      class Power
+        # ノードを初期化する
+        # @param [Object] base 底のノード
+        # @param [Object] exp 指数のノード
+        def initialize(base, exp)
+          @base = base
+          @exp = exp
+        end
+
+        # @param round_type [Symbol] 端数処理方法
+        # @return [Integer] 評価結果
+        # @raise [ArgumentError] 指数が負の場合
+        def eval(round_type)
+          b = @base.eval(round_type)
+          e = @exp.eval(round_type)
+          raise ArgumentError, "べき乗の指数に負の値は使用できません: #{e}" if e.negative?
+
+          b**e
+        end
+
+        # @return [String] メッセージへの出力
+        def output
+          "#{@base.output}^#{@exp.output}"
+        end
+
+        # @return [String] ノードのS式
+        def s_exp
+          "(^ #{@base.s_exp} #{@exp.s_exp})"
+        end
+      end
+
+      # 常用対数（xLOGn）のノード
+      #
+      # x を底、n を真数とした対数 log_x(n) を計算する。
+      # 結果は切り捨てにより整数化する。
+      class Log
+        # ノードを初期化する
+        # @param [Object] base 底のノード
+        # @param [Object] value 真数のノード
+        def initialize(base, value)
+          @base = base
+          @value = value
+        end
+
+        # @param round_type [Symbol] 端数処理方法
+        # @return [Integer] 評価結果（切り捨て）
+        # @raise [ArgumentError] 底または真数が対数の定義域外の場合
+        def eval(round_type)
+          b = @base.eval(round_type).to_f
+          v = @value.eval(round_type).to_f
+          raise ArgumentError, "対数の底は1より大きい値でなければなりません: #{b}" if b <= 1.0
+          raise ArgumentError, "対数の真数は正の値でなければなりません: #{v}" unless v.positive?
+
+          (Math.log(v) / Math.log(b)).floor
+        end
+
+        # @return [String] メッセージへの出力
+        def output
+          "#{@base.output}LOG#{@value.output}"
+        end
+
+        # @return [String] ノードのS式
+        def s_exp
+          "(LOG #{@base.s_exp} #{@value.s_exp})"
+        end
+      end
+
       class Negative
         def initialize(body)
           @body = body

--- a/lib/bcdice/arithmetic/parser.y
+++ b/lib/bcdice/arithmetic/parser.y
@@ -1,5 +1,5 @@
 class BCDice::Arithmetic::Parser
-  token NUMBER R U C F PLUS MINUS ASTERISK SLASH PARENL PARENR
+  token NUMBER R U C F PLUS MINUS ASTERISK SLASH PARENL PARENR CARET LOG
 
   rule
     add: add PLUS mul
@@ -32,6 +32,14 @@ class BCDice::Arithmetic::Parser
          { result = val[1] }
          | MINUS unary
          { result = Arithmetic::Node::Negative.new(val[1]) }
+         | log_op
+
+    log_op: log_op LOG power
+          { result = Arithmetic::Node::Log.new(val[0], val[2]) }
+          | power
+
+    power: term CARET power
+         { result = Arithmetic::Node::Power.new(val[0], val[2]) }
          | term
 
     term: PARENL add PARENR

--- a/lib/bcdice/arithmetic/parser.y
+++ b/lib/bcdice/arithmetic/parser.y
@@ -1,5 +1,5 @@
 class BCDice::Arithmetic::Parser
-  token NUMBER R U C F PLUS MINUS ASTERISK SLASH PARENL PARENR CARET LOG
+  token NUMBER R U C F PLUS MINUS ASTERISK SLASH PARENL PARENR CARET
 
   rule
     add: add PLUS mul
@@ -32,11 +32,7 @@ class BCDice::Arithmetic::Parser
          { result = val[1] }
          | MINUS unary
          { result = Arithmetic::Node::Negative.new(val[1]) }
-         | log_op
-
-    log_op: log_op LOG power
-          { result = Arithmetic::Node::Log.new(val[0], val[2]) }
-          | power
+         | power
 
     power: term CARET power
          { result = Arithmetic::Node::Power.new(val[0], val[2]) }

--- a/lib/bcdice/command/lexer.rb
+++ b/lib/bcdice/command/lexer.rb
@@ -17,6 +17,7 @@ module BCDice
         "@" => :AT,
         "#" => :SHARP,
         "$" => :DOLLAR,
+        "^" => :CARET,
       }.freeze
 
       def initialize(source, notations)
@@ -38,6 +39,8 @@ module BCDice
 
         if (number = @scanner.scan(/\d+/))
           [:NUMBER, number.to_i]
+        elsif (log_op = @scanner.scan(/LOG(?=[^A-Za-z]|$)/i))
+          [:LOG, log_op.upcase]
         elsif (cmp_op = @scanner.scan(/[<>!=]+/))
           cmp_op = Normalize.comparison_operator(cmp_op)
           type = cmp_op ? :CMP_OP : :ILLEGAL

--- a/lib/bcdice/command/lexer.rb
+++ b/lib/bcdice/command/lexer.rb
@@ -17,7 +17,6 @@ module BCDice
         "@" => :AT,
         "#" => :SHARP,
         "$" => :DOLLAR,
-        "^" => :CARET,
       }.freeze
 
       def initialize(source, notations)
@@ -39,8 +38,6 @@ module BCDice
 
         if (number = @scanner.scan(/\d+/))
           [:NUMBER, number.to_i]
-        elsif (log_op = @scanner.scan(/LOG(?=[^A-Za-z]|$)/i))
-          [:LOG, log_op.upcase]
         elsif (cmp_op = @scanner.scan(/[<>!=]+/))
           cmp_op = Normalize.comparison_operator(cmp_op)
           type = cmp_op ? :CMP_OP : :ILLEGAL

--- a/lib/bcdice/common_command/calc/parser.y
+++ b/lib/bcdice/common_command/calc/parser.y
@@ -1,5 +1,5 @@
 class BCDice::CommonCommand::Calc::Parser
-  token NUMBER R U C F S PLUS MINUS ASTERISK SLASH PARENL PARENR CARET LOG
+  token NUMBER R U C F S PLUS MINUS ASTERISK SLASH PARENL PARENR CARET
 
   rule
     expr: secret C add
@@ -45,11 +45,7 @@ class BCDice::CommonCommand::Calc::Parser
          { result = val[1] }
          | MINUS unary
          { result = Arithmetic::Node::Negative.new(val[1]) }
-         | log_op
-
-    log_op: log_op LOG power
-          { result = Arithmetic::Node::Log.new(val[0], val[2]) }
-          | power
+         | power
 
     power: term CARET power
          { result = Arithmetic::Node::Power.new(val[0], val[2]) }

--- a/lib/bcdice/common_command/calc/parser.y
+++ b/lib/bcdice/common_command/calc/parser.y
@@ -1,5 +1,5 @@
 class BCDice::CommonCommand::Calc::Parser
-  token NUMBER R U C F S PLUS MINUS ASTERISK SLASH PARENL PARENR
+  token NUMBER R U C F S PLUS MINUS ASTERISK SLASH PARENL PARENR CARET LOG
 
   rule
     expr: secret C add
@@ -45,6 +45,14 @@ class BCDice::CommonCommand::Calc::Parser
          { result = val[1] }
          | MINUS unary
          { result = Arithmetic::Node::Negative.new(val[1]) }
+         | log_op
+
+    log_op: log_op LOG power
+          { result = Arithmetic::Node::Log.new(val[0], val[2]) }
+          | power
+
+    power: term CARET power
+         { result = Arithmetic::Node::Power.new(val[0], val[2]) }
          | term
 
     term: PARENL add PARENR

--- a/lib/bcdice/common_command/lexer.rb
+++ b/lib/bcdice/common_command/lexer.rb
@@ -31,8 +31,6 @@ module BCDice
 
         if (number = @scanner.scan(/\d+/))
           [:NUMBER, number.to_i]
-        elsif (log_op = @scanner.scan(/LOG(?=[^A-Za-z]|$)/i))
-          [:LOG, log_op.upcase]
         elsif (cmp_op = @scanner.scan(/[<>!=]+/))
           [:CMP_OP, Normalize.comparison_operator(cmp_op)]
         else

--- a/lib/bcdice/common_command/lexer.rb
+++ b/lib/bcdice/common_command/lexer.rb
@@ -17,6 +17,7 @@ module BCDice
         "]" => :BRACKETR,
         "?" => :QUESTION,
         "@" => :AT,
+        "^" => :CARET,
       }.freeze
 
       def initialize(source)
@@ -30,6 +31,8 @@ module BCDice
 
         if (number = @scanner.scan(/\d+/))
           [:NUMBER, number.to_i]
+        elsif (log_op = @scanner.scan(/LOG(?=[^A-Za-z]|$)/i))
+          [:LOG, log_op.upcase]
         elsif (cmp_op = @scanner.scan(/[<>!=]+/))
           [:CMP_OP, Normalize.comparison_operator(cmp_op)]
         else

--- a/test/data/Cthulhu.toml
+++ b/test/data/Cthulhu.toml
@@ -6,8 +6,14 @@ rands = [
 ]
 [[ test ]]
 game_system = "Cthulhu"
-input = "c(10log100)"
-output = "c(10LOG100) ＞ 2"
+input = "c((2^3^4)-2^(3^4))"
+output = "c((2^3^4)-2^(3^4)) ＞ 0"
+rands = [
+]
+[[ test ]]
+game_system = "Cthulhu"
+input = "c((2^3^4)-(2^3)^4)"
+output = "c((2^3^4)-(2^3)^4) ＞ 2417851639229258349408256"
 rands = [
 ]
 [[ test ]]

--- a/test/data/Cthulhu.toml
+++ b/test/data/Cthulhu.toml
@@ -1,5 +1,25 @@
 [[ test ]]
 game_system = "Cthulhu"
+input = "c(10^10)"
+output = "c(10^10) ＞ 10000000000"
+rands = [
+]
+[[ test ]]
+game_system = "Cthulhu"
+input = "c(10log100)"
+output = "c(10LOG100) ＞ 2"
+rands = [
+]
+[[ test ]]
+game_system = "Cthulhu"
+input = "c(10*5)"
+output = "c(10*5) ＞ 50"
+rands = [
+]
+
+
+[[ test ]]
+game_system = "Cthulhu"
 input = "1D100<=70 ファンブルなし"
 output = "(1D100<=70) ＞ 100 ＞ 失敗"
 failure = true


### PR DESCRIPTION
公式Discordサーバにて、「べき乗」と「対数」のコマンドがほしい旨要望があったので、試しに実装してみました。

・べき乗 「x^n」で(x**nではない)
　ex. c(2^3) ＞ 8
・xLOGn で「Logx(n)」を処理します。
　ex. c(10LOG100) ＞ 2

CoC6での実行を望まれていたので、CoC6にテストを書いてみました。

実際にどの程度活用するか不明ではありますが、参考までに。